### PR TITLE
Proper initialize EZSP multicast table

### DIFF
--- a/bellows/config/ezsp.py
+++ b/bellows/config/ezsp.py
@@ -1,3 +1,4 @@
+import bellows.multicast
 import bellows.types
 import voluptuous as vol
 
@@ -31,9 +32,10 @@ EZSP_SCHEMA = {
     ),
     #
     # The maximum number of multicast groups that the device may be a member of
-    vol.Optional(c.CONFIG_MULTICAST_TABLE_SIZE.name): vol.All(
-        int, vol.Range(min=0, max=255)
-    ),
+    vol.Optional(
+        c.CONFIG_MULTICAST_TABLE_SIZE.name,
+        default=bellows.multicast.Multicast.TABLE_SIZE,
+    ): vol.All(int, vol.Range(min=0, max=255)),
     #
     # The maximum number of destinations to which a node can route messages. This
     # includes both messages originating at this node and those relayed for others

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -94,12 +94,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await self._cfg(c.CONFIG_END_DEVICE_POLL_TIMEOUT, 60)
             await self._cfg(c.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, 8)
         await self._cfg(
-            c.CONFIG_MULTICAST_TABLE_SIZE,
-            ezsp_config.get(
-                c.CONFIG_MULTICAST_TABLE_SIZE.name, self.multicast.TABLE_SIZE
-            ),
-        )
-        await self._cfg(
             t.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT,
             ezsp_config[c.CONFIG_PACKET_BUFFER_COUNT.name],
         )

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -93,12 +93,11 @@ def _test_startup(app, nwk_type, ieee, auto_form=False, init=0, ezsp_version=4):
 
     loop = asyncio.get_event_loop()
     p1 = mock.patch.object(bellows.ezsp, "EZSP", new=ezsp_mock)
-    p2 = mock.patch.object(
-        bellows.multicast.Multicast, "initialize", new=CoroutineMock()
-    )
+    p2 = mock.patch.object(bellows.multicast.Multicast, "startup")
 
-    with p1, p2:
+    with p1, p2 as multicast_mock:
         loop.run_until_complete(app.startup(auto_form=auto_form))
+    assert multicast_mock.await_count == 1
 
 
 def test_startup(app, ieee):


### PR DESCRIPTION
Proper initialize EZSP multicast table.
Allow configurable multicast table size.
Fixes https://github.com/home-assistant/core/issues/35661