### PR TITLE
Don't use route discovery if source routing is enabled on EZSP v8

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -70,6 +70,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
 
         self.use_source_routing = self.config[CONF_PARAM_SRC_RTG]
+        if self.use_source_routing:
+            self._tx_options ^= t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
         self._req_lock = asyncio.Lock()
 
     @property
@@ -512,10 +514,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 while True:
                     if self.use_source_routing and self._ezsp.ezsp_version < 8:
                         (res,) = await self._ezsp.set_source_route(device)
-                        if res == t.EmberStatus.SUCCESS:
+                        if res != t.EmberStatus.SUCCESS:
                             aps_frame.options ^= (
                                 t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
                             )
+                        else:
                             LOGGER.debug(
                                 "Set source route for %s to %s: %s",
                                 device.nwk,

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -512,8 +512,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             async with self._in_flight_msg:
                 delays = [0.5, 1.0, 1.5]
                 while True:
-                    if self.use_source_routing and self._ezsp.ezsp_version < 8:
-                        (res,) = await self._ezsp.set_source_route(device)
+                    if self.use_source_routing:
+                        if self._ezsp.ezsp_version < 8:
+                            (res,) = await self._ezsp.set_source_route(device)
+                        else:
+                            res = (
+                                t.EmberStatus.SUCCESS
+                                if device.relays is not None
+                                else t.EmberStatus.ERR_FATAL
+                            )
                         if res != t.EmberStatus.SUCCESS:
                             aps_frame.options ^= (
                                 t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -622,10 +622,24 @@ async def test_request_src_rtg_not_enabled(relays, app, ezsp_mock):
 
 @pytest.mark.parametrize("relays", [[], [0x1234]])
 async def test_request_src_rtg_success(relays, app_src_rtg, ezsp_mock):
-    app_src_rtg.use_source_routing = True
     res = await _request(app_src_rtg, relays=relays)
     assert res[0] == 0
     assert ezsp_mock.set_source_route.await_count == 1
+    assert ezsp_mock.sendUnicast.await_count == 1
+    assert (
+        not ezsp_mock.sendUnicast.call_args[0][2].options
+        & t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
+    )
+
+
+@pytest.mark.parametrize("relays", [[], [0x1234]])
+async def test_request_src_rtg_success_v8(relays, app_src_rtg, ezsp_mock):
+    """Source routing on EZSP v8 or newer."""
+
+    ezsp_mock.ezsp_version = 8
+    res = await _request(app_src_rtg, relays=relays)
+    assert res[0] == 0
+    assert ezsp_mock.set_source_route.await_count == 0
     assert ezsp_mock.sendUnicast.await_count == 1
     assert (
         not ezsp_mock.sendUnicast.call_args[0][2].options


### PR DESCRIPTION
Avoid setting up APS Route Discovery option, if running source routing on EZSP V8 or newer