### PR TITLE
Set CONFIG_MAX_END_DEVICE_CHILDREN default to 24

### DIFF
--- a/bellows/config/ezsp.py
+++ b/bellows/config/ezsp.py
@@ -74,7 +74,7 @@ EZSP_SCHEMA = {
     vol.Optional(c.CONFIG_MAX_HOPS.name): vol.All(int, vol.Range(min=0, max=30)),
     #
     # The maximum number of end device children that a router will support
-    vol.Optional(c.CONFIG_MAX_END_DEVICE_CHILDREN.name, default=32): vol.All(
+    vol.Optional(c.CONFIG_MAX_END_DEVICE_CHILDREN.name, default=24): vol.All(
         int, vol.Range(min=0, max=32)
     ),
     #


### PR DESCRIPTION
Reduce the default max number of end devices the coordinator will support to 24. Fixes https://github.com/home-assistant/core/issues/36563