### PR TITLE
Update README.md with more introduction descriptions about EmberZNet interfaces for new developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `bellows` is a Python 3 library implemention for the [zigpy](https://github.com/zigpy/zigpy) project to add Zigbee radio support for Silicon Labs EM35x ("Ember") based devices using the EZSP (EmberZNet Serial Protocol) interface.
 
-The project can e used as a stand-alone library, however, the main goal of this project is to add native support for EmberZNet Zigbee radio based USB stick devices (a.k.a. "Ember" dongles) to Home Assistant's built-in ZHA (Zigbee Home Automation) integration component, allowing Home Assistant with such hardware to nativly support direct control of compatible Zigbee devices, such as; Philips HUE, GE, Ledvance, Osram Lightify, Xiaomi/Aqara, IKEA Tradfri, Samsung SmartThings, and many more.
+The project can be used as a stand-alone library, however, the main goal of this project is to add native support for EmberZNet Zigbee radio based USB stick devices (a.k.a. "Ember" dongles) to Home Assistant's built-in ZHA (Zigbee Home Automation) integration component, allowing Home Assistant with such hardware to nativly support direct control of compatible Zigbee devices, such as; Philips HUE, GE, Ledvance, Osram Lightify, Xiaomi/Aqara, IKEA Tradfri, Samsung SmartThings, and many more.
 
 - https://www.home-assistant.io/integrations/zha/
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 [![Build Status](https://travis-ci.org/zigpy/bellows.svg?branch=master)](https://travis-ci.org/zigpy/bellows)
 [![Coverage](https://coveralls.io/repos/github/zigpy/bellows/badge.svg?branch=master)](https://coveralls.io/github/zigpy/bellows?branch=master)
 
-`bellows` is a Python 3 project to implement support for EmberZNet devices using the EZSP protocol.
+`bellows` is a Python 3 library implemention for the [zigpy](https://github.com/zigpy/zigpy) project to add Zigbee radio support for Silicon Labs EM35x ("Ember") based devices using the EZSP (EmberZNet Serial Protocol) interface.
 
-The goal is to use this project to add support for the ZigBee Network
-Coprocessor (NCP) in devices like the [Linear/Nortek/GoControl HubZ/QuickStick
-Combo (HUSBZB-1)][HubZ] device to [Home Assistant][hass].
+The project can e used as a stand-alone library, however, the main goal of this project is to add native support for EmberZNet Zigbee radio based USB stick devices (a.k.a. "Ember" dongles) to Home Assistant's built-in ZHA (Zigbee Home Automation) integration component, allowing Home Assistant with such hardware to nativly support direct control of compatible Zigbee devices, such as; Philips HUE, GE, Ledvance, Osram Lightify, Xiaomi/Aqara, IKEA Tradfri, Samsung SmartThings, and many more.
 
-[Hubz]: http://www.gocontrol.com/detail.php?productId=6
-[hass]: https://home-assistant.io/
+- https://www.home-assistant.io/integrations/zha/
 
-## Compatible hardware
+bellows interacts with the Zigbee Network Coprocessor (NCP) with EmberZNet PRO Zigbee coordinator firmware using the EZSP protocol serial interface APIs via via UART for Silicon Labs EM35x Zigbee radio module/chips hardware. The library currectly supports the Silicon Labs EZSP (EmberZNet Serial Protocol) API versions for Silabs EM35x "Ember" SoCs using ASH or SPI protocols over a serial interface. The implementation of the SPI protocol assumes that the SPI provides a TTY-like software interface to the application, or is otherwise abstracted via the ZigBeePort interface.
+
+## Hardware requirement
 
 EmberZNet based Zigbee radios using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
  - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)
@@ -21,6 +20,14 @@ EmberZNet based Zigbee radios using the EZSP protocol (via the [bellows](https:/
  - Telegesis ETRX357USB (Note! This first have to be flashed with other EmberZNet firmware)
  - Telegesis ETRX357USB-LRS (Note! This first have to be flashed with other EmberZNet firmware)
  - Telegesis ETRX357USB-LRS+8M (Note! This first have to be flashed with other EmberZNet firmware)
+ 
+## Firmware requirement
+
+bellows requires that the Zigbee adapter/board/module is pre-flashed/flashed with compatible firmware with EmberZNet PRO Zigbee Stack that uses the standard Silicon Labs EZSP (EmberZNet Serial Protocol) APIs for ASH or SPI protocols over a serial interface.
+
+Silabs did use to provide two main NCP images pre-build with firmware for EM35x, one image supported hardware flow control with a baud rate of 115200 and the other image supported software flow control with a rate of 57600.
+
+Silicon Labs no longer provide pre-build firmware images, so now you have to build and compile firmware with their Simplicity Studio SDK for EmberZNet PRO Zigbee Protocol Stack Software. Simplicity Studio is a free download but building and compiling EmberZNet PRO Zigbee firmware images required that you have the serialnumber of an official Zigbee devkit registered to your Silicon Labs user account.
 
 ## Project status
 


### PR DESCRIPTION
Update README.md with more introduction descriptions about Silabs EmberZNet interfaces for new developers. My goal was is to get a better introduction to the workings of bellows & EZSP interfaces.

Much of this information been copied from Z-Smart Systems (@zsmartsystems) readme file for [com.zsmartsystems.zigbee](https://github.com/zsmartsystems/com.zsmartsystems.zigbee) by @cdjackson which by the way contains even more information which I was not sure if it should also be copied to bellows readme file as well or not, please see:

 - https://github.com/zsmartsystems/com.zsmartsystems.zigbee/blob/master/README.md

Note! If you read his whole readme you see it contains more detailed introductions about everything.

### Silicon Labs Ember EM35x / EFR32

The library supports the Silicon Labs EZSP (EmberZNet Serial Protocol) APIs for EM35x and EFR32 SoCs using ASH or SPI protocols over a serial interface. The implementation of the SPI protocol assumes that the SPI provides a TTY-like software interface to the application, or is otherwise abstracted via the ```ZigBeePort``` interface.  

It is worth noting that EM3588 devices that have an embedded USB core will likely work with any baud rate, where dongles using the external USB interface (eg CP2102 used with an EM3581) will likely require a specific baud rate.

Silabs did use to provide two main NCP images pre-build with firmware for EM35x, one image supported hardware flow control with a baud rate of 115200 and the other image supported software flow control with a rate of 57600. 

Silicon Labs no longer provide pre-build firmware images, so now you have to build and compile the firmware with their Simplicity Studio SDK for EmberZNet PRO Zigbee Protocol Stack Software. Simplicity Studio is a free download but building and compiling EmberZNet PRO Zigbee firmware images required that you have the serialnumber of an official Zigbee devkit registered to your Silicon Labs user account.

#### Ember NCP configuration

The library provides a standard set of configuration constants to configure the NCP for use as a coordinator. There are two methods available in the Ember driver to manipulate the configuration maps ```updateDefaultConfiguration``` and ```updateDefaultPolicy```. The configuration is sent to the NCP during the initialisation sequence which is performed when calling the ```ZigBeeNetworkManager.initialize()``` method, so any changes to configuration must be performed prior to this.

The Ember dongle driver includes a public method ```getEmberNcp()``` which returns a ```EmberNcp``` class. This class provides high-level methods for interacting directly with the NCP.

#### Ember Reset

By default the library uses the ASH Reset command to reset the NCP when the framework starts. Silabs have stated that this is not reliable due to possible communication problems between the NCP and the host. Where possible the user should implement a hardware reset to reset the NCP. Since this is application specific, the framework provides an interface for the application to implement this reset. The user should implement the ```EmberNcpResetProvider``` interface, and set this during NCP initialisation with the ```ZigBeeDongleEzsp.setEmberNcpResetProvider()``` method.

#### Ember MfgLib use

The library provides access to the ```mfglib``` functions in the NCP to facilitate device testing. To use this function, create the ```ZigBeeDongleEzsp``` and then call the ```getEmberMfglib(EmberMfglibListener)``` method to get the ```EmberMfglib``` class and also set the callback listener. The ```EmberMfglib``` class provides access to the ```mfglib``` functions.

Note that this can only be used if the dongle is not configured for use in the network (ie ```initialize``` has not been called).

The [com.zsmartsystems.zigbee.sniffer](https://github.com/zsmartsystems/com.zsmartsystems.zigbee.sniffer) project is an example of the use of these features to provide a network sniffer to route frames to [Wireshark](https://www.wireshark.org/).

## Console Commands

### General Commands

Note that the console is currently being refactored and this readme only documents the commands that have been migrated. For a full list of commands, use the _help_ command in the console.

| Command         | Description                                                                           |
|-----------------|---------------------------------------------------------------------------------------|
|join             |Enable or disable network join                                                         |
|leave            |Remove a node from the network                                                         |
|nodelist         |Lists the known nodes in the network                                                   |
|node             |Provides detailed information about a node                                             |
|endpoint         |Provides detailed information about an endpoint                                        |
|info             |Get basic info about a device                                                          |
|read             |Read an attribute                                                                      |
|write            |Write an attribute                                                                     |
|bind             |Binds a device to another device                                                       |
|unbind           |Unbinds a device from another device                                                   |
|bindtable        |Reads and displays the binding table from a node                                       |
|attsupported     |Check what attributes are supported within a cluster                                   |
|subscribe        |Subscribe to attribute reports                                                         |
|unsubscribe      |Unsubscribe from attribute reports                                                     |
|reportcfg        |Read the reporting configuration of an attribute                                       |
|otaupgrade       |Provides information about device Over The Air upgrade server status                   |
|installkey       |Adds an install key to the dongle                                                      |
|linkkey          |Sets the link key int the dongle, optionally computing the MMO Hash from the join code |
|netstart         |Join or Form a network as a router or coordinator                                      |
|netbackup        |Backup or restores the state of the dongle                                             |
|discovery        |Gets information on the network discovery tasks                                        |


### Ember NCP Commands

The following commands are available if the transport layer is using the Silabs Ember NCP.

| Command         | Description                                                                  |
|-----------------|------------------------------------------------------------------------------|
|ncpchildren      |Gets the NCP child information                                                |
|ncpconfig        |Read or write an NCP configuration value                                      |
|ncpscan          |Performs a scan, looking for other networks, or energy levels on each channel |
|ncpcounters      |Gets the NCP debug counters                                                   |
|ncpstate         |Gets the NCP network state and optionally brings the network up or down       |
|ncpvalue         |Read or write an NCP memory value                                             |
|ncpversion       |Gets the NCP firmware version                                                 |
|ncpsecuritystate |Gets the current NCP security state and configuration                         |
|ncptransientkey  |Adds a transient link key to the NCP                                          |
|ncpmmohash       |Uses the NCP to perform the MMO hash             