### PR TITLE
Export/Import NCP Trust Center parameters

### DIFF
--- a/bellows/cli/__init__.py
+++ b/bellows/cli/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from . import application, dump, ncp, network
+from . import application, backup, dump, ncp, network

--- a/bellows/cli/backup.py
+++ b/bellows/cli/backup.py
@@ -1,0 +1,84 @@
+import json
+import logging
+
+import bellows.types as t
+import click
+
+from . import util
+from .main import main
+
+LOGGER = logging.getLogger(__name__)
+
+ATTR_CHANNEL = "channel"
+ATTR_EXT_PAN_ID = "extended_pan_id"
+ATTR_KEY = "key"
+ATTR_KEY_FRAME_COUNTER = "frame_counter"
+ATTR_KEY_GLOBAL = "tc_link_key"
+ATTR_KEY_NWK = "network_key"
+ATTR_KEY_SEQ = "sequence_number"
+ATTR_KEY_TYPE = "key_type"
+ATTR_NODE_EUI64 = "node_ieee"
+ATTR_NODE_ID = "node_id"
+ATTR_NODE_TYPE = "node_type"
+ATTR_PAN_ID = "pan_id"
+
+
+def _print_cb(frame_name, response):
+    LOGGER.debug("%s callback: %s", frame_name, response)
+
+
+@main.command()
+@click.pass_context
+@util.background
+async def backup(ctx):
+    """Backup NCP config to stdio."""
+    click.echo("Backing up NCP")
+    ezsp = await util.setup(ctx.obj["device"], ctx.obj["baudrate"], _print_cb)
+
+    try:
+        await _backup(ezsp)
+    finally:
+        ezsp.close()
+
+
+def _dump_key(key):
+    """Return a dict with key data."""
+    return {
+        ATTR_KEY_TYPE: key.type,
+        ATTR_KEY: key.key,
+        ATTR_KEY_FRAME_COUNTER: key.outgoingFrameCounter,
+        ATTR_KEY_SEQ: key.sequenceNumber,
+    }
+
+
+async def _backup(ezsp):
+    (status,) = await ezsp.networkInit()
+    LOGGER.debug("Network init status: %s", status)
+    assert status == t.EmberStatus.SUCCESS
+
+    (status, node_type, network) = await ezsp.getNetworkParameters()
+    assert status == t.EmberStatus.SUCCESS
+    assert node_type == ezsp.types.EmberNodeType.COORDINATOR
+    LOGGER.debug("Network params: %s", network)
+
+    (node_id,) = await ezsp.getNodeId()
+    (ieee,) = await ezsp.getEui64()
+
+    result = {
+        ATTR_NODE_TYPE: node_type.value,
+        ATTR_NODE_ID: node_id,
+        ATTR_NODE_EUI64: str(ieee),
+        ATTR_PAN_ID: network.panId,
+        ATTR_EXT_PAN_ID: str(network.extendedPanId),
+    }
+
+    for key_name, key_type in (
+        (ATTR_KEY_GLOBAL, ezsp.types.EmberKeyType.TRUST_CENTER_LINK_KEY),
+        (ATTR_KEY_NWK, ezsp.types.EmberKeyType.CURRENT_NETWORK_KEY),
+    ):
+        (status, key) = await ezsp.getKey(key_type)
+        assert status == t.EmberStatus.SUCCESS
+        LOGGER.debug("%s key: %s", key_name, key)
+        result[key_name] = _dump_key(key)
+
+    click.echo(json.dumps(result))

--- a/bellows/cli/backup.py
+++ b/bellows/cli/backup.py
@@ -12,8 +12,8 @@ from .main import main
 
 LOGGER = logging.getLogger(__name__)
 
-ATTR_CHANNEL = "channel"
-ATTR_EXT_PAN_ID = "extended_pan_id"
+ATTR_CHANNELS = "channels"
+ATTR_EXT_PAN_ID = "extendedPanId"
 ATTR_KEY = "key"
 ATTR_KEY_BITMASK = "bitmask"
 ATTR_KEY_FRAME_COUNTER_IN = "incomingFrameCounter"
@@ -27,7 +27,10 @@ ATTR_KEY_TYPE = "type"
 ATTR_NODE_EUI64 = "node_ieee"
 ATTR_NODE_ID = "node_id"
 ATTR_NODE_TYPE = "node_type"
-ATTR_PAN_ID = "pan_id"
+ATTR_NWK_UPDATE_ID = "nwkUpdateId"
+ATTR_PAN_ID = "panId"
+ATTR_RADIO_CHANNEL = "radioChannel"
+ATTR_RADIO_TX_PWR = "radioTxPower"
 
 SCHEMA_KEY = vol.Schema(
     {
@@ -42,10 +45,14 @@ SCHEMA_KEY = vol.Schema(
 )
 SCHEMA_BAK = vol.Schema(
     {
+        ATTR_CHANNELS: cv_hex,
         ATTR_NODE_TYPE: cv_hex,
         ATTR_NODE_ID: cv_hex,
         ATTR_NODE_EUI64: vol.All(str, t.EmberEUI64.convert),
+        ATTR_NWK_UPDATE_ID: cv_hex,
         ATTR_PAN_ID: cv_hex,
+        ATTR_RADIO_CHANNEL: cv_hex,
+        ATTR_RADIO_TX_PWR: cv_hex,
         ATTR_EXT_PAN_ID: vol.All(str, t.ExtendedPanId.convert),
         ATTR_KEY_GLOBAL: SCHEMA_KEY,
         ATTR_KEY_NWK: SCHEMA_KEY,
@@ -90,6 +97,10 @@ async def _backup(ezsp):
         ATTR_NODE_EUI64: str(ieee),
         ATTR_PAN_ID: network.panId,
         ATTR_EXT_PAN_ID: str(network.extendedPanId),
+        ATTR_RADIO_CHANNEL: network.radioChannel,
+        ATTR_RADIO_TX_PWR: network.radioTxPower,
+        ATTR_NWK_UPDATE_ID: network.nwkUpdateId,
+        ATTR_CHANNELS: network.channels,
     }
 
     for key_name, key_type in (

--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -126,7 +126,7 @@ async def setup(dev, baudrate, cbh=None, configure=True):
         await cfg(c.CONFIG_STACK_PROFILE, 2)
         await cfg(c.CONFIG_SECURITY_LEVEL, 5)
         await cfg(c.CONFIG_SUPPORTED_NETWORKS, 1)
-        await cfg(c.CONFIG_PACKET_BUFFER_COUNT, 0xFF)
+        await cfg(c.CONFIG_PACKET_BUFFER_COUNT, 64)
 
     return s
 


### PR DESCRIPTION
Theoretically this allows backing up and restoring NCP state between the hardware version. 
Please note this is highly experimental. The restoration doesn't restore NCP children and relies on children just to find a new parent. 
Another warning: if this is done between different hardwares, the EUI64 is going to be different on the new hardware meaning the binding tables on all the devices are going to be wrong. 
You either have to reconfigure all the devices -- recommended so the bindings are updated or alternatively you could override the EUI64 on the new hardware, essentially producing a clone. **Be very careful** if you decide to go this route. You can change the EUI64 only once and once you set it it is impossible to change it without a specialized hardware (SWD programmer).

To export TC config, see `bellows backup --help` usually it is just `bellows backup > your-backup-file.txt`. The backup contains your network key, so you probably should keep that file secure.
To import, see `bellows restore --backup-file your-backup-file.txt`
