### PR TITLE
handle ID conflict reports

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -564,7 +564,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     def _handle_id_conflict(self, nwk: t.EmberNodeId) -> None:
         LOGGER.warning("NWK conflict is reported for %04x", nwk)
-        for device in self.devices:
+        for device in self.devices.values():
             if device.nwk != nwk:
                 continue
             LOGGER.warning(

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -592,23 +592,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         return await self.permit(time_s)
 
     def _handle_id_conflict(self, nwk: t.EmberNodeId) -> None:
-        LOGGER.warning("NWK conflict is reported for %04x", nwk)
+        LOGGER.warning("NWK conflict is reported for 0x%04x", nwk)
         for device in self.devices.values():
             if device.nwk != nwk:
                 continue
             LOGGER.warning(
-                "Found %s device for %04x NWK conflict: %s %s",
+                "Found %s device for 0x%04x NWK conflict: %s %s",
                 device.ieee,
                 nwk,
                 device.manufacturer,
                 device.model,
             )
             self.handle_leave(nwk, device.ieee)
-            asyncio.create_task(self._id_conflict_resolution(device))
-
-    async def _id_conflict_resolution(self, device: zigpy.device.Device):
-        res = await self._ezsp.lookupNodeIdByEUI64(device.ieee)
-        LOGGER.debug("Looking up NWK for %s ieee resulted in: %s", device.ieee, res)
 
     async def broadcast(
         self,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1080,3 +1080,73 @@ async def test_probe_success(mock_connect, mock_reset):
     assert mock_connect.await_count == 1
     assert mock_reset.call_count == 1
     assert mock_connect.return_value.close.call_count == 1
+
+
+def test_handle_id_conflict(app, ieee):
+    """Test handling of an ID confict report."""
+    nwk = t.EmberNodeId(0x1234)
+    app.add_device(ieee, nwk)
+    app.handle_leave = mock.MagicMock()
+
+    app.ezsp_callback_handler("idConflictHandler", [nwk + 1])
+    assert app.handle_leave.call_count == 0
+
+    app.ezsp_callback_handler("idConflictHandler", [nwk])
+    assert app.handle_leave.call_count == 1
+    assert app.handle_leave.call_args[0][0] == nwk
+
+
+def test_handle_tc_join_handler(app, ieee):
+    """Test updating device NWK on TC join/rejoin callbacks."""
+    nwk = t.EmberNodeId(0x1234)
+    new_nwk = t.EmberNodeId(0x4321)
+
+    app.ezsp_callback_handler(
+        "trustCenterJoinHandler",
+        (
+            nwk,
+            ieee,
+            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
+            mock.sentinel.decision,
+            mock.sentinel.parent,
+        ),
+    )
+
+    dev = app.add_device(ieee, nwk)
+    app.ezsp_callback_handler(
+        "trustCenterJoinHandler",
+        (
+            nwk,
+            ieee,
+            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
+            mock.sentinel.decision,
+            mock.sentinel.parent,
+        ),
+    )
+    assert dev.nwk == nwk
+
+    app.ezsp_callback_handler(
+        "trustCenterJoinHandler",
+        (
+            new_nwk,
+            ieee,
+            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
+            mock.sentinel.decision,
+            mock.sentinel.parent,
+        ),
+    )
+    assert dev.nwk == new_nwk
+
+    ieee[0] = 0x22
+    app.ezsp_callback_handler(
+        "trustCenterJoinHandler",
+        (
+            nwk,
+            ieee,
+            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
+            mock.sentinel.decision,
+            mock.sentinel.parent,
+        ),
+    )
+    assert dev.nwk == new_nwk
+

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1149,4 +1149,3 @@ def test_handle_tc_join_handler(app, ieee):
         ),
     )
     assert dev.nwk == new_nwk
-


### PR DESCRIPTION
If EZSP stack reports id conflict (NWK address conflict) then mark device as leaving.
If we get a trust center callback, then use that information to update NWK address of the device if it exists.