### PR TITLE
Allow unsecure rejoins for the duration of  Mgmt_Permit_Joining_req

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -242,6 +242,10 @@ class EZSP:
         status.set_result((t.EmberStatus.ERR_FATAL,))
         return status
 
+    def pre_permit(self, time_s: int) -> Coroutine:
+        """Pass through to protocol handler."""
+        return self._protocol.pre_permit(time_s)
+
     def update_policies(self, zigpy_config: dict) -> Coroutine:
         """Set up the policies for what the NCP should do."""
         return self._protocol.update_policies(zigpy_config)

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -49,6 +49,9 @@ class ProtocolHandler(abc.ABC):
     def _ezsp_frame_tx(self, name: str) -> bytes:
         """Serialize the named frame."""
 
+    async def pre_permit(self, time_s: int) -> None:
+        """Schedule task before allowing new joins."""
+
     async def initialize(self, zigpy_config: Dict) -> None:
         """Initialize EmberZNet Stack."""
 

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -28,6 +28,7 @@ class ProtocolHandler(abc.ABC):
             cmd_id: (name, tx_schema, rx_schema)
             for name, (cmd_id, tx_schema, rx_schema) in self.COMMANDS.items()
         }
+        self.tc_policy = 0
 
     async def _cfg(self, config_id: int, value: Any, optional=False) -> None:
         v = await self.setConfigurationValue(config_id, value)
@@ -89,6 +90,8 @@ class ProtocolHandler(abc.ABC):
         """Set up the policies for what the NCP should do."""
 
         policies = self.SCHEMAS[CONF_EZSP_POLICIES](zigpy_config[CONF_EZSP_POLICIES])
+        self.tc_policy = policies[self.types.EzspPolicyId.TRUST_CENTER_POLICY.name]
+
         for policy, value in policies.items():
             (status,) = await self.setPolicy(self.types.EzspPolicyId[policy], value)
             assert status == self.types.EmberStatus.SUCCESS  # TODO: Better check

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -1,4 +1,5 @@
 """"EZSP Protocol version 8 protocol handler."""
+import asyncio
 import logging
 from typing import Tuple
 
@@ -34,6 +35,19 @@ class EZSPv8(protocol.ProtocolHandler):
         frame_id, data = self.types.uint16_t.deserialize(data)
 
         return seq, frame_id, data
+
+    async def pre_permit(self, time_s: int) -> None:
+        """Schedule task before allowing new joins."""
+        await self.setPolicy(
+            v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
+            v8_types.EzspDecisionBitmask.ALLOW_JOINS
+            | v8_types.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
+        )
+        await asyncio.sleep(time_s + 2)
+        await self.setPolicy(
+            v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
+            v8_types.EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
+        )
 
     async def set_source_routing(self) -> None:
         """Enable source routing on NCP."""

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -45,8 +45,7 @@ class EZSPv8(protocol.ProtocolHandler):
         )
         await asyncio.sleep(time_s + 2)
         await self.setPolicy(
-            v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
-            v8_types.EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS,
+            v8_types.EzspPolicyId.TRUST_CENTER_POLICY, self.tc_policy,
         )
 
     async def set_source_routing(self) -> None:

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -535,6 +535,20 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 res = await asyncio.wait_for(req.result, APS_ACK_TIMEOUT)
         return res
 
+    def permit(self, time_s: int = 60, node: t.EmberNodeId = None):
+        """Permit joining."""
+        asyncio.create_task(
+            self._ezsp.setPolicy(self._ezsp.types.EzspPolicyId.TRUST_CENTER_POLICY, 3)
+        )
+        loop = asyncio.get_running_loop()
+        loop.call_later(
+            time_s + 2,
+            self._ezsp.setPolicy,
+            self._ezsp.types.EzspPolicyId.TRUST_CENTER_POLICY,
+            9,
+        )
+        return super().permit(time_s, node)
+
     def permit_ncp(self, time_s=60):
         assert 0 <= time_s <= 254
         return self._ezsp.permitJoining(time_s)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -537,16 +537,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     def permit(self, time_s: int = 60, node: t.EmberNodeId = None):
         """Permit joining."""
-        asyncio.create_task(
-            self._ezsp.setPolicy(self._ezsp.types.EzspPolicyId.TRUST_CENTER_POLICY, 3)
-        )
-        loop = asyncio.get_running_loop()
-        loop.call_later(
-            time_s + 2,
-            self._ezsp.setPolicy,
-            self._ezsp.types.EzspPolicyId.TRUST_CENTER_POLICY,
-            9,
-        )
+        asyncio.create_task(self._ezsp.pre_permit(time_s))
         return super().permit(time_s, node)
 
     def permit_ncp(self, time_s=60):


### PR DESCRIPTION
The configured TRUST_CENTER_POLICY becomes the default policy applied when no joins are allowed. During the period of allowing new joins, TC policy is modified with: `EzspDecisionBitmask.ALLOW_JOINS | EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS`

After joining period is expired, the configured TC policy is restored. By default it is `EzspDecisionBitmask.ALLOW_JOINS | EzspDecisionBitmask.IGNORE_UNSECURED_REJOINS`