### PR TITLE
Don't pin old version of click-log package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     entry_points={"console_scripts": ["bellows=bellows.cli.main:main"]},
     install_requires=[
         "Click",
-        "click-log==0.2.0",
+        "click-log>=0.2.1",
         "dataclasses;python_version<'3.7'",
         "pure_pcapy3==1.0.1",
         "pyserial-asyncio",


### PR DESCRIPTION
Don't pin old version of click-log package.
Fixes #376 