### PR TITLE
Persisting new network addressed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ ENV/
 
 # Editor temp files
 .*.swp
+
+# IDEs stuff
+.idea/

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -226,12 +226,13 @@ class ControllerApplication(bellows.zigbee.util.ListenableMixin):
         if ieee in self.devices:
             dev = self.get_device(ieee)
             dev.nwk = nwk
-            if dev.initializing or dev.status == bellows.zigbee.device.Status.ENDPOINTS_INIT:
-                LOGGER.debug("Skip initialization for existing device %s", ieee)
-                return
         else:
             dev = self.add_device(ieee, nwk)
-            self.listener_event('device_joined', dev)
+
+        self.listener_event('device_joined', dev)
+        if dev.initializing or dev.status == bellows.zigbee.device.Status.ENDPOINTS_INIT:
+            LOGGER.debug("Skip initialization for existing device %s", ieee)
+            return
 
         dev.schedule_initialize()
 


### PR DESCRIPTION
I noticed that if a device rejoins with a new network address (say it's been manually factory reset), its new network address doesn't get persisted (it's only updated in memory), so that anything coming from the device after the app is restarted, is deemed as "from unknown device".
This PR address this limitation, but it's my very first contribution, so please let me know if I should have approached this in a different way; thanks.