### PR TITLE
Allow custom policy configuration.

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -9,6 +9,7 @@ from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
 
 CONF_DEVICE_BAUDRATE = "baudrate"
 CONF_EZSP_CONFIG = "ezsp_config"
+CONF_EZSP_POLICIES = "ezsp_policies"
 CONF_PARAM_SRC_RTG = "source_routing"
 
 SCHEMA_DEVICE = SCHEMA_DEVICE.extend(
@@ -20,5 +21,10 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
         vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
         vol.Optional(CONF_PARAM_SRC_RTG, default=False): cv_boolean,
         vol.Optional(CONF_EZSP_CONFIG, default={}): dict,
+        vol.Optional(CONF_EZSP_POLICIES, default={}): vol.Schema(
+            {vol.Optional(str): int}
+        ),
     }
 )
+
+cv_uint16 = vol.All(int, vol.Range(min=0, max=65535))

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -81,7 +81,7 @@ class ProtocolHandler(abc.ABC):
 
         policies = self.SCHEMAS[CONF_EZSP_POLICIES](zigpy_config[CONF_EZSP_POLICIES])
         for policy, value in policies.items():
-            status, = await self.setPolicy(self.types.EzspPolicyId[policy], value)
+            (status,) = await self.setPolicy(self.types.EzspPolicyId[policy], value)
             assert status == self.types.EmberStatus.SUCCESS  # TODO: Better check
 
     def __call__(self, data: bytes) -> None:

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -5,7 +5,7 @@ import functools
 import logging
 from typing import Any, Callable, Dict, Tuple
 
-import bellows.config
+from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES
 from bellows.typing import GatewayType
 
 LOGGER = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class ProtocolHandler(abc.ABC):
     async def initialize(self, ezsp_config: Dict) -> None:
         """Initialize EmberZNet Stack."""
 
-        ezsp_config = self.SCHEMAS[bellows.config.CONF_EZSP_CONFIG](ezsp_config)
+        ezsp_config = self.SCHEMAS[CONF_EZSP_CONFIG](ezsp_config)
         for config, value in ezsp_config.items():
             if config in (self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name,):
                 # we want to set these last
@@ -79,21 +79,10 @@ class ProtocolHandler(abc.ABC):
     async def update_policies(self, zigpy_config: dict) -> None:
         """Set up the policies for what the NCP should do."""
 
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.TC_KEY_REQUEST_POLICY,
-            self.types.EzspDecisionId.GENERATE_NEW_TC_LINK_KEY,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.APP_KEY_REQUEST_POLICY,
-            self.types.EzspDecisionId.DENY_APP_KEY_REQUESTS,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.TRUST_CENTER_POLICY,
-            self.types.EzspDecisionId.ALLOW_PRECONFIGURED_KEY_JOINS,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
+        policies = self.SCHEMAS[CONF_EZSP_POLICIES](zigpy_config[CONF_EZSP_POLICIES])
+        for policy, value in policies.items():
+            status, = await self.setPolicy(self.types.EzspPolicyId[policy], value)
+            assert status == self.types.EmberStatus.SUCCESS  # TODO: Better check
 
     def __call__(self, data: bytes) -> None:
         """Handler for received data frame."""

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -5,6 +5,7 @@ import functools
 import logging
 from typing import Any, Callable, Dict, Tuple
 
+import bellows.config
 from bellows.typing import GatewayType
 
 LOGGER = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ class ProtocolHandler(abc.ABC):
     async def initialize(self, ezsp_config: Dict) -> None:
         """Initialize EmberZNet Stack."""
 
-        ezsp_config = self.SCHEMA(ezsp_config)
+        ezsp_config = self.SCHEMAS[bellows.config.CONF_EZSP_CONFIG](ezsp_config)
         for config, value in ezsp_config.items():
             if config in (self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name,):
                 # we want to set these last

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -2,9 +2,10 @@
 import logging
 from typing import Tuple
 
+import bellows.config
 import voluptuous
 
-from . import commands, config as v4_config, types as v4_types
+from . import commands, config, types as v4_types
 from .. import protocol
 
 EZSP_VERSION = 4
