### PR TITLE
Handle discover of unkwnown devices

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -11,6 +11,7 @@ CONF_DEVICE_BAUDRATE = "baudrate"
 CONF_EZSP_CONFIG = "ezsp_config"
 CONF_EZSP_POLICIES = "ezsp_policies"
 CONF_PARAM_SRC_RTG = "source_routing"
+CONF_PARAM_UNK_DEV = "handle_unknown_devices"
 
 SCHEMA_DEVICE = SCHEMA_DEVICE.extend(
     {vol.Optional(CONF_DEVICE_BAUDRATE, default=57600): int}
@@ -20,6 +21,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
         vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
         vol.Optional(CONF_PARAM_SRC_RTG, default=False): cv_boolean,
+        vol.Optional(CONF_PARAM_UNK_DEV, default=False): cv_boolean,
         vol.Optional(CONF_EZSP_CONFIG, default={}): dict,
         vol.Optional(CONF_EZSP_POLICIES, default={}): vol.Schema(
             {vol.Optional(str): int}

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -267,7 +267,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         except KeyError:
             LOGGER.debug("No such device %s", sender)
             if self.config[CONF_PARAM_UNK_DEV]:
-                asyncio.create_task(self._handle_no_such_device(sender))
+                asyncio.ensure_future(self._handle_no_such_device(sender))
             return
 
         device.radio_details(lqi, rssi)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -3,7 +3,12 @@ import logging
 import os
 from typing import Dict
 
-from bellows.config import CONF_PARAM_SRC_RTG, CONFIG_SCHEMA, SCHEMA_DEVICE
+from bellows.config import (
+    CONF_PARAM_SRC_RTG,
+    CONF_PARAM_UNK_DEV,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)
 from bellows.exception import ControllerError, EzspError
 import bellows.ezsp
 import bellows.multicast
@@ -261,6 +266,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             device = self.get_device(nwk=sender)
         except KeyError:
             LOGGER.debug("No such device %s", sender)
+            if self.config[CONF_PARAM_UNK_DEV]:
+                asyncio.create_task(self._handle_no_such_device(sender))
             return
 
         device.radio_details(lqi, rssi)
@@ -312,6 +319,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 message_tag,
                 exc,
             )
+
+    async def _handle_no_such_device(self, sender: int) -> None:
+        """Try to match unknown device by its EUI64 address."""
+        status, ieee = await self._ezsp.lookupEui64ByNodeId(sender)
+        if status == t.EmberStatus.SUCCESS:
+            LOGGER.debug("Found %s ieee for %s sender", ieee, sender)
+            self.handle_join(sender, ieee, 0)
+            return
+        LOGGER.debug("Couldn't look up ieee for %s", sender)
 
     def _handle_reset_request(self, error):
         """Reinitialize application controller."""


### PR DESCRIPTION
If we receive a frame from an unknown device, it means device is on the network, but not in `zigbee.db` and we have no knowledge of that device. In such case, try to lookup IEEE of that sender by NWK and if successful, try discovery of the device.

by default this is disabled, as it not gonna work well for sleepy Xiaomi devices, unless you keep them awake. To enable, add parameter `handle_unknown_devices` with value `yes` to zigpy configuration dict.
in case of Home assistant, add to `configuration.yaml`
```yaml
zha:
  zigpy_config:
    handle_unknown_devices: yes
```
