### PR TITLE
Return an awaitable if route is not known

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -3,7 +3,7 @@
 import asyncio
 import functools
 import logging
-from typing import Any, Callable, Coroutine, Dict, Tuple
+from typing import Any, Awaitable, Callable, Coroutine, Dict, Tuple
 
 from bellows.config import CONF_DEVICE, CONF_DEVICE_PATH, SCHEMA_DEVICE
 from bellows.exception import APIException, EzspError
@@ -234,8 +234,13 @@ class EZSP:
             except Exception as e:
                 LOGGER.exception("Exception running handler", exc_info=e)
 
-    def set_source_route(self, device: DeviceType) -> t.EmberStatus:
-        return self._protocol.set_source_route(device)
+    def set_source_route(self, device: DeviceType) -> Awaitable:
+        if device.relays is not None:
+            return self.setSourceRoute(device.nwk, device.relays)
+
+        status = asyncio.Future()
+        status.set_result(t.EmberStatus.ERR_FATAL)
+        return status
 
     def update_policies(self, zigpy_config: dict) -> Coroutine:
         """Set up the policies for what the NCP should do."""

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -6,9 +6,7 @@ import logging
 from typing import Any, Callable, Dict, Tuple
 
 from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES, CONF_PARAM_SRC_RTG
-import bellows.types as t
 from bellows.typing import GatewayType
-from zigpy.typing import DeviceType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -79,10 +77,6 @@ class ProtocolHandler(abc.ABC):
         self._awaiting[self._seq] = (c[0], c[2], future)
         self._seq = (self._seq + 1) % 256
         return asyncio.wait_for(future, timeout=EZSP_CMD_TIMEOUT)
-
-    @abc.abstractmethod
-    def set_source_route(self, device: DeviceType) -> t.EmberStatus:
-        """Set source route to the device if known."""
 
     @abc.abstractmethod
     async def set_source_routing(self) -> None:

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -4,7 +4,6 @@ from typing import Tuple
 
 import bellows.config
 import voluptuous
-from zigpy.typing import DeviceType
 
 from . import commands, config, types as v4_types
 from .. import protocol
@@ -33,13 +32,6 @@ class EZSPv4(protocol.ProtocolHandler):
     def _ezsp_frame_rx(self, data: bytes) -> Tuple[int, int, bytes]:
         """Handler for received data frame."""
         return data[0], data[2], data[3:]
-
-    def set_source_route(self, device: DeviceType) -> v4_types.EmberStatus:
-        """Set source route to the device if known."""
-        if device.relays is None:
-            return v4_types.EmberStatus.ERR_FATAL
-
-        return self.setSourceRoute(device.nwk, device.relays)
 
     async def set_source_routing(self) -> None:
         """Enable source routing on NCP."""

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -4,7 +4,6 @@ from typing import Tuple
 
 import bellows.config
 import voluptuous
-from zigpy.typing import DeviceType
 
 from . import commands, config, types as v8_types
 from .. import protocol
@@ -35,10 +34,6 @@ class EZSPv8(protocol.ProtocolHandler):
         frame_id, data = self.types.uint16_t.deserialize(data)
 
         return seq, frame_id, data
-
-    async def set_source_route(self, device: DeviceType) -> v8_types.EmberStatus:
-        """Set source route to the device if known."""
-        return v8_types.EmberStatus.SUCCESS
 
     async def set_source_routing(self) -> None:
         """Enable source routing on NCP."""

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -455,7 +455,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             )
                             await self._ezsp.setExtendedTimeout(device.ieee, True)
                         if self.use_source_routing and self._ezsp.ezsp_version < 8:
-                            res = await self._ezsp.set_source_route(device)
+                            (res,) = await self._ezsp.set_source_route(device)
                             if res == t.EmberStatus.SUCCESS:
                                 aps_frame.options ^= (
                                     t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -26,7 +26,9 @@ APP_CONFIG = {
 def app(monkeypatch):
     ezsp = mock.MagicMock()
     ezsp.ezsp_version = 7
-    ezsp.set_source_route = asynctest.CoroutineMock(return_value=t.EmberStatus.SUCCESS)
+    ezsp.set_source_route = asynctest.CoroutineMock(
+        return_value=[t.EmberStatus.SUCCESS]
+    )
     type(ezsp).is_ezsp_running = mock.PropertyMock(return_value=True)
     config = bellows.zigbee.application.ControllerApplication.SCHEMA(APP_CONFIG)
     ctrl = bellows.zigbee.application.ControllerApplication(config)
@@ -441,8 +443,8 @@ async def test_request_src_rtg_not_enabled(relays, app):
     app.use_source_routing = False
     res = await _request(app, relays=relays)
     assert res[0] == 0
-    assert app._ezsp.setSourceRoute.call_count == 0
-    assert app._ezsp.sendUnicast.call_count == 1
+    assert app._ezsp.set_source_route.await_count == 0
+    assert app._ezsp.sendUnicast.await_count == 1
     assert (
         app._ezsp.sendUnicast.call_args[0][2].options
         & t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
@@ -455,8 +457,8 @@ async def test_request_src_rtg_success(relays, app):
     app.use_source_routing = True
     res = await _request(app, relays=relays)
     assert res[0] == 0
-    assert app._ezsp.set_source_route.call_count == 1
-    assert app._ezsp.sendUnicast.call_count == 1
+    assert app._ezsp.set_source_route.await_count == 1
+    assert app._ezsp.sendUnicast.await_count == 1
     assert (
         not app._ezsp.sendUnicast.call_args[0][2].options
         & t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
@@ -467,11 +469,11 @@ async def test_request_src_rtg_success(relays, app):
 @pytest.mark.asyncio
 async def test_request_src_rtg_fail(relays, app):
     app.use_source_routing = True
-    app._ezsp.set_source_route.return_value = 1
+    app._ezsp.set_source_route.return_value = [1]
     res = await _request(app, relays=relays)
     assert res[0] == 0
-    assert app._ezsp.set_source_route.call_count == 1
-    assert app._ezsp.sendUnicast.call_count == 1
+    assert app._ezsp.set_source_route.await_count == 1
+    assert app._ezsp.sendUnicast.await_count == 1
     assert (
         app._ezsp.sendUnicast.call_args[0][2].options
         & t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY


### PR DESCRIPTION
Fix source routing for V7 and earlier protocols. If the route is not known, then return an awaitable.