### PR TITLE
Dependency fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,9 @@ setup(
     install_requires=[
         'Click',
         'click-log==0.2.0',
-        'pycrypto',
-        'crccheck',
         'pure_pcapy3==1.0.1',
         'pyserial-asyncio',
-        'zigpy==0.0.1',
+        'zigpy',
     ],
     dependency_links=[
         'https://github.com/rcloran/pure-pcapy-3/archive/e289c7d7566306dc02d8f4eb30c0358b41f40f26.zip#egg=pure_pcapy3-1.0.1',


### PR DESCRIPTION
 - Remove dependencies on pycrypto and crccheck (moved to zigpy)
 - Don't require a specific version of zigpy