### PR TITLE
Add an enum member to represent a missing key

### DIFF
--- a/bellows/ezsp/v4/types/named.py
+++ b/bellows/ezsp/v4/types/named.py
@@ -477,6 +477,8 @@ class EzspDecisionId(basic.uint8_t, enum.Enum):
 class EmberKeyType(basic.uint8_t, enum.Enum):
     # Describes the type of ZigBee security key.
 
+    # an enum member to represent a missing key
+    NO_KEY = 0x00
     # A shared key between the Trust Center and a device.
     TRUST_CENTER_LINK_KEY = 0x01
     # A shared secret used for deriving keys between the Trust Center and a

--- a/bellows/ezsp/v5/types/named.py
+++ b/bellows/ezsp/v5/types/named.py
@@ -478,6 +478,8 @@ class EzspDecisionId(basic.uint8_t, enum.Enum):
 class EmberKeyType(basic.uint8_t, enum.Enum):
     # Describes the type of ZigBee security key.
 
+    # an enum member to represent a missing key
+    NO_KEY = 0x00
     # A shared key between the Trust Center and a device.
     TRUST_CENTER_LINK_KEY = 0x01
     # A shared secret used for deriving keys between the Trust Center and a

--- a/bellows/ezsp/v6/types/named.py
+++ b/bellows/ezsp/v6/types/named.py
@@ -419,6 +419,8 @@ class EzspDecisionId(basic.uint8_t, enum.Enum):
 class EmberKeyType(basic.uint8_t, enum.Enum):
     # Describes the type of ZigBee security key.
 
+    # an enum member to represent a missing key
+    NO_KEY = 0x00
     # A shared key between the Trust Center and a device.
     TRUST_CENTER_LINK_KEY = 0x01
     # A shared secret used for deriving keys between the Trust Center and a

--- a/bellows/ezsp/v7/types/named.py
+++ b/bellows/ezsp/v7/types/named.py
@@ -447,6 +447,8 @@ class EzspDecisionId(basic.uint8_t, enum.Enum):
 class EmberKeyType(basic.uint8_t, enum.Enum):
     # Describes the type of ZigBee security key.
 
+    # an enum member to represent a missing key
+    NO_KEY = 0x00
     # A shared key between the Trust Center and a device.
     TRUST_CENTER_LINK_KEY = 0x01
     # A shared secret used for deriving keys between the Trust Center and a

--- a/bellows/ezsp/v8/types/named.py
+++ b/bellows/ezsp/v8/types/named.py
@@ -452,6 +452,8 @@ class EzspDecisionId(basic.uint8_t, enum.Enum):
 class EmberKeyType(basic.uint8_t, enum.Enum):
     # Describes the type of ZigBee security key.
 
+    # an enum member to represent a missing key
+    NO_KEY = 0x00
     # A shared key between the Trust Center and a device.
     TRUST_CENTER_LINK_KEY = 0x01
     # A shared secret used for deriving keys between the Trust Center and a


### PR DESCRIPTION
For erased or missing key, EZSP returns `EmberKeyType` of `0x00`. Add a type for it, so it doesn't throw a deserialization error.