### PR TITLE
Handle gracefully invalidCommand frames

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Callable, Dict, Tuple
 
 from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES
+from bellows.exception import EzspError
 from bellows.typing import GatewayType
 
 LOGGER = logging.getLogger(__name__)
@@ -105,12 +106,23 @@ class ProtocolHandler(abc.ABC):
             frame_name,
             binascii.hexlify(data),
         )
+        schema = self.COMMANDS_BY_ID[frame_id][2]
+        result, data = self.types.deserialize(data, schema)
 
         if sequence in self._awaiting:
             expected_id, schema, future = self._awaiting.pop(sequence)
-            assert expected_id == frame_id
-            result, data = self.types.deserialize(data, schema)
             try:
+                if frame_name == "invalidCommand":
+                    sent_cmd_name = self.COMMANDS_BY_ID[expected_id][0]
+                    future.set_exception(
+                        EzspError(
+                            f"{sent_cmd_name} command is an {frame_name}, was sent "
+                            f"under {sequence} sequence number: {result[0].name}"
+                        )
+                    )
+                    return
+
+                assert expected_id == frame_id
                 future.set_result(result)
             except asyncio.InvalidStateError:
                 LOGGER.debug(
@@ -119,9 +131,6 @@ class ProtocolHandler(abc.ABC):
                     self.COMMANDS_BY_ID.get(expected_id, [expected_id])[0],
                 )
         else:
-            schema = self.COMMANDS_BY_ID[frame_id][2]
-            frame_name = self.COMMANDS_BY_ID[frame_id][0]
-            result, data = self.types.deserialize(data, schema)
             self._handle_callback(frame_name, result)
 
     def __getattr__(self, name: str) -> Callable:

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -62,6 +62,17 @@ def test_receive_reply_after_timeout(prot_hndl):
     assert prot_hndl.cb_mock.call_count == 0
 
 
+def test_receive_reply_invalid_command(prot_hndl):
+    callback_mock = MagicMock(spec_set=asyncio.Future)
+    prot_hndl._awaiting[0] = (0, prot_hndl.COMMANDS["invalidCommand"][2], callback_mock)
+    prot_hndl(b"\x00\xff\x58\x31")
+
+    assert 0 not in prot_hndl._awaiting
+    assert callback_mock.set_exception.call_count == 1
+    assert callback_mock.set_result.call_count == 0
+    assert prot_hndl.cb_mock.call_count == 0
+
+
 @pytest.mark.asyncio
 async def test_cfg_initialize(prot_hndl, caplog):
     """Test initialization."""


### PR DESCRIPTION
Handle gracefully invalidCommand frames.
`invalidCommand` frame is normal part of protocol operation and can happen under certain circumstances, e.g. https://github.com/zigpy/bellows/issues/366 where some very old firmwares do not support command "readCounters".