### PR TITLE
cli: Call EZSP.close() on cli command completion

### DIFF
--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -42,20 +42,22 @@ def background(f):
 
 def app(f, app_startup=True):
     database_file = None
+    application = None
 
     async def async_inner(ctx, *args, **kwargs):
         nonlocal database_file
+        nonlocal application
         database_file = ctx.obj["database_file"]
-        app = await setup_application(
+        application = await setup_application(
             ctx.obj["device"], ctx.obj["baudrate"], database_file, startup=app_startup
         )
-        ctx.obj["app"] = app
+        ctx.obj["app"] = application
         await f(ctx, *args, **kwargs)
         await asyncio.sleep(0.5)
 
     def shutdown():
         try:
-            app._ezsp.close()
+            application._ezsp.close()
         except:  # noqa: E722
             pass
 


### PR DESCRIPTION
When testing "bellows form" locally, I noticed that sometimes the
command would not exit on it's own. When investigating, I noticed that
the utility shutdown() function incorrectly referred to the function app
rather than the local app created in async_inner(). The resultant
AttributeError was previously unnoticed because shutdown() silently
catches all exceptions.

This patch adds a reference to application as a local variable in the
top-level utility function, allowing close() to be called correctly.