### PR TITLE
Add Global TC link key as a transient link key only for EZSP v5 or later

### DIFF
--- a/bellows/ezsp/v5/__init__.py
+++ b/bellows/ezsp/v5/__init__.py
@@ -31,3 +31,9 @@ class EZSPv5(EZSPv4):
     def _ezsp_frame_rx(self, data: bytes) -> Tuple[int, int, bytes]:
         """Handler for received data frame."""
         return data[0], data[4], data[5:]
+
+    async def pre_permit(self, time_s: int) -> None:
+        """Add pre-shared TC Link key."""
+        wild_card_ieee = v5_types.EmberEUI64([0xFF] * 8)
+        tc_link_key = v5_types.EmberKeyData(b"ZigBeeAlliance09")
+        await self.addTransientLinkKey(wild_card_ieee, tc_link_key)

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -38,6 +38,9 @@ class EZSPv8(protocol.ProtocolHandler):
 
     async def pre_permit(self, time_s: int) -> None:
         """Temporarily change TC policy while allowing new joins."""
+        wild_card_ieee = v8_types.EmberEUI64([0xFF] * 8)
+        tc_link_key = v8_types.EmberKeyData(b"ZigBeeAlliance09")
+        await self.addTransientLinkKey(wild_card_ieee, tc_link_key)
         await self.setPolicy(
             v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
             v8_types.EzspDecisionBitmask.ALLOW_JOINS

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -518,9 +518,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""
-        wild_card_ieee = t.EmberEUI64([0xFF] * 8)
-        tc_link_key = t.EmberKeyData(b"ZigBeeAlliance09")
-        await self._ezsp.addTransientLinkKey(wild_card_ieee, tc_link_key)
         asyncio.create_task(self._ezsp.pre_permit(time_s))
         await super().permit(time_s, node)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1210,11 +1210,11 @@ async def test_cleanup_tc_link_key(app):
 @pytest.mark.asyncio
 @mock.patch("zigpy.application.ControllerApplication.permit", new=CoroutineMock())
 async def test_permit(app):
-    """Test permi method."""
+    """Test permit method."""
     ezsp = app._ezsp
     ezsp.addTransientLinkKey = CoroutineMock(return_value=(t.EmberStatus.SUCCESS,))
     ezsp.pre_permit = CoroutineMock()
     await app.permit(10, None)
     await asyncio.sleep(0)
-    assert ezsp.addTransientLinkKey.await_count == 1
+    assert ezsp.addTransientLinkKey.await_count == 0
     assert ezsp.pre_permit.await_count == 1

--- a/tests/test_ezsp_v5.py
+++ b/tests/test_ezsp_v5.py
@@ -1,4 +1,4 @@
-from asynctest import mock
+from asynctest import CoroutineMock, mock
 import bellows.ezsp.v5
 import pytest
 
@@ -21,6 +21,15 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_count == 1
     assert ezsp_f._handle_callback.call_args[0][0] == "version"
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
+
+
+@pytest.mark.asyncio
+async def test_pre_permit(ezsp_f):
+    """Test pre permit."""
+    p2 = mock.patch.object(ezsp_f, "addTransientLinkKey", new=CoroutineMock())
+    with p2 as tclk_mock:
+        await ezsp_f.pre_permit(1)
+    assert tclk_mock.await_count == 1
 
 
 command_frames = {

--- a/tests/test_ezsp_v8.py
+++ b/tests/test_ezsp_v8.py
@@ -37,9 +37,11 @@ async def test_set_source_routing(ezsp_f):
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = mock.patch.object(ezsp_f, "setPolicy", new=CoroutineMock())
-    with p1 as pre_permit_mock:
+    p2 = mock.patch.object(ezsp_f, "addTransientLinkKey", new=CoroutineMock())
+    with p1 as pre_permit_mock, p2 as tclk_mock:
         await ezsp_f.pre_permit(-1.9)
     assert pre_permit_mock.await_count == 2
+    assert tclk_mock.await_count == 1
 
 
 def test_command_frames(ezsp_f):


### PR DESCRIPTION
Add Global TC link key as a transient link key only for EZSP v5 or later.
HUSBZB-1 comes with EmberZNet 5.4.1.0 based firmware and does not support transient link key command. 

Fixes #340 