### PR TITLE
Trigger handle_join on TC join call backs

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -268,7 +268,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             if dev_update_status == t.EmberDeviceUpdate.DEVICE_LEFT:
                 self.handle_leave(nwk, ieee)
             else:
-                self._update_device(nwk, ieee, dev_update_status, decision, parent_nwk)
+                self.handle_join(nwk, ieee, parent_nwk)
         elif frame_name == "incomingRouteRecordHandler":
             self.handle_route_record(*args)
         elif frame_name == "incomingRouteErrorHandler":
@@ -382,32 +382,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._ezsp.close()
         await asyncio.sleep(0.5)
         await self.startup()
-
-    def _update_device(
-        self,
-        nwk: t.EmberNodeId,
-        ieee: t.EmberEUI64,
-        dev_update_status: t.EmberDeviceUpdate,
-        decision: t.EmberJoinDecision,
-        parent_nwk: t.EmberNodeId,
-    ) -> None:
-        """Handle Trust Center join callback.
-
-        If this is an existing device, then update the NWK address, otherwise it is a
-        nop
-        """
-        try:
-            device = self.get_device(ieee=ieee)
-            if device.nwk != nwk:
-                LOGGER.info(
-                    "Updating NWK address for %s device. New NWK address: %04x",
-                    ieee,
-                    nwk,
-                )
-                device.nwk = nwk
-        except KeyError:
-            # new device joining. wait till ZDO announce
-            pass
 
     async def mrequest(
         self,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -226,9 +226,14 @@ def test_dup_send_success(app, aps, ieee):
 def test_join_handler(app, ieee):
     # Calls device.initialize, leaks a task
     app.handle_join = mock.MagicMock()
-    app.ezsp_callback_handler("trustCenterJoinHandler", [1, ieee, None, None, None])
+    app.ezsp_callback_handler(
+        "trustCenterJoinHandler", [1, ieee, None, None, mock.sentinel.parent]
+    )
     assert ieee not in app.devices
-    assert app.handle_join.call_count == 0
+    assert app.handle_join.call_count == 1
+    assert app.handle_join.call_args[0][0] == 1
+    assert app.handle_join.call_args[0][1] == ieee
+    assert app.handle_join.call_args[0][2] is mock.sentinel.parent
 
 
 def test_leave_handler(app, ieee):
@@ -1094,24 +1099,3 @@ def test_handle_id_conflict(app, ieee):
     app.ezsp_callback_handler("idConflictHandler", [nwk])
     assert app.handle_leave.call_count == 1
     assert app.handle_leave.call_args[0][0] == nwk
-
-
-def test_handle_tc_join_handler(app, ieee):
-    """Test updating device NWK on TC join/rejoin callbacks."""
-    nwk = t.EmberNodeId(0x1234)
-    app.handle_join = mock.MagicMock()
-
-    app.ezsp_callback_handler(
-        "trustCenterJoinHandler",
-        (
-            nwk,
-            ieee,
-            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
-            mock.sentinel.decision,
-            mock.sentinel.parent,
-        ),
-    )
-    assert app.handle_join.call_count == 1
-    assert app.handle_join.call_args[0][0] == nwk
-    assert app.handle_join.call_args[0][1] == ieee
-    assert app.handle_join.call_args[0][2] is mock.sentinel.parent

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1099,7 +1099,7 @@ def test_handle_id_conflict(app, ieee):
 def test_handle_tc_join_handler(app, ieee):
     """Test updating device NWK on TC join/rejoin callbacks."""
     nwk = t.EmberNodeId(0x1234)
-    new_nwk = t.EmberNodeId(0x4321)
+    app.handle_join = mock.MagicMock()
 
     app.ezsp_callback_handler(
         "trustCenterJoinHandler",
@@ -1111,41 +1111,7 @@ def test_handle_tc_join_handler(app, ieee):
             mock.sentinel.parent,
         ),
     )
-
-    dev = app.add_device(ieee, nwk)
-    app.ezsp_callback_handler(
-        "trustCenterJoinHandler",
-        (
-            nwk,
-            ieee,
-            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
-            mock.sentinel.decision,
-            mock.sentinel.parent,
-        ),
-    )
-    assert dev.nwk == nwk
-
-    app.ezsp_callback_handler(
-        "trustCenterJoinHandler",
-        (
-            new_nwk,
-            ieee,
-            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
-            mock.sentinel.decision,
-            mock.sentinel.parent,
-        ),
-    )
-    assert dev.nwk == new_nwk
-
-    ieee[0] = 0x22
-    app.ezsp_callback_handler(
-        "trustCenterJoinHandler",
-        (
-            nwk,
-            ieee,
-            t.EmberDeviceUpdate.STANDARD_SECURITY_SECURED_REJOIN,
-            mock.sentinel.decision,
-            mock.sentinel.parent,
-        ),
-    )
-    assert dev.nwk == new_nwk
+    assert app.handle_join.call_count == 1
+    assert app.handle_join.call_args[0][0] == nwk
+    assert app.handle_join.call_args[0][1] == ieee
+    assert app.handle_join.call_args[0][2] is mock.sentinel.parent


### PR DESCRIPTION
There was a problem were Zigpy would have stale information, if EZSP reported NWK conflict. After further testing, the approach in #274 was causing some issues, if the user was joining a device which was reset without removing the device 1st.
In new approach, we revert to the old behavior where we trigger a `handle_join()` and let it handle all the updates and updating the saved state.

