### PR TITLE
Update setup.py adding "pyusb>=1.1.0" requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "dataclasses;python_version<'3.7'",
         "pure_pcapy3==1.0.1",
         "pyserial-asyncio",
+        "pyusb>=1.1.0",
         "voluptuous",
         "zigpy>=0.21.0",
     ],


### PR DESCRIPTION
Update setup.py adding "pyusb>=1.1.0" requirement as probably does not hurt have latest pyusb / libusb installed when trying to add USB adapters.

Reference https://github.com/zigpy/zigpy-zigate/issues/71 and https://github.com/home-assistant/home-assistant.io/pull/15829