### PR TITLE
WIP 0.7.2 -> 0.7.3

### DIFF
--- a/bellows/__init__.py
+++ b/bellows/__init__.py
@@ -1,0 +1,5 @@
+MAJOR_VERSION = 0
+MINOR_VERSION = 7
+PATCH_VERSION = '3'
+__short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
+__version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,11 @@
 
 from setuptools import find_packages, setup
 
+import bellows
+
 setup(
     name="bellows-homeassistant",
-    version="0.7.2",
+    version=bellows.__version__,
     description="Library implementing EZSP",
     url="http://github.com/zigpy/bellows",
     author="Russell Cloran",
@@ -19,7 +21,7 @@ setup(
         'click-log==0.2.0',
         'pure_pcapy3==1.0.1',
         'pyserial-asyncio',
-        'zigpy-homeassistant',
+        'zigpy-homeassistant>=0.3.3',
     ],
     dependency_links=[
         'https://github.com/rcloran/pure-pcapy-3/archive/e289c7d7566306dc02d8f4eb30c0358b41f40f26.zip#egg=pure_pcapy3-1.0.1',


### PR DESCRIPTION
Requires `zigpy-homeassistant >= 0.3.3` published to PyPi and https://github.com/zigpy/bellows/pull/159