### PR TITLE
Feature efr32 support - EZSP v8 framing

### DIFF
--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -111,8 +111,8 @@ class EZSP:
             frame.insert(1, 0x00)  # Frame control low byte
         if self.ezsp_version >= 8:
             frame[2] = 0x01  # EZSP v8 - FC High Byte
-            frame[3] = c[0] & 0x00FF  # Extended Frame ID starting from EZSP 8 - LSB
-            frame[4] = (c[0] & 0xFF00) >> 8  # Extended Frame ID starting from EZSP 8 - MSB
+            frame[3] = c[0] & 0x00FF  # Extended Frame ID - LSB
+            frame[4] = (c[0] & 0xFF00) >> 8  # Extended Frame ID - MSB
 
         return bytes(frame) + data
 
@@ -224,7 +224,7 @@ class EZSP:
         data randomization removed.
         """
         if self.ezsp_version >= 8:
-            sequence, frame_control_lb, frame_control_hb, frame_id, data = data[0], data[1], data[2], ((data[4] << 8) | data[3] ), data[5:]
+            sequence, frame_id, data = data[0], ((data[4] << 8) | data[3]), data[5:]
         else:
             sequence, frame_id, data = data[0], data[2], data[3:]
 

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -107,8 +107,12 @@ class EZSP:
         data = t.serialize(args, c[1])
         frame = [self._seq & 0xFF, 0, c[0]]  # Frame control. TODO.  # Frame ID
         if self.ezsp_version >= 5:
-            frame.insert(1, 0xFF)  # Legacy Frame ID
-            frame.insert(1, 0x00)  # Ext frame control. TODO.
+            frame.insert(1, 0xFF)  # Legacy Frame ID / Frame Control High Byte v8
+            frame.insert(1, 0x00)  # Frame control low byte
+        if self.ezsp_version >= 8:
+            frame[2] = 0x01  # Extended Frame ID starting from EZSP 8
+            frame[3] = c[0] & 0xFF  # Extended Frame ID starting from EZSP 8
+            frame[4] = 0x00  # Extended Frame ID starting from EZSP 8
 
         return bytes(frame) + data
 
@@ -219,7 +223,11 @@ class EZSP:
         just have EZSP application stuff here, with all escaping/stuffing and
         data randomization removed.
         """
-        sequence, frame_id, data = data[0], data[2], data[3:]
+        if self.ezsp_version >= 8:
+            sequence, frame_control_lb, frame_control_hb, frame_id, data = data[0], data[1], data[2], ((data[4] << 8) | data[3] ), data[5:]
+        else:
+            sequence, frame_id, data = data[0], data[2], data[3:]
+
         if frame_id == 0xFF:
             frame_id = 0
             if len(data) > 1:

--- a/bellows/ezsp.py
+++ b/bellows/ezsp.py
@@ -107,12 +107,12 @@ class EZSP:
         data = t.serialize(args, c[1])
         frame = [self._seq & 0xFF, 0, c[0]]  # Frame control. TODO.  # Frame ID
         if self.ezsp_version >= 5:
-            frame.insert(1, 0xFF)  # Legacy Frame ID / Frame Control High Byte v8
+            frame.insert(1, 0xFF)  # Legacy Frame
             frame.insert(1, 0x00)  # Frame control low byte
         if self.ezsp_version >= 8:
-            frame[2] = 0x01  # Extended Frame ID starting from EZSP 8
-            frame[3] = c[0] & 0xFF  # Extended Frame ID starting from EZSP 8
-            frame[4] = 0x00  # Extended Frame ID starting from EZSP 8
+            frame[2] = 0x01  # EZSP v8 - FC High Byte
+            frame[3] = c[0] & 0x00FF  # Extended Frame ID starting from EZSP 8 - LSB
+            frame[4] = (c[0] & 0xFF00) >> 8  # Extended Frame ID starting from EZSP 8 - MSB
 
         return bytes(frame) + data
 

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -186,6 +186,11 @@ def test_receive_protocol_5(ezsp_f):
     ezsp_f.frame_received(b"\x01\x80\xff\x00\x00\x06\x02\x00")
     assert ezsp_f.handle_callback.call_count == 1
 
+def test_receive_protocol_8(ezsp_f):
+    ezsp_f._ezsp_version = 8
+    ezsp_f.handle_callback = mock.MagicMock()
+    ezsp_f.frame_received(b"\x01\x80\x01\x00\x00\x06\x02\x00")
+    assert ezsp_f.handle_callback.call_count == 1
 
 def test_receive_reply(ezsp_f):
     ezsp_f.handle_callback = mock.MagicMock()
@@ -305,6 +310,10 @@ def test_ezsp_frame(ezsp_f):
     ezsp_f._ezsp_version = 5
     data = ezsp_f._ezsp_frame("version", 6)
     assert data == b"\x22\x00\xff\x00\x00\x06"
+
+    ezsp_f._ezsp_version = 8
+    data = ezsp_f._ezsp_frame("version", 8)
+    assert data == b"\x22\x00\x01\x00\x00\x08"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -186,11 +186,13 @@ def test_receive_protocol_5(ezsp_f):
     ezsp_f.frame_received(b"\x01\x80\xff\x00\x00\x06\x02\x00")
     assert ezsp_f.handle_callback.call_count == 1
 
+
 def test_receive_protocol_8(ezsp_f):
     ezsp_f._ezsp_version = 8
     ezsp_f.handle_callback = mock.MagicMock()
     ezsp_f.frame_received(b"\x01\x80\x01\x00\x00\x06\x02\x00")
     assert ezsp_f.handle_callback.call_count == 1
+
 
 def test_receive_reply(ezsp_f):
     ezsp_f.handle_callback = mock.MagicMock()


### PR DESCRIPTION
Hi,

I added the support for EZSP v8 framing which allows bellows to run against Silicon Labs EmberZNet SDK 6.7.6 (latest). EZSP v8 simply passes Frame ID field to a 16 bit value

I added it so it does not affect currently supported devices, but adapts to those that run a newer version of EZSP
I tested it over a Silicon Labs Thunderboard Sense 2 (EFR32MG12 based), for which I built a specific NCP firmware (bellows CLI commands tests only)

Best,
Brian

