### PR TITLE
Allow `bellows dump` to pipe packets over stdout

### DIFF
--- a/bellows/cli/dump.py
+++ b/bellows/cli/dump.py
@@ -30,7 +30,9 @@ def dump(ctx, channel, outfile):
         start_time = ctx.obj.get("start_time", None)
         if start_time:
             duration = time.time() - start_time
-            click.echo("\nCaptured %s frames in %0.2fs" % (captured, duration))
+            click.echo(
+                "\nCaptured %s frames in %0.2fs" % (captured, duration), err=True
+            )
     finally:
         if "ezsp" in ctx.obj:
             loop.run_until_complete(ctx.obj["ezsp"].mfglibEnd())
@@ -49,7 +51,7 @@ async def _dump(ctx, channel, outfile):
 
     pcap = pure_pcapy.Dumper(outfile, 128, 195)  # DLT_IEEE_15_4
 
-    click.echo("Capture started")
+    click.echo("Capture started", err=True)
     ctx.obj["start_time"] = time.time()
     ctx.obj["captured"] = 0
 


### PR DESCRIPTION
Moves a few logging messages from stdout to stderr and terminates the command when the stdout pipe is broken.

"Fixes" https://github.com/zigpy/bellows/issues/425 when used with https://github.com/zigpy/zigpy-cli/pull/1