### PR TITLE
Add Zigbee Endpoint to coordinator.

### DIFF
--- a/bellows/commands.py
+++ b/bellows/commands.py
@@ -5,9 +5,9 @@ COMMANDS = {
     'version': (0x00, (t.uint8_t, ), (t.uint8_t, t.uint8_t, t.uint16_t)),
     'getConfigurationValue': (0x52, (t.EzspConfigId, ), (t.EzspStatus, t.uint16_t)),
     'setConfigurationValue': (0x53, (t.EzspConfigId, t.uint16_t), (t.EzspStatus, )),
-    # TODO: Last four fields are length, length, array, array. Need some
-    #       composite type to handle that.
-    # 'addEndpoint': (0x02, 'BHHBBBYY', 'b'),
+    'addEndpoint': (0x02, (t.uint8_t, t.uint16_t, t.uint16_t, t.uint8_t,
+                           t.uint8_t, t.uint8_t, t.List(t.uint16_t,),
+                           t.List(t.uint16_t)), (t.EzspStatus, )),
     'setPolicy': (0x55, (t.EzspPolicyId, t.EzspDecisionId), (t.EzspStatus, )),
     'getPolicy': (0x56, (t.EzspPolicyId, ), (t.EzspStatus, t.EzspDecisionId)),
     'getValue': (0xAA, (t.EzspValueId, ), (t.EzspStatus, t.LVBytes)),

--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -98,7 +98,7 @@ class _List(list):
 
     def serialize(self):
         assert self._length is None or len(self) == self._length
-        return b''.join([i.serialize() for i in self])
+        return b''.join([self._itemtype(i).serialize() for i in self])
 
     @classmethod
     def deserialize(cls, data):

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -48,6 +48,24 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._cfg(c.CONFIG_END_DEVICE_POLL_TIMEOUT, 60)
         await self._cfg(c.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, 6)
 
+        await self.add_endpoint(
+            output_clusters=[zigpy.zcl.clusters.security.IasZone.cluster_id]
+        )
+
+    async def add_endpoint(self, endpoint=1,
+                           profile_id=zigpy.profiles.zha.PROFILE_ID,
+                           device_id=0xbeef,
+                           app_flags=0x00,
+                           input_clusters=[],
+                           output_clusters=[]):
+        """Add endpoint."""
+        res = await self._ezsp.addEndpoint(
+            endpoint, profile_id, device_id, app_flags,
+            len(input_clusters), len(output_clusters),
+            input_clusters, output_clusters
+        )
+        LOGGER.debug("Ezsp adding endpoint: %s", res)
+
     async def startup(self, auto_form=False):
         """Perform a complete application startup"""
         await self.initialize()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -44,6 +44,7 @@ def _test_startup(app, nwk_type, auto_form=False, init=0):
         return [init]
 
     app._ezsp._command = mockezsp
+    app._ezsp.addEndpoint = mockezsp
     app._ezsp.setConfigurationValue = mockezsp
     app._ezsp.networkInit = mockinit
     app._ezsp.getNetworkParameters = mockezsp


### PR DESCRIPTION
Add endpoint containing IAS client cluster during HUSBZB initialization.
A few IAS devices, particularly [Bosch ISW-ZPR1-WP13](https://us.boschsecurity.com/en/products/intrusionalarmsystems/premiseswireless/zigbee/zigbee_products_56458) (humongous, but cheap) and [Nyce-3014-HA](https://www.amazon.com/NYCE-NCZ-3014-HA-ZigBee-Garage-Sensor/dp/B00WTDV1TU) (and Nyce is very nyce) won't stay on the network after joining, unless there's an endpoint with IAS client cluster on the controller. 

Kudos to @Yoda-x for figuring this out. For more details please follow [Support for HA version of NYCE sensors](https://github.com/Yoda-x/ha-zha-new/issues/47) issue on `zha_new`