### PR TITLE
Fix bug causing NCP to not resubscribe to multicast after restart

### DIFF
--- a/bellows/multicast.py
+++ b/bellows/multicast.py
@@ -16,6 +16,8 @@ class Multicast:
 
     async def _initialize(self) -> None:
         e = self._ezsp
+        self._multicast = {}
+        self._available = set()
         for i in range(0, self.TABLE_SIZE):
             status, entry = await e.getMulticastTableEntry(i)
             if status != t.EmberStatus.SUCCESS:


### PR DESCRIPTION
Since the list of multicast groups was not reset during initialization,
the controller would not resubscribe to multicast groups
it was a part of until the whole system was rebooted.