### PR TITLE
Fix click dependency name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     entry_points={"console_scripts": ["bellows=bellows.cli.main:main"]},
     install_requires=[
-        "Click",
+        "click",
         "click-log>=0.2.1",
         "dataclasses;python_version<'3.7'",
         "pure_pcapy3==1.0.1",


### PR DESCRIPTION
Click is written lower case. At least in my setup the capital lead to
pypi to pick the wrong package:

```
Searching for Click
...
Best match: click log-0.3.2
```