### PR TITLE
Reset relays for EZSP version 8

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -174,6 +174,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         for cnt_group in self.state.counters:
             cnt_group.reset()
 
+        if ezsp.ezsp_version >= 8:
+            for device in self.devices.values():
+                device.relays = None
+
         ezsp.add_callback(self.ezsp_callback_handler)
         self.controller_event.set()
         self._watchdog_task = asyncio.create_task(self._watchdog())

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -116,7 +116,7 @@ async def _test_startup(app, nwk_type, ieee, auto_form=False, init=0, ezsp_versi
 
     app._in_flight_msg = None
     ezsp_mock = MagicMock()
-    type(ezsp_mock.return_value).ezsp_version = PropertyMock(return_value=ezsp_version)
+    type(ezsp_mock).ezsp_version = PropertyMock(return_value=ezsp_version)
     ezsp_mock.initialize = AsyncMock(return_value=ezsp_mock)
     ezsp_mock.connect = AsyncMock()
     ezsp_mock.setConcentrator = AsyncMock()
@@ -171,6 +171,18 @@ async def test_startup_nwk_params(app, ieee):
 async def test_startup_ezsp_ver7(app, ieee):
     app.state.counters["ezsp_counters"] = MagicMock()
     await _test_startup(app, t.EmberNodeType.COORDINATOR, ieee, ezsp_version=7)
+    assert app.state.counters["ezsp_counters"].reset.call_count == 1
+
+
+async def test_startup_ezsp_ver8(app, ieee):
+    app.state.counters["ezsp_counters"] = MagicMock()
+    ieee_1 = t.EmberEUI64.convert("11:22:33:44:55:66:77:88")
+    dev_1 = app.add_device(ieee_1, 0x1234)
+    dev_1.relays = [
+        t.EmberNodeId(0x2222),
+    ]
+
+    await _test_startup(app, t.EmberNodeType.COORDINATOR, ieee, ezsp_version=8)
     assert app.state.counters["ezsp_counters"].reset.call_count == 1
 
 


### PR DESCRIPTION
EZSP protocol version 8 does not allow setting the source routes from the host. This causes issues on restarts, because the NCP does not have the routes, even though zigpy still have the old routes and because of this it does not set the ROUTER_DISCOVERY APS options. 
Clear device relays (source routes) on restart and use router discovery until new route is received.