### PR TITLE
Reset EZSP stack on error frames or missing heartbeats

### DIFF
--- a/bellows/exception.py
+++ b/bellows/exception.py
@@ -7,3 +7,7 @@ class BellowsException(ZigbeeException):
 
 class EzspError(BellowsException):
     pass
+
+
+class ControllerError(BellowsException):
+    pass

--- a/bellows/exception.py
+++ b/bellows/exception.py
@@ -1,0 +1,9 @@
+from zigpy.exceptions import ZigbeeException
+
+
+class BellowsException(ZigbeeException):
+    pass
+
+
+class EzspError(BellowsException):
+    pass

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -149,14 +149,15 @@ class EZSP:
     def connection_lost(self, exc):
         """Lost serial connection."""
         LOGGER.debug("%s connection lost unexpectedly: %s", self._device, exc)
-        self.enter_failed_state("Serial connection loss: {}".format(exc))
+        self.enter_failed_state("Serial connection loss: {}".format(exc),
+                                preempt=True)
 
-    def enter_failed_state(self, error):
+    def enter_failed_state(self, error, preempt=False):
         """UART received error frame."""
         LOGGER.error(
             "NCP entered failed state. Requesting APP controller restart")
         self.stop_ezsp()
-        self.handle_callback('_reset_controller_application', [error])
+        self.handle_callback('_reset_controller_application', [error, preempt])
 
     async def formNetwork(self, parameters):  # noqa: N802
         fut = asyncio.Future()

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -62,6 +62,7 @@ class EZSP:
             await self._command('version', result[0])
 
     def close(self):
+        self.stop_ezsp()
         if self._gw:
             self._gw.close()
             self._gw = None

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -7,6 +7,7 @@ import bellows.uart as uart
 from bellows.commands import COMMANDS
 
 
+EZSP_CMD_TIMEOUT = 3
 LOGGER = logging.getLogger(__name__)
 
 
@@ -71,7 +72,7 @@ class EZSP:
         future = asyncio.Future()
         self._awaiting[self._seq] = (c[0], c[2], future)
         self._seq = (self._seq + 1) % 256
-        return future
+        return asyncio.wait_for(future, timeout=EZSP_CMD_TIMEOUT)
 
     async def _list_command(self, name, item_frames, completion_frame, spos, *args):
         """Run a command, returning result callbacks as a list"""

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -150,15 +150,14 @@ class EZSP:
     def connection_lost(self, exc):
         """Lost serial connection."""
         LOGGER.debug("%s connection lost unexpectedly: %s", self._device, exc)
-        self.enter_failed_state("Serial connection loss: {}".format(exc),
-                                preempt=True)
+        self.enter_failed_state("Serial connection loss: {}".format(exc))
 
-    def enter_failed_state(self, error, preempt=False):
+    def enter_failed_state(self, error):
         """UART received error frame."""
         LOGGER.error(
             "NCP entered failed state. Requesting APP controller restart")
         self.stop_ezsp()
-        self.handle_callback('_reset_controller_application', [error, preempt])
+        self.handle_callback('_reset_controller_application', (error, ))
 
     async def formNetwork(self, parameters):  # noqa: N802
         fut = asyncio.Future()

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -129,8 +129,9 @@ class Gateway(asyncio.Protocol):
 
         LOGGER.debug("RSTACK Version: %d Reason: %s frame: %s", version,
                      code.name, binascii.hexlify(data))
-        # Only handle the frame, if it is a reply to our reset request
+        # not a reset we've requested. Signal application reset
         if code is not t.NcpResetCode.RESET_SOFTWARE:
+            self._application.enter_failed_state(code, preempt=True)
             return
 
         if self._reset_future is None:

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -131,7 +131,7 @@ class Gateway(asyncio.Protocol):
                      code.name, binascii.hexlify(data))
         # not a reset we've requested. Signal application reset
         if code is not t.NcpResetCode.RESET_SOFTWARE:
-            self._application.enter_failed_state(code, preempt=True)
+            self._application.enter_failed_state(code)
             return
 
         if self._reset_future is None:

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -8,6 +8,7 @@ import bellows.types as t
 
 
 LOGGER = logging.getLogger(__name__)
+RESET_TIMEOUT = 5
 
 
 class Gateway(asyncio.Protocol):

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -1,11 +1,11 @@
 import asyncio
 import binascii
 import logging
-import serial_asyncio
+
 import serial
+import serial_asyncio
 
 import bellows.types as t
-
 
 LOGGER = logging.getLogger(__name__)
 RESET_TIMEOUT = 5
@@ -169,6 +169,15 @@ class Gateway(asyncio.Protocol):
     def _reset_cleanup(self, future):
         """Delete reset future."""
         self._reset_future = None
+
+    def connection_lost(self, exc):
+        """Port was closed unexpectedly."""
+        if exc is None:
+            LOGGER.debug("Closed serial connection")
+            return
+
+        LOGGER.error("Lost serial connection: %s", exc)
+        self._application.connection_lost(exc)
 
     def reset(self):
         """Send a reset frame and init internal state."""

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -12,6 +12,7 @@ import zigpy.zdo
 
 import bellows.types as t
 import bellows.zigbee.util
