### PR TITLE
Refactor multicast initialization.

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -39,7 +39,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         super().__init__(config=zigpy.config.ZIGPY_SCHEMA(config))
         self._ctrl_event = asyncio.Event()
         self._ezsp = None
-        self._multicast = bellows.multicast.Multicast()
+        self._multicast = None
         self._pending = zigpy.util.Requests()
         self._watchdog_task = None
         self._reset_task = None
@@ -72,6 +72,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         await e.reset()
         await e.version()
+        self._multicast = bellows.multicast.Multicast(e)
 
         ezsp_config = self.config[CONF_EZSP_CONFIG]
         for config, value in ezsp_config.items():
@@ -107,7 +108,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self.add_endpoint(
             output_clusters=[zigpy.zcl.clusters.security.IasZone.cluster_id]
         )
-        await self.multicast._initialize(e)
 
     async def add_endpoint(
         self,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -89,10 +89,14 @@ def _test_startup(app, nwk_type, ieee, auto_form=False, init=0, ezsp_version=4):
     ezsp_mock.return_value.getConfigurationValue.side_effect = CoroutineMock(
         return_value=(0, 1)
     )
-    app.multicast._initialize = mockezsp
 
     loop = asyncio.get_event_loop()
-    with mock.patch.object(bellows.ezsp, "EZSP", new=ezsp_mock):
+    p1 = mock.patch.object(bellows.ezsp, "EZSP", new=ezsp_mock)
+    p2 = mock.patch.object(
+        bellows.multicast.Multicast, "initialize", new=CoroutineMock()
+    )
+
+    with p1, p2:
         loop.run_until_complete(app.startup(auto_form=auto_form))
 
 

--- a/tests/test_multicast.py
+++ b/tests/test_multicast.py
@@ -13,13 +13,12 @@ def ezsp_f():
 
 @pytest.fixture
 def multicast(ezsp_f):
-    m = bellows.multicast.Multicast()
-    m._ezsp = ezsp_f
+    m = bellows.multicast.Multicast(ezsp_f)
     return m
 
 
 @pytest.mark.asyncio
-async def test_initialize(multicast, ezsp_f):
+async def test_initialize(ezsp_f):
     group_id = 0x0200
     mct = active_multicasts = 4
 
@@ -37,9 +36,8 @@ async def test_initialize(multicast, ezsp_f):
         return [t.EmberStatus.SUCCESS, entry]
 
     ezsp_f.getMulticastTableEntry.side_effect = mock_get
-    await multicast._initialize(ezsp_f)
-    ezsp = multicast._ezsp
-    assert ezsp.getMulticastTableEntry.call_count == multicast.TABLE_SIZE
+    multicast = await bellows.multicast.Multicast.initialize(ezsp_f)
+    assert ezsp_f.getMulticastTableEntry.call_count == multicast.TABLE_SIZE
     assert len(multicast._available) == multicast.TABLE_SIZE - active_multicasts
 
 
@@ -57,7 +55,7 @@ async def test_initialize_fail(multicast, ezsp_f):
         return [t.EmberStatus.ERR_FATAL, entry]
 
     ezsp_f.getMulticastTableEntry.side_effect = mock_get
-    await multicast._initialize(ezsp_f)
+    await multicast.initialize(ezsp_f)
     ezsp = multicast._ezsp
     assert ezsp.getMulticastTableEntry.call_count == multicast.TABLE_SIZE
     assert len(multicast._available) == 0


### PR DESCRIPTION
Make `Multicast.initialize()` a class method.