### PR TITLE
Change the default TC policy for EZSPv8 to allow unsecure rejoins

### DIFF
--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -260,7 +260,7 @@ EZSP_POLICIES_SCH = {
         EzspPolicyId.TRUST_CENTER_POLICY.name,
         default=EzspDecisionBitmask.ALLOW_JOINS
         | EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY
-        | EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
+        | EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
     ): cv_uint16,
     **EZSP_POLICIES_SHARED,
     **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},


### PR DESCRIPTION
Change the default TC policy for EZSPv8 to allow unsecure rejoins. 