### PR TITLE
Use a more sensible EZSP command timeout value

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -11,7 +11,7 @@ from bellows.typing import GatewayType
 
 LOGGER = logging.getLogger(__name__)
 
-EZSP_CMD_TIMEOUT = 100
+EZSP_CMD_TIMEOUT = 5
 
 
 class ProtocolHandler(abc.ABC):


### PR DESCRIPTION
Use a more sensible EZSP command timeout value.