### PR TITLE
Add "bootloader" CLI command

### DIFF
--- a/bellows/cli/ncp.py
+++ b/bellows/cli/ncp.py
@@ -79,3 +79,14 @@ async def info(ctx):
         click.echo(v)
 
     s.close()
+
+
+@main.command()
+@click.pass_context
+@util.background
+async def bootloader(ctx):
+    """Get bootloader information"""
+    ezsp = await util.setup(ctx.obj["device"], ctx.obj["baudrate"], configure=False)
+    res = await ezsp.getStandaloneBootloaderVersionPlatMicroPhy()
+    click.echo(res)
+    ezsp.clotse()


### PR DESCRIPTION
Add "bootloader" CLI command.
If NCP has bootloader available, it will launch it. For example on Nortek GoControl HUSBZB-1 sticks, after launching bootloader, it is available via terminal using `115200` baud connection rate.

```
debug: Using selector: EpollSelector
debug: Using selector: EpollSelector
debug: Connected. Resetting.
debug: Resetting EZSP
debug: Resetting ASH
debug: Sending: b'1ac038bc7e'
debug: RSTACK Version: 2 Reason: RESET_SOFTWARE frame: b'c1020b0a527e'
debug: Send command version: (4,)
debug: Sending: b'004221a850ed2c7e'
debug: Data frame: b'0142a1a8532825d4f4497e'
debug: Sending: b'8160597e'
debug: Application frame 0 (version) received: b'07023066'
debug: Send command version: (7,)
debug: Sending: b'7d31432157542a1205877e'
debug: Data frame: b'1243a157542a12b069f2a5a17e'
debug: Sending: b'82503a7e'
debug: Application frame 0 (version) received: b'07023066'
debug: Switched to EZSP protocol version 7
EZSP Stack Type: 2, Stack Version: 26160
debug: Send command getStandaloneBootloaderVersionPlatMicroPhy: ()
debug: Sending: b'2240215754bbef5f7e'
debug: Data frame: b'2340a15754bb05e65d9e49e6697e'
debug: Sending: b'83401b7e'
debug: Application frame 145 (getStandaloneBootloaderVersionPlatMicroPhy) received: b'1054040a03'
bootloader version: 0x5410, nodePlat: 0x04, nodeMicro: 0x0a, nodePhy: 0x03
debug: Send command launchStandaloneBootloader: (0,)
debug: Sending: b'3341215754a515fb937e'
debug: Data frame: b'3441a15754a515c0077e'
debug: Sending: b'8430fc7e'
debug: Application frame 143 (launchStandaloneBootloader) received: b'00'
bootloader launched successfully
debug: Closed serial connection
```

![image](https://user-images.githubusercontent.com/5826160/79917579-baf57d00-83f8-11ea-9972-bdb73fdfccea.png)
