### PR TITLE
Fix zcl commands CLI command

### DIFF
--- a/bellows/cli/application.py
+++ b/bellows/cli/application.py
@@ -302,14 +302,12 @@ async def write_attribute(ctx, attribute, value, manufacturer):
 
 @zcl.command()
 @click.pass_context
-def commands(ctx):
-    database = ctx.obj["database_file"]
+@util.app
+async def commands(ctx):
+    app = ctx.obj["app"]
     node = ctx.obj["node"]
     endpoint_id = ctx.obj["endpoint"]
     cluster_id = ctx.obj["cluster"]
-
-    ezsp = bellows.ezsp.EZSP()
-    app = bellows.zigbee.application.ControllerApplication(ezsp, database)
 
     dev, endpoint, cluster = util.get_in_cluster(app, node, endpoint_id, cluster_id)
     if cluster is None:

--- a/bellows/cli/main.py
+++ b/bellows/cli/main.py
@@ -7,7 +7,7 @@ from . import opts
 
 
 @click.group()
-@click_log.simple_verbosity_option(logging.getLogger())
+@click_log.simple_verbosity_option(logging.getLogger(), default="WARNING")
 @opts.device
 @opts.baudrate
 @click.pass_context

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -92,7 +92,9 @@ class EZSP:
             self._ezsp_version = ver
             await self._command("version", ver)
             LOGGER.debug("Switched to EZSP protocol version %d", self.ezsp_version)
-        LOGGER.info("EZSP Stack Type: %s, Stack Version: %s", stack_type, stack_version)
+        LOGGER.debug(
+            "EZSP Stack Type: %s, Stack Version: %s", stack_type, stack_version
+        )
 
     def close(self):
         self.stop_ezsp()


### PR DESCRIPTION
Fix zcl commands CLI command.
Set default logging level to warning.

Fixes #252 

