### PR TITLE
Update README.md with recommendation to upgrade EmberZNet firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ bellows interacts with the Zigbee Network Coprocessor (NCP) with EmberZNet PRO Z
 
 EmberZNet based Zigbee radios using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
  - [ITEAD Sonoff ZBBridge](https://www.itead.cc/smart-home/sonoff-zbbridge.html) (Note! This first have to be flashed with [Tasmota firmware and EmberZNet firmware](https://www.digiblur.com/2020/07/how-to-use-sonoff-zigbee-bridge-with.html))
- - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/)
- - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs_usb_adapter.html)
- - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs_zigbee_shield.html)
+ - [Nortek GoControl QuickStick Combo Model HUSBZB-1 (Z-Wave & Zigbee Ember 3581 USB Adapter)](https://www.nortekcontrol.com/products/2gig/husbzb-1-gocontrol-quickstick-combo/) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/walthowd/husbzb-firmware))
+ - [Elelabs Zigbee USB Adapter](https://elelabs.com/products/elelabs_usb_adapter.html) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
+ - [Elelabs Zigbee Raspberry Pi Shield](https://elelabs.com/products/elelabs_zigbee_shield.html) (Note! Not a must but recommend [upgrade the EmberZNet NCP application firmware](https://github.com/Elelabs/elelabs-zigbee-ezsp-utility))
  - Telegesis ETRX357USB (Note! This first have to be flashed with other EmberZNet firmware)
  - Telegesis ETRX357USB-LRS (Note! This first have to be flashed with other EmberZNet firmware)
  - Telegesis ETRX357USB-LRS+8M (Note! This first have to be flashed with other EmberZNet firmware)


### PR DESCRIPTION
Update zha.markdown with recommendations to upgrade EmberZNet NCP application firmware on Silicon Labs based Zigbee adapter and links to information about how to do so where it is available.

Looks like quite a few users in the Home Assistant community have reported that some paring issues or instability with old firmware are resolved simply by upgrading EmberZNet firmware.

Does someone, by the way, have a link to good instructions on how-to upgrade firmware on Telegesis ETRX357USB adapters as well as links to publicly available firmware images for them?

Also submit PR https://github.com/home-assistant/home-assistant.io/pull/14503 to update https://www.home-assistant.io/integrations/zha/

Upgrading firmware might not be the solution for everyone or even possible on all adapters but if at least some people do so then it might off-load some bug-reports.