### PR TITLE
Refactor ezsp.probe() method

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1067,7 +1067,8 @@ async def test_probe_success(mock_connect, mock_reset):
     """Test device probing."""
 
     res = await ezsp.EZSP.probe(APP_CONFIG[config.CONF_DEVICE])
-    assert res is True
+    assert res
+    assert type(res) is dict
     assert mock_connect.call_count == 1
     assert mock_connect.await_count == 1
     assert mock_reset.call_count == 1
@@ -1077,7 +1078,8 @@ async def test_probe_success(mock_connect, mock_reset):
     mock_reset.reset_mock()
     mock_connect.reset_mock()
     res = await ezsp.EZSP.probe(APP_CONFIG[config.CONF_DEVICE])
-    assert res is True
+    assert res
+    assert type(res) is dict
     assert mock_connect.call_count == 1
     assert mock_connect.await_count == 1
     assert mock_reset.call_count == 1

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -255,7 +255,7 @@ async def test_probe_success(mock_connect, mock_reset):
     """Test device probing."""
 
     res = await ezsp.EZSP.probe(DEVICE_CONFIG)
-    assert res is True
+    assert type(res) is dict
     assert mock_connect.call_count == 1
     assert mock_connect.await_count == 1
     assert mock_reset.call_count == 1
@@ -265,7 +265,7 @@ async def test_probe_success(mock_connect, mock_reset):
     mock_reset.reset_mock()
     mock_connect.reset_mock()
     res = await ezsp.EZSP.probe(DEVICE_CONFIG)
-    assert res is True
+    assert type(res) is dict
     assert mock_connect.call_count == 1
     assert mock_connect.await_count == 1
     assert mock_reset.call_count == 1
@@ -286,10 +286,10 @@ async def test_probe_fail(exception):
         res = await ezsp.EZSP.probe(DEVICE_CONFIG)
 
     assert res is False
-    assert mock_connect.call_count == 1
-    assert mock_connect.await_count == 1
-    assert mock_reset.call_count == 1
-    assert mock_connect.return_value.close.call_count == 1
+    assert mock_connect.call_count == 2
+    assert mock_connect.await_count == 2
+    assert mock_reset.call_count == 2
+    assert mock_connect.return_value.close.call_count == 2
 
 
 @patch.object(ezsp.EZSP, "set_source_routing", new_callable=AsyncMock)


### PR DESCRIPTION
When probing for the radio, try default baudrate 1st then 115200 baudrate.
This would allow ZHA to detect EZSP based radio which are using 115200 serial port rate.