### PR TITLE
Fix permit with install code.

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -357,7 +357,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if key is None:
             raise Exception("Invalid install code")
 
-        v = await self._ezsp.addTransientLinkKey(node, key)
+        link_key = t.EmberKeyData()
+        link_key.contents = key
+        v = await self._ezsp.addTransientLinkKey(node, link_key)
+
         if v[0] != t.EmberStatus.SUCCESS:
             raise Exception("Failed to set link key")
 
@@ -368,7 +371,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if v[0] != t.EmberStatus.SUCCESS:
             raise Exception("Failed to change policy to allow generation of new trust center keys")
 
-        return self._ezsp.permitJoining(time_s, True)
+        return await self.permit(time_s)
 
     async def broadcast(self, profile, cluster, src_ep, dst_ep, grpid, radius,
                         sequence, data,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -251,23 +251,25 @@ def test_permit(app):
 def test_permit_with_key(app):
     app._ezsp.addTransientLinkKey = get_mock_coro([0])
     app._ezsp.setPolicy = get_mock_coro([0])
+    app.permit = get_mock_coro([0])
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(app.permit_with_key(bytes([1, 2, 3, 4, 5, 6, 7, 8]), bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]), 60))
 
     assert app._ezsp.addTransientLinkKey.call_count == 1
-    assert app._ezsp.permitJoining.call_count == 1
+    assert app.permit.call_count == 1
 
 
 def test_permit_with_key_ieee(app, ieee):
     app._ezsp.addTransientLinkKey = get_mock_coro([0])
     app._ezsp.setPolicy = get_mock_coro([0])
+    app.permit = get_mock_coro([0])
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(app.permit_with_key(ieee, bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x4A, 0xF7]), 60))
 
     assert app._ezsp.addTransientLinkKey.call_count == 1
-    assert app._ezsp.permitJoining.call_count == 1
+    assert app.permit.call_count == 1
 
 
 def test_permit_with_key_invalid_install_code(app, ieee):


### PR DESCRIPTION
`permit_with_key()` produces
```
debug: MulticastTableEntry[15] = <EmberMulticastTableEntry multicastId=0x0000 endpoint=0 networkIndex=0>
debug: Send command addTransientLinkKey: (91:e3:5d:0b:00:6f:0d:00, [187, 253, 160, 137, 172, 42, 120, 128, 28, 247, 252, 189, 166, 83, 57, 116])
'EmberKeyData' object has no attribute 'contents'
^CError in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 40, in _python_exit
    t.join()
  File "/usr/lib/python3.7/threading.py", line 1032, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.7/threading.py", line 1048, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```

This PR fixes parameter sent to `addTransientLinkKey()` command.
