### PR TITLE
Silabs released new version of ezsp protocol

### DIFF
--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -51,7 +51,7 @@ class EZSP:
             0,    # Frame control. TODO.
             c[0]  # Frame ID
         ]
-        if self.ezsp_version == 5:
+        if self.ezsp_version == 5 or self.ezsp_version == 6:
             frame.insert(1, 0xFF)  # Legacy Frame ID
             frame.insert(1, 0x00)  # Ext frame control. TODO.
 


### PR DESCRIPTION
Silicon labs have released new version of their protocol - v6.

This small change fixes the issue with it. Without this change it fails during start up with the following log:
```
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 47, in uvloop.loop.Handle._run
  File "/usr/lib/python3.6/site-packages/serial_asyncio/__init__.py", line 106, in _read_ready
    self._protocol.data_received(data)
  File "/usr/lib/python3.6/site-packages/bellows/uart.py", line 64, in data_received
    self.frame_received(frame)
  File "/usr/lib/python3.6/site-packages/bellows/uart.py", line 76, in frame_received
    self.data_frame_received(data)
  File "/usr/lib/python3.6/site-packages/bellows/uart.py", line 97, in data_frame_received
    self._application.frame_received(self._randomize(data[1:-3]))
  File "/usr/lib/python3.6/site-packages/bellows/ezsp.py", line 173, in frame_received
    assert expected_id == frame_id
AssertionError
```
The failure occurs because these additional bytes are not inserted.
Tested with:
- EFR32MG12 development kit
- Silabs EM3588 USB adapter
- Elelabs ZigBee Raspberry Pi shield (EM357)
- Elelabs ZigBee USB adapter (EM3585)