### PR TITLE
Set network update id after network was formed from backup.

### DIFF
--- a/bellows/cli/backup.py
+++ b/bellows/cli/backup.py
@@ -6,6 +6,8 @@ import bellows.types as t
 import click
 import voluptuous as vol
 from zigpy.config.validators import cv_hex, cv_key
+import zigpy.types
+import zigpy.zdo.types
 
 from . import util
 from .main import main
@@ -184,6 +186,14 @@ async def restore(
     finally:
         ezsp.close()
 
+    ezsp = await util.setup(ctx.obj["device"], ctx.obj["baudrate"], _print_cb)
+    try:
+        await _update_nwk_id(
+            ezsp, backup_data[ATTR_NWK_UPDATE_ID],
+        )
+    finally:
+        ezsp.close()
+
 
 async def _restore(ezsp, backup_data, force, update_eui64_token=False):
     """Restore backup."""
@@ -263,6 +273,7 @@ async def _restore(ezsp, backup_data, force, update_eui64_token=False):
     assert status == t.EmberStatus.SUCCESS
 
     await _form_network(ezsp, backup_data)
+    await asyncio.sleep(2)
 
 
 async def _restore_keys(ezsp, key_table):
@@ -305,3 +316,46 @@ async def _form_network(ezsp, backup_data):
     (status,) = await ezsp.setValue(ezsp.types.EzspValueId.VALUE_STACK_TOKEN_WRITING, 1)
     LOGGER.debug("Set token writing: %s", status)
     assert status == t.EmberStatus.SUCCESS
+
+
+async def _update_nwk_id(ezsp, nwk_update_id):
+    """Update NWK id by sending a ZDO broadcast."""
+
+    stack_up = asyncio.Future()
+    stack_dwn = asyncio.Future()
+
+    def _stack_handler(frame, args):
+        if frame != "stackStatusHandler":
+            return
+        if args[0] == t.EmberStatus.NETWORK_UP:
+            stack_up.set_result(True)
+        else:
+            stack_dwn.set_result(True)
+
+    cb_id = ezsp.add_callback(_stack_handler)
+
+    (status,) = await ezsp.networkInit()
+    LOGGER.debug("Network init status: %s", status)
+    assert status == t.EmberStatus.SUCCESS
+
+    await asyncio.wait_for(stack_up, timeout=5)
+    ezsp.remove_callback(cb_id)
+
+    aps_frame = t.EmberApsFrame(
+        profileId=0x0000,
+        clusterId=zigpy.zdo.types.ZDOCmd.Mgmt_NWK_Update_req,
+        sourceEndpoint=0x00,
+        destinationEndpoint=0x00,
+        options=t.EmberApsOption.APS_OPTION_NONE,
+        groupId=0x0000,
+        sequence=0xDE,
+    )
+    nwk_update_id = t.uint8_t(nwk_update_id).serialize()
+    payload = b"\xDE" + zigpy.types.Channels.ALL_CHANNELS.serialize() + b"\xFF"
+    payload += nwk_update_id + b"\x00\x00"
+
+    status, _ = await ezsp.sendBroadcast(
+        zigpy.types.BroadcastAddress.ALL_DEVICES, aps_frame, 0x00, 0x01, payload,
+    )
+    assert status == t.EmberStatus.SUCCESS
+    await asyncio.sleep(3)


### PR DESCRIPTION
Restore network update id. This is more of a hack, because EZSP doesn't expose commands to set NWK Update ID during formation.
