### PR TITLE
Don't log counters on EZSP version 4

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -626,7 +626,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 await asyncio.wait_for(
                     self.controller_event.wait(), timeout=WATCHDOG_WAKE_PERIOD * 2
                 )
-                if LOGGER.level < logging.DEBUG:
+                if LOGGER.level < logging.DEBUG or self._ezsp.ezsp_version == 4:
                     await self._ezsp.nop()
                 else:
                     (res,) = await self._ezsp.readCounters()


### PR DESCRIPTION
Don't try to `readCounters` on EZSP version 4, as some really old firmware on Telegis sticks does not support those. This would disable counter reading on HUSBZB-1 sticks as well, unless firmware is updated to a newer one. 

This 2nd part of the "counter" problem fix, indicated in https://github.com/zigpy/bellows/issues/366