### PR TITLE
Remove EZSP join handler

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -263,8 +263,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         elif frame_name == "trustCenterJoinHandler":
             if args[2] == t.EmberDeviceUpdate.DEVICE_LEFT:
                 self.handle_leave(args[0], args[1])
-            else:
-                self.handle_join(args[0], args[1], args[4])
         elif frame_name == "incomingRouteRecordHandler":
             self.handle_route_record(*args)
         elif frame_name == "incomingRouteErrorHandler":

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -202,12 +202,6 @@ def test_dup_send_success(app, aps, ieee):
     assert req.result.set_result.call_count == 1
 
 
-def test_join_handler(app, ieee):
-    # Calls device.initialize, leaks a task
-    app.ezsp_callback_handler("trustCenterJoinHandler", [1, ieee, None, None, None])
-    assert ieee in app.devices
-
-
 def test_leave_handler(app, ieee):
     app.devices[ieee] = mock.sentinel.device
     app.ezsp_callback_handler(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -202,6 +202,12 @@ def test_dup_send_success(app, aps, ieee):
     assert req.result.set_result.call_count == 1
 
 
+def test_join_handler(app, ieee):
+    # Calls device.initialize, leaks a task
+    app.ezsp_callback_handler("trustCenterJoinHandler", [1, ieee, None, None, None])
+    assert ieee not in app.devices
+
+
 def test_leave_handler(app, ieee):
     app.devices[ieee] = mock.sentinel.device
     app.ezsp_callback_handler(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -204,8 +204,10 @@ def test_dup_send_success(app, aps, ieee):
 
 def test_join_handler(app, ieee):
     # Calls device.initialize, leaks a task
+    app.handle_join = mock.MagicMock()
     app.ezsp_callback_handler("trustCenterJoinHandler", [1, ieee, None, None, None])
     assert ieee not in app.devices
+    assert app.handle_join.call_count == 0
 
 
 def test_leave_handler(app, ieee):


### PR DESCRIPTION
This PR removes the EZSP join handler. All devices were triggering handle_join 2x because device announce was also triggering the join handler. 