### PR TITLE
Update README.md with EmberZNet and EZSP Protocol Version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Silicon Labs do not currently have a consolidated list of changes by EmberZNet S
 
 The largest change was between EZSP v4 (first added in EmberZNet 4.7.2 SDK) and EZSP v5 that was added in EmberZNet 5.9.0 SDK which requires the Legacy Frame ID 0xFF. The change from EZSP v5 to EZSP v6 was done in EmberZNet 6.0.0 SDK. The change from EZSP v6 to EZSP v7 was in EmberZNet 6.4.0 SDK. EmberZNet 6.7.0 SDK added EZSP v8 (and Secure EZSP Protocol Version 2).
 
-Perhaps more important to know today is that EmberZNet 6.6.4.x is backwards compatible with EZSP v5 and v6, but EmberZNet 6.7.0.x and later is not.
+Perhaps more important to know today is that  EZSP v5, v6 and v7 (EmberZNet 6.6.x.x) use the same framing format, but EmberZNet 6.7.x.x/EZSP v8 introduced new framing format and expanded command id field from 8 bits to 16 bits.
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Silabs did use to provide two main NCP images pre-build with firmware for EM35x,
 
 Silicon Labs no longer provide pre-build firmware images, so now you have to build and compile firmware with their Simplicity Studio SDK for EmberZNet PRO Zigbee Protocol Stack Software. Simplicity Studio is a free download but building and compiling EmberZNet PRO Zigbee firmware images required that you have the serialnumber of an official Zigbee devkit registered to your Silicon Labs user account.
 
+### EmberZNet and EZSP Protocol Version
+
+Silicon Labs do not currently have a consolidated list of changes by EmberZNet SDK or EZSP protocol version. The EZSP additions, changes and deletions have only ever been listed in the "Zigbee EmberZNet Release Notes" (EmberZNet SDK) under the "New items" section as well as the matching UG100 EZSP Reference Guide included with each EmberZNet SDK release.
+
+The largest change was between EZSP v4 (first added in EmberZNet 4.7.2 SDK) and EZSP v5 that was added in EmberZNet 5.9.0 SDK which requires the Legacy Frame ID 0xFF. The change from EZSP v5 to EZSP v6 was done in EmberZNet 6.0.0 SDK. The change from EZSP v6 to EZSP v7 was in EmberZNet 6.4.0 SDK. EmberZNet 6.7.0 SDK added EZSP v8 (and Secure EZSP Protocol Version 2).
+
+Perhaps more important to know today is that EmberZNet 6.6.4.x is backwards compatible with EZSP v5 and v6, but EmberZNet 6.7.0.x and later is not.
+
 ## Project status
 
 This project is in early stages, so it is likely that APIs will change.


### PR DESCRIPTION
Update bellows radio library for zigpy README.md with EmberZNet and EZSP Protocol Version information.

@mtx512 @grobasoz @NilsBohr @walthowd @MattWestb Does anyone of you have the expertise to confirm if all this is right?

### EmberZNet and EZSP Protocol Version

Silicon Labs do not currently have a consolidated list of changes by EmberZNet SDK or EZSP protocol version. The EZSP additions, changes and deletions have only ever been listed in the "Zigbee EmberZNet Release Notes" (EmberZNet SDK) under the "New items" section as well as the matching UG100 EZSP Reference Guide included with each EmberZNet SDK release.

The largest change was between EZSP v4 (first added in EmberZNet 4.7.2 SDK) and EZSP v5 that was added in EmberZNet 5.9.0 SDK which requires the Legacy Frame ID 0xFF. The change from EZSP v5 to EZSP v6 was done in EmberZNet 6.0.0 SDK. The change from EZSP v6 to EZSP v7 was in EmberZNet 6.4.0 SDK. EmberZNet 6.7.0 SDK added EZSP v8 (and Secure EZSP Protocol Version 2).

Perhaps more important to know today is that EmberZNet 6.6.4.x is backwards compatible with EZSP v5 and v6, but EmberZNet 6.7.0.x and later is not.