### PR TITLE
Fix fans to use enums for attributes.

### DIFF
--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -85,6 +85,9 @@ class uint64_t(uint_t):  # noqa: N801
 class enum8(uint8_t):  # noqa: N801 
     pass
 
+class enum16(uint16_t):  # noqa: N801 
+    pass
+
 class Single(float):
     def serialize(self):
         return struct.pack('<f', self)

--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -82,6 +82,8 @@ class uint56_t(uint_t):  # noqa: N801
 class uint64_t(uint_t):  # noqa: N801
     _size = 8
 
+class enum8(uint8_t):  # noqa: N801 
+    pass
 
 class Single(float):
     def serialize(self):

--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -82,11 +82,14 @@ class uint56_t(uint_t):  # noqa: N801
 class uint64_t(uint_t):  # noqa: N801
     _size = 8
 
-class enum8(uint8_t):  # noqa: N801 
+
+class enum8(uint8_t):  # noqa: N801
     pass
 
-class enum16(uint16_t):  # noqa: N801 
+
+class enum16(uint16_t):  # noqa: N801
     pass
+
 
 class Single(float):
     def serialize(self):

--- a/bellows/zigbee/zcl/clusters/hvac.py
+++ b/bellows/zigbee/zcl/clusters/hvac.py
@@ -116,8 +116,8 @@ class Fan(Cluster):
     ep_attribute = 'fan'
     attributes = {
         # Fan Control Status
-        0x0000: ('fan_mode', t.uint8_t),  # enum8
-        0x0001: ('fan_mode_sequence', t.uint8_t),  # enum8
+        0x0000: ('fan_mode', t.enum8),  # enum8
+        0x0001: ('fan_mode_sequence', t.enum8),  # enum8
     }
     server_commands = {}
     client_commands = {}

--- a/bellows/zigbee/zcl/foundation.py
+++ b/bellows/zigbee/zcl/foundation.py
@@ -85,7 +85,7 @@ DATA_TYPES = {
     0x2e: ('Signed Integer', t.int56s, Analog),
     0x2f: ('Signed Integer', t.int64s, Analog),
     0x30: ('Enumeration', t.enum8, Discrete),
-    0x31: ('Enumeration', t.uint16_t, Discrete),
+    0x31: ('Enumeration', t.enum16, Discrete),
     # 0x38: ('Floating point', t.Half, Analog),
     0x39: ('Floating point', t.Single, Analog),
     0x3a: ('Floating point', t.Double, Analog),

--- a/bellows/zigbee/zcl/foundation.py
+++ b/bellows/zigbee/zcl/foundation.py
@@ -84,7 +84,7 @@ DATA_TYPES = {
     0x2d: ('Signed Integer', t.int48s, Analog),
     0x2e: ('Signed Integer', t.int56s, Analog),
     0x2f: ('Signed Integer', t.int64s, Analog),
-    0x30: ('Enumeration', t.uint8_t, Discrete),
+    0x30: ('Enumeration', t.enum8, Discrete),
     0x31: ('Enumeration', t.uint16_t, Discrete),
     # 0x38: ('Floating point', t.Half, Analog),
     0x39: ('Floating point', t.Single, Analog),
@@ -111,7 +111,7 @@ DATA_TYPES = {
 DATA_TYPE_IDX = {
     t: tidx
     for tidx, (tname, t, ad) in DATA_TYPES.items()
-    if ad is Analog
+    if ad is Analog or tname == 'Enumeration'
 }
 DATA_TYPE_IDX[t.uint32_t] = 0x23
 DATA_TYPE_IDX[t.EmberEUI64] = 0xf0


### PR DESCRIPTION
I'm trying to get bellows to communicate with 
https://www.homedepot.com/p/Hampton-Bay-Universal-Wink-Enabled-White-Ceiling-Fan-Premier-Remote-Control-99432/206591100.

More details about the receiver can be found here:
https://community.smartthings.com/t/home-decorators-ceiling-fan-light-controller-mr101z-first-impressions/81408

And the smartthings implementation can be found here:
https://github.com/dcoffing/KOF-CeilingFan/blob/master/devicetypes/dcoffing/kof-zigbee-fan-controller.src/kof-zigbee-fan-controller.groovy

There are few issues to work through, this solves the first one, writing the ceiling fan attribute results in the following error:
```[[<WriteAttributesStatusRecord status=Status.INVALID_DATA_TYPE attrid=0>]]```

As described in the ZCL [cluster spec](http://www.zigbee.org/~zigbeeor/wp-content/uploads/2014/10/07-5123-06-zigbee-cluster-library-specification.pdf) `6.4.2.2 Attributes`, the 2 available attributes are both enums. I'm following the approach taken in #71.