### PR TITLE
Add aditional Node Type

### DIFF
--- a/bellows/types/named.py
+++ b/bellows/types/named.py
@@ -1092,6 +1092,8 @@ class EmberNodeType(basic.uint8_t, enum.Enum):
     RF4CE_TARGET = 0x06
     # RF4CE controller node.
     RF4CE_CONTROLLER = 0x07
+    # Device is not joined or no network is formed.
+    UNKNOWN_NODE_TYPE = 0xFF
 
 
 class EmberNetworkStatus(basic.uint8_t, enum.Enum):


### PR DESCRIPTION
Though the EZSP protocol document states only 8 different Node Types, it seems that real life NCP implementations also have a 0xFF Node type, which can be seen right after "Leave network" command.
In that state the Node Type is unknown.
However, the `bellows` library doesn't parse the value 0xFF and the `bellows info` command fails:
```
debug: Send command getNetworkParameters
debug: Sending: b'224821575402db807e'
debug: Data frame: b'2348a1575402864d6ce987554c023139164f2fa5edce678bfd3e9c8e45287e'
debug: Sending: b'83401b7e'
debug: Application frame 40 (getNetworkParameters) received
Exception in callback SerialTransport._read_ready()
handle: <Handle SerialTransport._read_ready()>
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/events.py", line 125, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.5/dist-packages/serial_asyncio/__init__.py", line 106, in _read_ready
    self._protocol.data_received(data)
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/uart.py", line 64, in data_received
    self.frame_received(frame)
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/uart.py", line 86, in frame_received
    self.data_frame_received(data)
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/uart.py", line 107, in data_frame_received
    self._application.frame_received(self._randomize(data[1:-3]))
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/ezsp.py", line 170, in frame_received
    result, data = t.deserialize(data, schema)
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/types/__init__.py", line 9, in deserialize
    value, data = type_.deserialize(data)
  File "/usr/local/lib/python3.5/dist-packages/bellows-0.6.0-py3.5.egg/bellows/types/basic.py", line 10, in deserialize
    r = cls(int.from_bytes(data[:cls._size], 'little', signed=cls._signed))
  File "/usr/lib/python3.5/enum.py", line 241, in __call__
    return cls.__new__(cls, value)
  File "/usr/lib/python3.5/enum.py", line 476, in __new__
    raise ValueError("%r is not a valid %s" % (value, cls.__name__))
ValueError: 255 is not a valid EmberNodeType
```