### PR TITLE
Fix ezsp unit test.

### DIFF
--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -140,12 +140,14 @@ def test_receive_new(ezsp_f):
 
 def test_receive_reply(ezsp_f):
     ezsp_f.handle_callback = mock.MagicMock()
-    callback_mock = mock.MagicMock()
+    callback_mock = mock.MagicMock(spec_set=asyncio.Future)
     ezsp_f._awaiting[0] = (0, ezsp_f.COMMANDS['version'][2], callback_mock)
     ezsp_f.frame_received(b'\x00\xff\x00\x04\x05\x06')
 
     assert 0 not in ezsp_f._awaiting
-    assert callback_mock.set_result.called_once_with([4, 5, 6])
+    assert callback_mock.set_exception.call_count == 0
+    assert callback_mock.set_result.call_count == 1
+    callback_mock.set_result.assert_called_once_with([4, 5, 6])
     assert ezsp_f.handle_callback.call_count == 0
 
 


### PR DESCRIPTION
`test_receive_reply` uses `assert callback_mock.set_result.called_once_with([4, 5, 6])` and since `called_once_with()` is a non-existent method, the assertion will always be successful.