@@ -15,7 +16,7 @@ class EZSPv4(protocol.ProtocolHandler):
     """EZSP Version 4 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMA = voluptuous.Schema(v4_config.EZSP_SCHEMA)
+    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
     types = v4_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -16,7 +16,10 @@ class EZSPv4(protocol.ProtocolHandler):
     """EZSP Version 4 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
+    SCHEMAS = {
+        bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA),
+        bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
+    }
     types = v4_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v4/config.py
+++ b/bellows/ezsp/v4/config.py
@@ -284,6 +284,6 @@ EZSP_POLICIES_SHARED = {
 }
 
 EZSP_POLICIES_SCH = {
-    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
     **EZSP_POLICIES_SHARED,
+    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
 }

--- a/bellows/ezsp/v4/config.py
+++ b/bellows/ezsp/v4/config.py
@@ -1,3 +1,4 @@
+from bellows.config import cv_uint16
 import bellows.multicast
 import voluptuous as vol
 
@@ -265,4 +266,24 @@ EZSP_SCHEMA = {
     vol.Optional(c.CONFIG_TRANSIENT_KEY_TIMEOUT_S.name): vol.All(
         int, vol.Range(min=0, max=65535)
     ),
+}
+
+EZSP_POLICIES_SHARED = {
+    vol.Optional(
+        types.EzspPolicyId.TC_KEY_REQUEST_POLICY.name,
+        default=types.EzspDecisionId.GENERATE_NEW_TC_LINK_KEY,
+    ): cv_uint16,
+    vol.Optional(
+        types.EzspPolicyId.APP_KEY_REQUEST_POLICY.name,
+        default=types.EzspDecisionId.DENY_APP_KEY_REQUESTS,
+    ): cv_uint16,
+    vol.Optional(
+        types.EzspPolicyId.TRUST_CENTER_POLICY.name,
+        default=types.EzspDecisionId.ALLOW_PRECONFIGURED_KEY_JOINS,
+    ): cv_uint16,
+}
+
+EZSP_POLICIES_SCH = {
+    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
+    **EZSP_POLICIES_SHARED,
 }

--- a/bellows/ezsp/v5/__init__.py
+++ b/bellows/ezsp/v5/__init__.py
@@ -2,9 +2,10 @@
 import logging
 from typing import Tuple
 
+import bellows.config
 import voluptuous
 
-from . import commands, config as v5_config, types as v5_types
+from . import commands, config, types as v5_types
 from .. import protocol
 
 EZSP_VERSION = 5
@@ -15,7 +16,7 @@ class EZSPv5(protocol.ProtocolHandler):
     """EZSP Version 5 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMA = voluptuous.Schema(v5_config.EZSP_SCHEMA)
+    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
     types = v5_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v5/__init__.py
+++ b/bellows/ezsp/v5/__init__.py
@@ -16,7 +16,10 @@ class EZSPv5(protocol.ProtocolHandler):
     """EZSP Version 5 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
+    SCHEMAS = {
+        bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA),
+        bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
+    }
     types = v5_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v5/config.py
+++ b/bellows/ezsp/v5/config.py
@@ -1,7 +1,15 @@
-from ..v4 import config as v4_config
+from bellows.config import cv_uint16
+import voluptuous as vol
+
+from ..v4 import config as v4_config, types
 
 _deletions = ("CONFIG_BROADCAST_ALARM_DATA_SIZE", "CONFIG_UNICAST_ALARM_DATA_SIZE")
 
 EZSP_SCHEMA = {k: v for k, v in v4_config.EZSP_SCHEMA.items() if k not in _deletions}
 
 del _deletions
+
+EZSP_POLICIES_SCH = {
+    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
+    **v4_config.EZSP_POLICIES_SHARED,
+}

