### PR TITLE
cli: join network fails because of typo

### DIFF
--- a/bellows/cli/network.py
+++ b/bellows/cli/network.py
@@ -59,7 +59,7 @@ async def join(ctx, channels, pan_id, extended_pan_id):
         network = networks[0]
 
         pan_id = network.panId
-        extended_pan_id = network.ExtendedPanId
+        extended_pan_id = network.extendedPanId
         channel = network.channel
 
         click.echo(


### PR DESCRIPTION
I'm new to bellows, and I am testing it via the CLI. I noticed that `network.extendedPanId` must be used instead of `network.ExtendedPanId` for a `bellows join` command.

I still don't have any success (next error: `TypeError: zha_security() missing 1 required positional argument: 'config'`), but at least I'm one step further with this fix.