### PR TITLE
Use Hashed TC link key

### DIFF
--- a/bellows/cli/backup.py
+++ b/bellows/cli/backup.py
@@ -250,7 +250,9 @@ async def _restore(
         preconfiguredTrustCenterEui64=[0x00] * 8,
     )
     if upg_tc_link_key:
-        sec_bitmask |= t.EmberInitialSecurityBitmask.TRUST_CENTER_USES_HASHED_LINK_KEY
+        init_sec_state.bitmask |= (
+            t.EmberInitialSecurityBitmask.TRUST_CENTER_USES_HASHED_LINK_KEY
+        )
         init_sec_state.preconfiguredKey = t.EmberKeyData(os.urandom(16))
 
     (status,) = await ezsp.setInitialSecurityState(init_sec_state)

--- a/bellows/ezsp/v4/config.py
+++ b/bellows/ezsp/v4/config.py
@@ -271,7 +271,7 @@ EZSP_SCHEMA = {
 EZSP_POLICIES_SHARED = {
     vol.Optional(
         types.EzspPolicyId.TC_KEY_REQUEST_POLICY.name,
-        default=types.EzspDecisionId.GENERATE_NEW_TC_LINK_KEY,
+        default=types.EzspDecisionId.ALLOW_TC_KEY_REQUESTS,
     ): cv_uint16,
     vol.Optional(
         types.EzspPolicyId.APP_KEY_REQUEST_POLICY.name,

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -535,10 +535,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 res = await asyncio.wait_for(req.result, APS_ACK_TIMEOUT)
         return res
 
-    def permit(self, time_s: int = 60, node: t.EmberNodeId = None):
+    async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""
+        wild_card_ieee = t.EmberEUI64([0xFF] * 8)
+        tc_link_key = t.EmberKeyData(b"ZigBeeAlliance09")
+        await self._ezsp.addTransientLinkKey(wild_card_ieee, tc_link_key)
         asyncio.create_task(self._ezsp.pre_permit(time_s))
-        return super().permit(time_s, node)
+        await super().permit(time_s, node)
 
     def permit_ncp(self, time_s=60):
         assert 0 <= time_s <= 254

--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -26,7 +26,8 @@ def zha_security(config: Dict[str, Any], controller: bool = False) -> None:
     if controller:
         isc.bitmask |= (
             t.EmberInitialSecurityBitmask.TRUST_CENTER_GLOBAL_LINK_KEY
+            | t.EmberInitialSecurityBitmask.TRUST_CENTER_USES_HASHED_LINK_KEY
             | t.EmberInitialSecurityBitmask.HAVE_NETWORK_KEY
         )
-        isc.bitmask = t.uint16_t(isc.bitmask)
+        isc.preconfiguredKey = t.EmberKeyData(os.urandom(16))
     return isc


### PR DESCRIPTION
Implement https://www.silabs.com/community/wireless/zigbee-and-thread/knowledge-base.entry.html/2018/06/18/hashed_link_keys-Ltmt

As side effect add well known TC global link key as "transient key" to allow interoperability with HA12 devices.