### PR TITLE
EZSP multicast ID

### DIFF
--- a/bellows/multicast.py
+++ b/bellows/multicast.py
@@ -30,8 +30,11 @@ class Multicast:
 
     async def startup(self, coordinator) -> None:
         await self._initialize()
-        for group_id in coordinator.member_of:
-            await self.subscribe(group_id)
+        for ep_id, ep in coordinator.endpoints.items():
+            if ep_id == 0:
+                continue
+            for group_id in ep.member_of:
+                await self.subscribe(group_id)
 
     async def subscribe(self, group_id) -> t.EmberStatus:
         if group_id in self._multicast:

--- a/bellows/multicast.py
+++ b/bellows/multicast.py
@@ -1,0 +1,75 @@
+import logging
+
+from bellows import types as t
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Multicast:
+    """Multicast table controller for EZSP."""
+    TABLE_SIZE = 16
+
+    def __init__(self, ezsp):
+        self._ezsp = ezsp
+        self._multicast = {}
+        self._available = set()
+
+    async def initialize(self) -> None:
+        e = self._ezsp
+        for i in range(0, self.TABLE_SIZE):
+            status, entry = await e.getMulticastTableEntry(i)
+            if status != t.EmberStatus.SUCCESS:
+                LOGGER.error("Couldn't get MulticastTableEntry #%s: %s",
+                             i, status)
+                continue
+            LOGGER.debug("MulticastTableEntry[%s] = %s", i, entry)
+            if entry.endpoint != 0:
+                self._multicast[entry.multicastId] = (entry, i)
+            else:
+                self._available.add(i)
+
+    async def subscribe(self, group_id) -> t.EmberStatus:
+        try:
+            idx = self._available.pop()
+        except KeyError:
+            LOGGER.error("No more available slots MulticastId subscription")
+            return t.EmberStatus.INDEX_OUT_OF_RANGE
+        entry = t.EmberMulticastTableEntry()
+        entry.endpoint = t.uint8_t(1)
+        entry.multicastId = t.EmberMulticastId(group_id)
+        entry.networkIndex = t.uint8_t(0)
+        status = await self._ezsp.setMulticastTableEntry(idx, entry)
+        if status[0] != t.EmberStatus.SUCCESS:
+            LOGGER.warning(
+                "Set MulticastTableEntry #%s for %s multicast id: %s",
+                idx, entry.multicastId, status)
+            self._available.add(idx)
+            return status[0]
+
+        self._multicast[entry.multicastId] = (entry, idx)
+        LOGGER.debug("Set MulticastTableEntry #%s for %s multicast id: %s",
+                     idx, entry.multicastId, status)
+        return status[0]
+
+    async def unsubscribe(self, group_id) -> t.EmberStatus:
+        try:
+            entry, idx = self._multicast[group_id]
+        except KeyError:
+            LOGGER.error(
+                "Couldn't find MulticastTableEntry for %s multicast_id",
+                group_id)
+            return t.EmberStatus.INDEX_OUT_OF_RANGE
+
+        entry.endpoint = t.uint8_t(0)
+        status = await self._ezsp.setMulticastTableEntry(idx, entry)
+        if status[0] != t.EmberStatus.SUCCESS:
+            LOGGER.warning(
+                "Set MulticastTableEntry #%s for %s multicast id: %s",
+                idx, entry.multicastId, status)
+            return status[0]
+
+        self._multicast.pop(group_id)
+        self._available.add(idx)
+        LOGGER.debug("Set MulticastTableEntry #%s for %s multicast id: %s",
+                     idx, entry.multicastId, status)
+        return status[0]

--- a/bellows/multicast.py
+++ b/bellows/multicast.py
@@ -29,6 +29,11 @@ class Multicast:
                 self._available.add(i)
 
     async def subscribe(self, group_id) -> t.EmberStatus:
+        if group_id in self._multicast:
+            LOGGER.debug("%s is already subscribed",
+                         t.EmberMulticastId(group_id))
+            return t.EmberStatus.SUCCESS
+
         try:
             idx = self._available.pop()
         except KeyError:

--- a/bellows/multicast.py
+++ b/bellows/multicast.py
@@ -14,7 +14,7 @@ class Multicast:
         self._multicast = {}
         self._available = set()
 
-    async def initialize(self) -> None:
+    async def _initialize(self) -> None:
         e = self._ezsp
         for i in range(0, self.TABLE_SIZE):
             status, entry = await e.getMulticastTableEntry(i)
@@ -27,6 +27,11 @@ class Multicast:
                 self._multicast[entry.multicastId] = (entry, i)
             else:
                 self._available.add(i)
+
+    async def startup(self, coordinator) -> None:
+        await self._initialize()
+        for group_id in coordinator.member_of:
+            await self.subscribe(group_id)
 
     async def subscribe(self, group_id) -> t.EmberStatus:
         if group_id in self._multicast:

--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -153,3 +153,13 @@ def fixed_list(length, itemtype):
         _itemtype = itemtype
 
     return FixedList
