### PR TITLE
Close thread on UART opening failure.

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -350,9 +350,13 @@ async def connect(port, baudrate, application, use_thread=True):
         application = ThreadsafeProxy(application, asyncio.get_event_loop())
         thread = EventLoopThread()
         await thread.start()
-        protocol, connection_done = await thread.run_coroutine_threadsafe(
-            _connect(port, baudrate, application)
-        )
+        try:
+            protocol, connection_done = await thread.run_coroutine_threadsafe(
+                _connect(port, baudrate, application)
+            )
+        except Exception:
+            thread.force_stop()
+            raise
         connection_done.add_done_callback(lambda _: thread.force_stop())
     else:
         protocol, _ = await _connect(port, baudrate, application)

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,7 +1,7 @@
 import asyncio
 import threading
-from unittest import mock
 
+from asynctest import CoroutineMock, mock
 from bellows import uart
 import pytest
 import serial_asyncio
@@ -47,6 +47,31 @@ async def test_connect_threaded(monkeypatch):
 
     # Need to close to release thread
     gw.close()
+
+    # Ensure all threads are cleaned up
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
+
+
+@pytest.mark.asyncio
+async def test_connect_threaded_failure(monkeypatch):
+
+    portmock = mock.MagicMock()
+    appmock = mock.MagicMock()
+    transport = mock.MagicMock()
+
+    mockconnect = CoroutineMock()
+    mockconnect.side_effect = OSError
+
+    monkeypatch.setattr(serial_asyncio, "create_serial_connection", mockconnect)
+
+    def on_transport_close():
+        gw.connection_lost(None)
+
+    transport.close.side_effect = on_transport_close
+    with pytest.raises(OSError):
+        gw = await uart.connect(portmock, 115200, appmock)
 
     # Ensure all threads are cleaned up
     [t.join(1) for t in threading.enumerate() if "bellows" in t.name]


### PR DESCRIPTION
Don't leave thread running, if we can't open serial port.