### PR TITLE
Change defaults for CONFIG_KEY_TABLE_SIZE

### DIFF
--- a/bellows/ezsp/v7/config.py
+++ b/bellows/ezsp/v7/config.py
@@ -135,7 +135,7 @@ EZSP_SCHEMA = {
     #
     # The size of the Key Table used for storing individual link keys (if the device
     # is a Trust Center) or Application Link Keys (if the device is a normal node)
-    vol.Optional(EzspConfigId.CONFIG_KEY_TABLE_SIZE.name, default=4): vol.All(
+    vol.Optional(EzspConfigId.CONFIG_KEY_TABLE_SIZE.name, default=12): vol.All(
         int, vol.Range(min=0)
     ),
     #

--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -140,7 +140,7 @@ EZSP_SCHEMA = {
     #
     # The size of the Key Table used for storing individual link keys (if the device
     # is a Trust Center) or Application Link Keys (if the device is a normal node)
-    vol.Optional(EzspConfigId.CONFIG_KEY_TABLE_SIZE.name, default=4): vol.All(
+    vol.Optional(EzspConfigId.CONFIG_KEY_TABLE_SIZE.name): vol.All(
         int, vol.Range(min=0)
     ),
     #


### PR DESCRIPTION
For EZSP v7 set the `CONFIG_KEY_TABLE_SIZE=12`, since EmberZNet 6.4.1 (EZSP v7) still had the default at 0. But later EmberZNet version have the default at 12, so don't set it explicitly in EZSP v8 and let firmware makers to configure the default.