### PR TITLE
Fix frame FCS on EZSPv8 unconditionally

### DIFF
--- a/bellows/cli/dump.py
+++ b/bellows/cli/dump.py
@@ -80,7 +80,7 @@ async def _dump(ctx, channel, outfile):
 
             # Later releases of EmberZNet incorrectly use a static FCS
             fcs = data[-2:]
-            if s.ezsp_version == 8 and fcs == b"\x0F\x00":
+            if s.ezsp_version == 8:
                 computed_fcs = ieee_15_4_fcs(data[0:-2])
                 LOGGER.debug("Fixing FCS (expected %s, got %s)", computed_fcs, fcs)
                 data = data[0:-2] + computed_fcs


### PR DESCRIPTION
Seems like the incorrect FCS captured on EZSPv8 depends on the channel, e.g. here's channel 20
```
Frame 1: 54 bytes on wire (432 bits), 54 bytes captured (432 bits)
IEEE 802.15.4 Data, Dst: 0x0000, Src: 0xc08f, Bad FCS
    Frame Control Field: 0x8841, Frame Type: Data, PAN ID Compression, Destination Addressing Mode: Short/16-bit, Frame Version: IEEE Std 802.15.4-2003, Source Addressing Mode: Short/16-bit
    Sequence Number: 15
    Destination PAN: 0x5812
    Destination: 0x0000
    Source: 0xc08f
    FCS: 0x0014 (Incorrect, expected FCS=0xe726)
    [Expert Info (Warning/Checksum): Bad FCS]
Data (43 bytes)
```

So this forces FCS recalculation on EZSP v8 unconditionally.