### PR TITLE
Don't error out if setting a configuration value fails

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -30,10 +30,12 @@ class ProtocolHandler(abc.ABC):
         }
         self.tc_policy = 0
 
-    async def _cfg(self, config_id: int, value: Any, optional=False) -> None:
-        v = await self.setConfigurationValue(config_id, value)
-        if not optional:
-            assert v[0] == self.types.EmberStatus.SUCCESS  # TODO: Better check
+    async def _cfg(self, config_id: int, value: Any) -> None:
+        (status,) = await self.setConfigurationValue(config_id, value)
+        if status != self.types.EmberStatus.SUCCESS:
+            LOGGER.warning(
+                "Couldn't set %s=%s configuration value: %s", config_id, value, status
+            )
 
     def _ezsp_frame(self, name: str, *args: Tuple[Any, ...]) -> bytes:
         """Serialize the named frame and data."""

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 from asynctest import CoroutineMock, mock
 import bellows.ezsp.v4
@@ -58,7 +59,7 @@ def test_receive_reply_after_timeout(prot_hndl):
 
 
 @pytest.mark.asyncio
-async def test_cfg_initialize(prot_hndl):
+async def test_cfg_initialize(prot_hndl, caplog):
     """Test initialization."""
 
     p1 = mock.patch.object(prot_hndl, "setConfigurationValue", new=CoroutineMock())
@@ -69,8 +70,9 @@ async def test_cfg_initialize(prot_hndl):
         assert src_mock.call_count == 1
 
         cfg_mock.return_value = (t.EzspStatus.ERROR_OUT_OF_MEMORY,)
-        with pytest.raises(AssertionError):
+        with caplog.at_level(logging.WARNING):
             await prot_hndl.initialize({"ezsp_config": {}, "source_routing": False})
+            assert "Couldn't set" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
With new EZSP firmware appearing every day, it is unpractical for all firmwares to have the same default values, so instead `bellows` relies on firmware vendor to have sensible defaults and setting the configuration value is a preference, not a requirement. 