--- a/bellows/ezsp/v5/config.py
+++ b/bellows/ezsp/v5/config.py
@@ -10,6 +10,6 @@ EZSP_SCHEMA = {k: v for k, v in v4_config.EZSP_SCHEMA.items() if k not in _delet
 del _deletions
 
 EZSP_POLICIES_SCH = {
-    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
     **v4_config.EZSP_POLICIES_SHARED,
+    **{vol.Optional(policy.name): cv_uint16 for policy in types.EzspPolicyId},
 }

--- a/bellows/ezsp/v6/__init__.py
+++ b/bellows/ezsp/v6/__init__.py
@@ -1,9 +1,10 @@
 """"EZSP Protocol version 6 protocol handler."""
 import logging
 
+import bellows.config
 import voluptuous
 
-from . import commands, config as v6_config, types as v6_types
+from . import commands, config, types as v6_types
 from ..v5 import EZSPv5
 
 EZSP_VERSION = 6
@@ -14,5 +15,5 @@ class EZSPv6(EZSPv5):
     """EZSP Version 6 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMA = voluptuous.Schema(v6_config.EZSP_SCHEMA)
+    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
     types = v6_types

--- a/bellows/ezsp/v6/__init__.py
+++ b/bellows/ezsp/v6/__init__.py
@@ -15,5 +15,8 @@ class EZSPv6(EZSPv5):
     """EZSP Version 6 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
+    SCHEMAS = {
+        bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA),
+        bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
+    }
     types = v6_types

--- a/bellows/ezsp/v6/config.py
+++ b/bellows/ezsp/v6/config.py
@@ -1,7 +1,9 @@
+from bellows.config import cv_uint16
 import voluptuous as vol
 
+from ..v4.config import EZSP_POLICIES_SHARED
 from ..v5 import config as v5_config
-from .types import EzspConfigId
+from .types import EzspConfigId, EzspPolicyId
 
 _deletions = (
     "CONFIG_MOBILE_NODE_POLL_TIMEOUT",
@@ -27,3 +29,8 @@ EZSP_SCHEMA = {
 }
 
 del _deletions
+
+EZSP_POLICIES_SCH = {
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
+    **EZSP_POLICIES_SHARED,
+}

--- a/bellows/ezsp/v6/config.py
+++ b/bellows/ezsp/v6/config.py
@@ -31,6 +31,6 @@ EZSP_SCHEMA = {
 del _deletions
 
 EZSP_POLICIES_SCH = {
-    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
     **EZSP_POLICIES_SHARED,
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
 }

--- a/bellows/ezsp/v7/__init__.py
+++ b/bellows/ezsp/v7/__init__.py
@@ -15,5 +15,8 @@ class EZSPv7(EZSPv5):
     """EZSP Version 7 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
+    SCHEMAS = {
+        bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA),
+        bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
+    }
     types = v7_types

--- a/bellows/ezsp/v7/__init__.py
+++ b/bellows/ezsp/v7/__init__.py
@@ -1,9 +1,10 @@
 """"EZSP Protocol version 7 protocol handler."""
 import logging
 
+import bellows.config
 import voluptuous
 
-from . import commands, config as v7_config, types as v7_types
+from . import commands, config, types as v7_types
 from ..v5 import EZSPv5
 
 EZSP_VERSION = 7
@@ -14,5 +15,5 @@ class EZSPv7(EZSPv5):
     """EZSP Version 7 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMA = voluptuous.Schema(v7_config.EZSP_SCHEMA)
+    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
     types = v7_types

--- a/bellows/ezsp/v7/config.py
+++ b/bellows/ezsp/v7/config.py
@@ -1,7 +1,9 @@
+from bellows.config import cv_uint16
 import bellows.multicast
 import voluptuous as vol
 
-from .types import EmberZdoConfigurationFlags, EzspConfigId
+from ..v4.config import EZSP_POLICIES_SHARED
+from .types import EmberZdoConfigurationFlags, EzspConfigId, EzspPolicyId
 
 EZSP_SCHEMA = {
     # The number of packet buffers available to the stack. When set to the special
@@ -246,4 +248,9 @@ EZSP_SCHEMA = {
     vol.Optional(
         EzspConfigId.CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S.name
     ): vol.All(int, vol.Range(min=0)),
+}
+
+EZSP_POLICIES_SCH = {
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
+    **EZSP_POLICIES_SHARED,
 }

--- a/bellows/ezsp/v7/config.py
+++ b/bellows/ezsp/v7/config.py
@@ -251,6 +251,6 @@ EZSP_SCHEMA = {
 }
 
 EZSP_POLICIES_SCH = {
-    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
     **EZSP_POLICIES_SHARED,
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
 }

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -16,7 +16,10 @@ class EZSPv8(protocol.ProtocolHandler):
     """EZSP Version 8 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
+    SCHEMAS = {
+        bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA),
+        bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
+    }
     types = v8_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -34,24 +34,3 @@ class EZSPv8(protocol.ProtocolHandler):
         frame_id, data = self.types.uint16_t.deserialize(data)
 
         return seq, frame_id, data
-
-    async def update_policies(self, zigpy_config: dict) -> None:
-        """Set up the policies for what the NCP should do."""
-
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.TC_KEY_REQUEST_POLICY,
-            self.types.EzspDecisionId.GENERATE_NEW_TC_LINK_KEY,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.APP_KEY_REQUEST_POLICY,
-            self.types.EzspDecisionId.DENY_APP_KEY_REQUESTS,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
-        v = await self.setPolicy(
-            self.types.EzspPolicyId.TRUST_CENTER_POLICY,
-            v8_types.EzspDecisionBitmask.ALLOW_JOINS
-            | v8_types.EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY
-            | v8_types.EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
-        )
-        assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -2,9 +2,10 @@
 import logging
 from typing import Tuple
 
+import bellows.config
 import voluptuous
 
-from . import commands, config as v8_config, types as v8_types
+from . import commands, config, types as v8_types
 from .. import protocol
 
 EZSP_VERSION = 8
@@ -15,7 +16,7 @@ class EZSPv8(protocol.ProtocolHandler):
     """EZSP Version 8 Protocol version handler."""
 
     COMMANDS = commands.COMMANDS
-    SCHEMA = voluptuous.Schema(v8_config.EZSP_SCHEMA)
+    SCHEMAS = {bellows.config.CONF_EZSP_CONFIG: voluptuous.Schema(config.EZSP_SCHEMA)}
     types = v8_types
 
     def _ezsp_frame_tx(self, name: str) -> bytes:

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -19,7 +19,7 @@ COMMANDS = {
         ),
         (t.EzspStatus,),
     ),