+from bellows.exception import EzspError
 
 APS_ACK_TIMEOUT = 120
 APS_REPLY_TIMEOUT = 10
@@ -27,6 +28,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._ezsp = ezsp
         self._pending = Requests()
 
+    @zigpy.util.retryable(asyncio.TimeoutError, tries=5, delay=3)
     async def initialize(self):
         """Perform basic NCP initialization steps"""
         e = self._ezsp

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -378,7 +378,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         while True:
             try:
                 await asyncio.wait_for(self.controller_event.wait(),
-                                       timeout=WATCHDOG_WAKE_PERIOD)
+                                       timeout=WATCHDOG_WAKE_PERIOD * 2)
                 await self._ezsp.nop()
                 failures = 0
             except (asyncio.TimeoutError, EzspError) as exc:

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -171,6 +171,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 self.handle_leave(args[0], args[1])
             else:
                 self.handle_join(args[0], args[1], args[4])
+        elif frame_name == '_reset_controller_application':
+            self._handle_reset_request(args[0])
 
     def _handle_frame(self, message_type, aps_frame, lqi, rssi, sender, binding_index, address_index, message):
         try:
@@ -224,6 +226,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             LOGGER.warning("Unexpected message send notification")
         except asyncio.futures.InvalidStateError as exc:
             LOGGER.debug("Invalid state on future - probably duplicate response: %s", exc)
