### PR TITLE
Handle `None` node descriptors

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -463,9 +463,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             )
 
                     async with self._req_lock:
-                        if expect_reply and device.node_desc.is_end_device in (
-                            True,
-                            None,
+                        if expect_reply and (
+                            device.node_desc is None or device.node_desc.is_end_device
                         ):
                             LOGGER.debug(
                                 "Extending timeout for %s/0x%04x",

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -5,6 +5,7 @@ import pytest
 import zigpy.config
 from zigpy.device import Device
 from zigpy.zcl.clusters import security
+import zigpy.zdo.types as zdo_t
 
 import bellows.config as config
 from bellows.exception import ControllerError, EzspError
@@ -408,7 +409,16 @@ async def _request(
     app._ezsp.setExtendedTimeout = AsyncMock()
     device = MagicMock()
     device.relays = relays
-    device.node_desc.is_end_device = is_end_device
+
+    if is_end_device is not None:
+        device.node_desc = zdo_t.NodeDescriptor(
+            logical_type=(
+                zdo_t.LogicalType.EndDevice
+                if is_end_device
+                else zdo_t.LogicalType.Router
+            )
+        )
+
     res = await app.request(device, 9, 8, 7, 6, 5, b"", **kwargs)
     assert len(app._pending) == 0
     return res


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/711

Could also keep the code compatible with both versions of zigpy by testing `device.node_desc.is_end_device in (True, None)` instead of just `device.node_desc.is_end_device`.

CI passes locally for me with zigpy `dev`.