### PR TITLE
Remove async_generator dependency

### DIFF
--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -3,7 +3,6 @@ import sys
 import threading
 from unittest import mock
 
-from async_generator import async_generator, yield_
 from bellows.thread import EventLoopThread, ThreadsafeProxy
 import pytest
 
@@ -40,14 +39,13 @@ class ExceptionCollector:
 
 
 @pytest.fixture
-@async_generator  # Remove when Python 3.5 is no longer supported
 async def thread():
     thread = EventLoopThread()
     await thread.start()
     thread.loop.call_soon_threadsafe(
         thread.loop.set_exception_handler, ExceptionCollector()
     )
-    await yield_(thread)
+    yield thread
     thread.force_stop()
     if thread.thread_complete is not None:
         await asyncio.wait_for(thread.thread_complete, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ install_command = pip install {opts} {packages}
 commands = py.test --cov --cov-report=
 deps =
     asynctest
-    async_generator
     coveralls
     pytest
     pytest-cov


### PR DESCRIPTION
Since we're not supporting Py35 or Py36 we can drop async_generator requirement.