+
+    def _handle_reset_request(self, error):
+        """Reinitialize application controller."""
+        LOGGER.debug("Restarting application controller. Cause: '%s'", error)
+        asyncio.ensure_future(self.startup())
 
     @zigpy.util.retryable_request
     async def request(self, nwk, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply=True,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -13,7 +13,6 @@ from zigpy.exceptions import DeliveryError
 def app(monkeypatch):
     ezsp = mock.MagicMock()
     type(ezsp).is_ezsp_running = mock.PropertyMock(return_value=True)
-    monkeypatch.setattr(bellows.zigbee.application, 'APS_ACK_TIMEOUT', 0.1)
     ctrl = bellows.zigbee.application.ControllerApplication(ezsp)
     ctrl._ctrl_event.set()
     return ctrl
@@ -406,8 +405,7 @@ def test_request_send_timeout_reply_success(app):
 def test_request_ctrl_not_running(app):
     app._ctrl_event.clear()
     with pytest.raises(ControllerError):
-        _request(app, [0], do_reply=False, expect_reply=True,
-                 send_ack_received=False, timeout=0.1)
+        _request(app, [0], do_reply=False, expect_reply=True, timeout=0.1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -625,3 +625,19 @@ async def test_watchdog(app, monkeypatch):
 
     assert app._ezsp.nop.call_count > 4
     assert app._handle_reset_request.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown(app):
+    reset_f = asyncio.Future()
+    watchdog_f = asyncio.Future()
+    app._reset_task = reset_f
+    app._watchdog_task = watchdog_f
+
+    await app.shutdown()
+    assert app.controller_event.is_set() is False
+    assert reset_f.done() is True
+    assert reset_f.cancelled() is True
+    assert watchdog_f.done() is True
+    assert watchdog_f.cancelled() is True
+    assert app._ezsp.close.call_count == 1

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -293,9 +293,7 @@ def test_connection_lost(ezsp_f):
 def test_enter_failed_state(ezsp_f):
     ezsp_f.stop_ezsp = mock.MagicMock(spec_set=ezsp_f.stop_ezsp)
     ezsp_f.handle_callback = mock.MagicMock(spec_set=ezsp_f.handle_callback)
-    ezsp_f.enter_failed_state(mock.sentinel.error, mock.sentinel.preempt)
+    ezsp_f.enter_failed_state(mock.sentinel.error)
     assert ezsp_f.stop_ezsp.call_count == 1
     assert ezsp_f.handle_callback.call_count == 1
-    assert isinstance(ezsp_f.handle_callback.call_args[0][1], list)
-    assert ezsp_f.handle_callback.call_args[0][1][0] is mock.sentinel.error
-    assert ezsp_f.handle_callback.call_args[0][1][1] is mock.sentinel.preempt
+    assert ezsp_f.handle_callback.call_args[0][1][0] == mock.sentinel.error

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -5,11 +5,14 @@ from unittest import mock
 import pytest
 
 from bellows import ezsp, uart
+from bellows.exception import EzspError
 
 
 @pytest.fixture
 def ezsp_f():
-    return ezsp.EZSP()
+    api = ezsp.EZSP()
+    api._gw = mock.MagicMock(spec_set=uart.Gateway)
+    return api
 
 
 def test_connect(ezsp_f, monkeypatch):
@@ -20,22 +23,52 @@ def test_connect(ezsp_f, monkeypatch):
         connected = True
 
     monkeypatch.setattr(uart, 'connect', mockconnect)
+    ezsp_f._gw = None
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(ezsp_f.connect(None, None))
+    loop.run_until_complete(ezsp_f.connect(mock.sentinel.port,
+                                           mock.sentinel.speed))
     assert connected
 
+    ezsp_f.connect = mock.MagicMock(
+        side_effect=asyncio.coroutine(mock.MagicMock()))
+    loop.run_until_complete(ezsp_f.reconnect())
+    assert ezsp_f.connect.call_count == 1
+    assert ezsp_f.connect.call_args[0][0] is mock.sentinel.port
+    assert ezsp_f.connect.call_args[0][1] is mock.sentinel.speed
 
-def test_reset(ezsp_f):
-    ezsp_f._gw = mock.MagicMock()
-    ezsp_f.reset()
+
+@pytest.mark.asyncio
+async def test_reset(ezsp_f):
+    ezsp_f.stop_ezsp = mock.MagicMock()
+    ezsp_f.start_ezsp = mock.MagicMock()
+    reset_mock = asyncio.coroutine(mock.MagicMock())
+    ezsp_f._gw.reset = mock.MagicMock(side_effect=reset_mock)
+    f_1 = asyncio.Future()
+    ezsp_f._awaiting[1] = (mock.sentinel.schema1, mock.sentinel.schema2, f_1)
+
+    await ezsp_f.reset()
     assert ezsp_f._gw.reset.call_count == 1
+    assert ezsp_f.start_ezsp.call_count == 1
+    assert ezsp_f.stop_ezsp.call_count == 1
+    assert f_1.done() is True
+    assert f_1.cancelled() is True
+    assert len(ezsp_f._awaiting) == 0
+    assert len(ezsp_f._callbacks) == 0
+    assert ezsp_f._seq == 0
 
 
 def test_close(ezsp_f):
-    ezsp_f._gw = mock.MagicMock()
+    closed = False
+
+    def close_mock(*args):
+        nonlocal closed
+        closed = True
+
+    ezsp_f._gw.close = close_mock
     ezsp_f.close()
-    assert ezsp_f._gw.close.call_count == 1
+    assert closed is True
+    assert ezsp_f._gw is None
 
 
 def test_attr(ezsp_f):
@@ -56,8 +89,14 @@ def test_non_existent_attr_with_list(ezsp_f):
 
 def test_command(ezsp_f):
     ezsp_f._gw = mock.MagicMock()
+    ezsp_f.start_ezsp()
     ezsp_f._command('version')
     assert ezsp_f._gw.data.call_count == 1
+
+
+def test_command_ezsp_stopped(ezsp_f):
+    with pytest.raises(EzspError):
+        ezsp_f._command('version')
 
 
 def _test_list_command(ezsp_f, mockcommand):
@@ -195,6 +234,7 @@ def test_callback_exc(ezsp_f):
 
 def test_version_5(ezsp_f):
     ezsp_f._gw = mock.MagicMock()
+    ezsp_f.start_ezsp()
 
     ezsp_f.frame_received(b'\x00\x00\xff\x00\x00\x05\x05\x06')
     assert ezsp_f.ezsp_version == 5
@@ -215,3 +255,33 @@ def test_change_version(ezsp_f):
 
     ezsp_f._command = mockcommand
     loop.run_until_complete(ezsp_f.version())
+
+
+def test_stop_ezsp(ezsp_f):
+    ezsp_f._ezsp_event.set()
+    ezsp_f.stop_ezsp()
+    assert ezsp_f._ezsp_event.is_set() is False
+
+
+def test_start_ezsp(ezsp_f):
+    ezsp_f._ezsp_event.clear()
+    ezsp_f.start_ezsp()
+    assert ezsp_f._ezsp_event.is_set() is True
+
+
+def test_connection_lost(ezsp_f):
+    ezsp_f.enter_failed_state = mock.MagicMock(
+        spec_set=ezsp_f.enter_failed_state)
+    ezsp_f.connection_lost(mock.sentinel.exc)
+    assert ezsp_f.enter_failed_state.call_count == 1
+
+
+def test_enter_failed_state(ezsp_f):
+    ezsp_f.stop_ezsp = mock.MagicMock(spec_set=ezsp_f.stop_ezsp)
+    ezsp_f.handle_callback = mock.MagicMock(spec_set=ezsp_f.handle_callback)
+    ezsp_f.enter_failed_state(mock.sentinel.error, mock.sentinel.preempt)
+    assert ezsp_f.stop_ezsp.call_count == 1
+    assert ezsp_f.handle_callback.call_count == 1
+    assert isinstance(ezsp_f.handle_callback.call_args[0][1], list)
+    assert ezsp_f.handle_callback.call_args[0][1][0] is mock.sentinel.error
+    assert ezsp_f.handle_callback.call_args[0][1][1] is mock.sentinel.preempt


### PR DESCRIPTION
This is one of the fixes targeted to address #124 
1. Reset EZSP if we receive error frames
2. Reset EZSP if there're missing heartbeats (EZSP nop command) from EZSP
3. Reset EZSP if serial connection is lost

in my test it would successfully reconnect on USB stick un-plug/plug back in. I was able to reproduce the Error farme with "Maximum NAK exceeded" condition, by artificially suppressing sending ACKs to NCP and successfully recovering from it. 
With that said, I'm looking for volunteers to test drive it and additional feedback.
