### PR TITLE
Increase PAN_ID_CONFLICT_REPORT_THRESHOLD.

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -68,6 +68,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             t.EmberZdoConfigurationFlags.APP_HANDLES_UNSUPPORTED_ZDO_REQUESTS
         )
         await self._cfg(c.CONFIG_APPLICATION_ZDO_FLAGS, zdo)
+        await self._cfg(c.CONFIG_PAN_ID_CONFLICT_REPORT_THRESHOLD, 2)
         await self._cfg(c.CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE, 2)
         await self._cfg(c.CONFIG_ADDRESS_TABLE_SIZE, 16)
         await self._cfg(c.CONFIG_SOURCE_ROUTE_TABLE_SIZE, 8)


### PR DESCRIPTION
Increase the number of PAN_ID_CONFLICT_REPORT_THRESHOLD to 2 to limit the probability of a spurious PAN_ID changed because of a conflict. When this happens, most of the Xiaomi devices are falling of the network.
More information https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2012/06/29/why_is_my_networkch-l7gl

> Setting this value to 2 or 3 dramatically reduces the chances of a spurious PAN ID change