### PR TITLE
Change default Trust Center policy for ezsp v8.

### DIFF
--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -259,8 +259,7 @@ EZSP_POLICIES_SCH = {
     vol.Optional(
         EzspPolicyId.TRUST_CENTER_POLICY.name,
         default=EzspDecisionBitmask.ALLOW_JOINS
-        | EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY
-        | EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
+        | EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
     ): cv_uint16,
     **EZSP_POLICIES_SHARED,
     **{vol.Optional(policy.name): cv_uint16 for policy in EzspPolicyId},


### PR DESCRIPTION
Remove `EzspDecisionBitmask.JOINS_USE_INSTALL_CODE_KEY` as it prevents HA1.2 devices joining with a shared link key. 
Disallow unsecure rejoins by default.