-    "setPolicy": (0x0055, (t.EzspPolicyId, t.EzspDecisionId), (t.EzspStatus,)),
+    "setPolicy": (0x0055, (t.EzspPolicyId, t.uint16_t), (t.EzspStatus,)),
     "getPolicy": (0x0056, (t.EzspPolicyId,), (t.EzspStatus, t.EzspDecisionId)),
     "sendPanIdUpdate": (0x0057, (t.EmberPanId,), (t.Bool,)),
     "getValue": (0x00AA, (t.EzspValueId,), (t.EzspStatus, t.LVBytes)),

--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -256,12 +256,12 @@ EZSP_SCHEMA = {
 }
 
 EZSP_POLICIES_SCH = {
-    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
-    **EZSP_POLICIES_SHARED,
     vol.Optional(
         EzspPolicyId.TRUST_CENTER_POLICY.name,
         default=EzspDecisionBitmask.ALLOW_JOINS
         | EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY
         | EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
     ): cv_uint16,
+    **EZSP_POLICIES_SHARED,
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
 }

--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -1,7 +1,14 @@
+from bellows.config import cv_uint16
 import bellows.multicast
 import voluptuous as vol
 
-from .types import EmberZdoConfigurationFlags, EzspConfigId
+from ..v4.config import EZSP_POLICIES_SHARED
+from .types import (
+    EmberZdoConfigurationFlags,
+    EzspConfigId,
+    EzspDecisionBitmask,
+    EzspPolicyId,
+)
 
 EZSP_SCHEMA = {
     # The number of packet buffers available to the stack. When set to the special
@@ -246,4 +253,15 @@ EZSP_SCHEMA = {
     vol.Optional(
         EzspConfigId.CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S.name
     ): vol.All(int, vol.Range(min=0)),
+}
+
+EZSP_POLICIES_SCH = {
+    **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},
+    **EZSP_POLICIES_SHARED,
+    vol.Optional(
+        EzspPolicyId.TRUST_CENTER_POLICY.name,
+        default=EzspDecisionBitmask.ALLOW_JOINS
+        | EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY
+        | EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
+    ): cv_uint16,
 }


### PR DESCRIPTION
Allow configuration of the custom EZSP policies, e.g. 
```yaml
zha:
    zigpy_config:
        ezsp_policies:
            TRUST_CENTER_POLICY: 0
            TC_KEY_REQUEST_POLICY: 80
```
key -- is `EzspPolicyId`
value -- is `EzspDecisionId`
