### PR TITLE
Skip get_board_info() in case EZSP Radio doesn't support it

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -145,10 +145,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             output_clusters=[zigpy.zcl.clusters.security.IasZone.cluster_id]
         )
 
-        brd_manuf, brd_name, version = await self._ezsp.get_board_info()
-        LOGGER.info("EZSP Radio manufacturer: %s", brd_manuf)
-        LOGGER.info("EZSP Radio board name: %s", brd_name)
-        LOGGER.info("EmberZNet version: %s", version)
+        try:
+            brd_manuf, brd_name, version = await self._ezsp.get_board_info()
+            LOGGER.info("EZSP Radio manufacturer: %s", brd_manuf)
+            LOGGER.info("EZSP Radio board name: %s", brd_name)
+            LOGGER.info("EmberZNet version: %s", version)
+        except EzspError as exc:
+            LOGGER.info("EZSP Radio does not support getMfgToken command: %s", str(exc))
 
         v = await ezsp.networkInit()
         if v[0] != t.EmberStatus.SUCCESS:


### PR DESCRIPTION
Handle exceptions in case EZSP Radio doesn't support the getMfgToken
token command. This is required to make ZHA work with the EmberZNet
Zigbee stack running on Linux (zigbeed).

See also discussion: https://github.com/zigpy/zigpy/discussions/894