### PR TITLE
Don't use deprecated log methods.

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -135,7 +135,7 @@ class Gateway(asyncio.Protocol):
             return
 
         if self._reset_future is None:
-            LOGGER.warn("Reset future is None")
+            LOGGER.warning("Reset future is None")
             return
 
         # Make sure that the reset_future is not done


### PR DESCRIPTION
Make travis throw less warnings.

```
=============================== warnings summary ===============================
tests/test_uart.py::test_rstack_frame_received_nofut
  /home/travis/build/zigpy/bellows/bellows/uart.py:138: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOGGER.warn("Reset future is None")
-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 96 passed, 1 warnings in 3.04 seconds =====================
```