### PR TITLE
Increase maximums to support 'pro' devices

### DIFF
--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -22,7 +22,7 @@ EZSP_SCHEMA = {
     # The maximum number of router neighbors the stack can keep track of. A neighbor
     # is a node within radio range
     vol.Optional(EzspConfigId.CONFIG_NEIGHBOR_TABLE_SIZE.name): vol.All(
-        int, vol.Range(min=8, max=16)
+        int, vol.Range(min=8, max=26)
     ),
     #
     # The maximum number of APS retried messages the stack can be transmitting at
@@ -80,7 +80,7 @@ EZSP_SCHEMA = {
     #
     # The maximum number of end device children that a router will support
     vol.Optional(EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN.name, default=32): vol.All(
-        int, vol.Range(min=0, max=32)
+        int, vol.Range(min=0, max=64)
     ),
     #
     # The maximum amount of time that the MAC will hold a message for indirect

--- a/bellows/ezsp/v8/config.py
+++ b/bellows/ezsp/v8/config.py
@@ -79,7 +79,7 @@ EZSP_SCHEMA = {
     ),
     #
     # The maximum number of end device children that a router will support
-    vol.Optional(EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN.name, default=32): vol.All(
+    vol.Optional(EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN.name): vol.All(
         int, vol.Range(min=0, max=64)
     ),
     #


### PR DESCRIPTION
Increase the max for children and neighbors to support 'pro' type devices that can handle the settings. 
Remove the default for MAX_END_DEVICE_CHILDREN for V8 EZSP. Inherit the default from NCP