+
+
+class HexRepr:
+    _hex_len = 2
+
+    def __repr__(self):
+        return ('0x{:0' + str(self._hex_len) + 'x}').format(self)
+
+    def __str__(self):
+        return ('0x{:0' + str(self._hex_len) + 'x}').format(self)

--- a/bellows/types/named.py
+++ b/bellows/types/named.py
@@ -36,19 +36,19 @@ class EmberRf4ceApplicationCapabilities(basic.uint8_t):
     pass
 
 
-class EmberNodeId(basic.uint16_t):
+class EmberNodeId(basic.HexRepr, basic.uint16_t):
     # 16-bit ZigBee network address.
-    pass
+    _hex_len = 4
 
 
-class EmberPanId(basic.uint16_t):
+class EmberPanId(basic.HexRepr, basic.uint16_t):
     # 802.15.4 PAN ID.
-    pass
+    _hex_len = 4
 
 
-class EmberMulticastId(basic.uint16_t):
+class EmberMulticastId(basic.HexRepr, basic.uint16_t):
     # 16-bit ZigBee multicast group identifier.
-    pass
+    _hex_len = 4
 
 
 class EmberLibraryStatus(basic.uint8_t):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'click-log==0.2.0',
         'pure_pcapy3==1.0.1',
         'pyserial-asyncio',
