### PR TITLE
Remove default value for CONFIG_TRANSIENT_KEY_TIMEOUT_S

### DIFF
--- a/bellows/config/ezsp.py
+++ b/bellows/config/ezsp.py
@@ -242,7 +242,7 @@ EZSP_SCHEMA = {
     # Deprecated
     # The amount of time a trust center will store a transient key
     # with which a device can use to join the network
-    vol.Optional(c.CONFIG_TRANSIENT_KEY_TIMEOUT_S.name, default=180): vol.All(
+    vol.Optional(c.CONFIG_TRANSIENT_KEY_TIMEOUT_S.name): vol.All(
         int, vol.Range(min=0, max=65535)
     ),
     #


### PR DESCRIPTION
Remove default value for CONFIG_TRANSIENT_KEY_TIMEOUT_S. 
Fixes #255 