-        'zigpy-homeassistant>=0.3.3',
+        'zigpy-homeassistant>=0.4.0',
     ],
     dependency_links=[
         'https://github.com/rcloran/pure-pcapy-3/archive/e289c7d7566306dc02d8f4eb30c0358b41f40f26.zip#egg=pure_pcapy3-1.0.1',

--- a/tests/test_multicast.py
+++ b/tests/test_multicast.py
@@ -1,0 +1,179 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+import bellows.ezsp
+import bellows.multicast
+import bellows.types as t
+
+
+@pytest.fixture
+def multicast():
+    e = mock.MagicMock()
+    return bellows.multicast.Multicast(e)
+
+
+@pytest.mark.asyncio
+async def test_initialize(multicast):
+    group_id = 0x0200
+    mct = active_multicasts = 4
+
+    async def mock_get(*args):
+        nonlocal group_id, mct
+        entry = t.EmberMulticastTableEntry()
+        if mct > 0:
+            entry.endpoint = t.uint8_t(group_id % 3 + 1)
+        else:
+            entry.endpoint = t.uint8_t(0)
+        entry.multicastId = t.EmberMulticastId(group_id)
+        entry.networkIndex = t.uint8_t(0)
+        group_id += 1
+        mct -= 1
+        return [t.EmberStatus.SUCCESS, entry]
+
+    multicast._ezsp.getMulticastTableEntry.side_effect = mock_get
+    await multicast._initialize()
+    ezsp = multicast._ezsp
+    assert ezsp.getMulticastTableEntry.call_count == multicast.TABLE_SIZE
+    assert len(multicast._available) == multicast.TABLE_SIZE - active_multicasts
+
+
+@pytest.mark.asyncio
+async def test_initialize_fail(multicast):
+    group_id = 0x0200
+
+    async def mock_get(*args):
+        nonlocal group_id
+        entry = t.EmberMulticastTableEntry()
+        entry.endpoint = t.uint8_t(group_id % 3 + 1)
+        entry.multicastId = t.EmberMulticastId(group_id)
+        entry.networkIndex = t.uint8_t(0)
+        group_id += 1
+        return [t.EmberStatus.ERR_FATAL, entry]
+
+    multicast._ezsp.getMulticastTableEntry.side_effect = mock_get
+    await multicast._initialize()
+    ezsp = multicast._ezsp
+    assert ezsp.getMulticastTableEntry.call_count == multicast.TABLE_SIZE
+    assert len(multicast._available) == 0
+
+
+@pytest.mark.asyncio
+async def test_startup(multicast):
+    coordinator = mock.MagicMock()
+    coordinator.member_of = [mock.sentinel.grp, mock.sentinel.grp,
+                             mock.sentinel.grp]
+    multicast._initialize = mock.MagicMock()
+    multicast._initialize.side_effect = asyncio.coroutine(mock.MagicMock())
+    multicast.subscribe = mock.MagicMock()
+    multicast.subscribe.side_effect = asyncio.coroutine(mock.MagicMock())
+    await multicast.startup(coordinator)
+
+    assert multicast._initialize.call_count == 1
+    assert multicast.subscribe.call_count == len(coordinator.member_of)
+    assert multicast.subscribe.call_args[0][0] == mock.sentinel.grp
+
+
+def _subscribe(multicast, group_id, success=True):
+    async def mock_set(*args):
+        if success:
+            return [t.EmberStatus.SUCCESS]
+        return [t.EmberStatus.ERR_FATAL]
+
+    multicast._ezsp.setMulticastTableEntry = mock.MagicMock()
+    multicast._ezsp.setMulticastTableEntry.side_effect = mock_set
+    return multicast.subscribe(group_id)
+
+
+@pytest.mark.asyncio
+async def test_subscribe(multicast):
+    grp_id = 0x0200
+    multicast._available.add(1)
+
+    ret = await _subscribe(multicast, grp_id, success=True)
+    assert ret == t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 1
+    assert set_entry.call_args[0][1].multicastId == grp_id
+    assert grp_id in multicast._multicast
+
+    set_entry.reset_mock()
+    ret = await _subscribe(multicast, grp_id, success=True)
+    assert ret == t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 0
+    assert grp_id in multicast._multicast
+
+
+@pytest.mark.asyncio
+async def test_subscribe_fail(multicast):
+    grp_id = 0x0200
+    multicast._available.add(1)
+
+    ret = await _subscribe(multicast, grp_id, success=False)
+    assert ret != t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 1
+    assert set_entry.call_args[0][1].multicastId == grp_id
+    assert grp_id not in multicast._multicast
+    assert len(multicast._available) == 1
+
+
+@pytest.mark.asyncio
+async def test_subscribe_no_avail(multicast):
+    grp_id = 0x0200
+
+    ret = await _subscribe(multicast, grp_id, success=True)
+    assert ret != t.EmberStatus.SUCCESS
+
+
+def _unsubscribe(multicast, group_id, success=True):
+    async def mock_set(*args):
+        if success:
+            return [t.EmberStatus.SUCCESS]
+        return [t.EmberStatus.ERR_FATAL]
+
+    multicast._ezsp.setMulticastTableEntry = mock.MagicMock()
+    multicast._ezsp.setMulticastTableEntry.side_effect = mock_set
+    return multicast.unsubscribe(group_id)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe(multicast):
+    grp_id = 0x0200
+    multicast._available.add(1)
+
+    await _subscribe(multicast, grp_id, success=True)
+
+    multicast._ezsp.setMulticastTableEntry.reset_mock()
+    ret = await _unsubscribe(multicast, grp_id, success=True)
+    assert ret == t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 1
+    assert grp_id not in multicast._multicast
+    assert len(multicast._available) == 1
+
+    multicast._ezsp.setMulticastTableEntry.reset_mock()
+    ret = await _unsubscribe(multicast, grp_id, success=True)
+    assert ret != t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 0
+    assert grp_id not in multicast._multicast
+    assert len(multicast._available) == 1
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_fail(multicast):
+    grp_id = 0x0200
+    multicast._available.add(1)
+
+    await _subscribe(multicast, grp_id, success=True)
+
+    multicast._ezsp.setMulticastTableEntry.reset_mock()
+    ret = await _unsubscribe(multicast, grp_id, success=False)
+    assert ret != t.EmberStatus.SUCCESS
+    set_entry = multicast._ezsp.setMulticastTableEntry
+    assert set_entry.call_count == 1
+    assert grp_id in multicast._multicast
+    assert len(multicast._available) == 0

--- a/tests/test_multicast.py
+++ b/tests/test_multicast.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest import mock
 
 import pytest
+from zigpy.endpoint import Endpoint
 
 import bellows.ezsp
 import bellows.multicast
@@ -61,9 +62,15 @@ async def test_initialize_fail(multicast):
 
 @pytest.mark.asyncio
 async def test_startup(multicast):
+
     coordinator = mock.MagicMock()
-    coordinator.member_of = [mock.sentinel.grp, mock.sentinel.grp,
-                             mock.sentinel.grp]
+    ep1 = mock.MagicMock(spec_set=Endpoint)
+    ep1.member_of = [mock.sentinel.grp, mock.sentinel.grp,
+                     mock.sentinel.grp]
+    coordinator.endpoints = {
+        0: mock.sentinel.ZDO,
+        1: ep1
+    }
     multicast._initialize = mock.MagicMock()
     multicast._initialize.side_effect = asyncio.coroutine(mock.MagicMock())
     multicast.subscribe = mock.MagicMock()
@@ -71,7 +78,7 @@ async def test_startup(multicast):
     await multicast.startup(coordinator)
 
     assert multicast._initialize.call_count == 1
-    assert multicast.subscribe.call_count == len(coordinator.member_of)
+    assert multicast.subscribe.call_count == len(ep1.member_of)
     assert multicast.subscribe.call_args[0][0] == mock.sentinel.grp
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -61,3 +61,11 @@ def test_ember_eui64():
     eui64, data = t.EmberEUI64.deserialize(ser)
     assert data == b''
     assert eui64.serialize() == ser
+
+
+def test_hex_repr():
+    class NwkAsHex(t.HexRepr, t.uint16_t):
+        _hex_len = 4
+    nwk = NwkAsHex(0x1234)
+    assert str(nwk) == '0x1234'
+    assert repr(nwk) == '0x1234'


### PR DESCRIPTION
Subscribe EZSP radio to receive multicast IDs. This is a matching PR for https://github.com/zigpy/zigpy/pull/157

EZSP radio is added as a Zigpy device. Calling `await application_controller.get_device(nwk=0x0000).add_to_group(group_id, "group name")` would add group id and subscribe NCP to receive multicast for that specific ID
