### PR TITLE
Set probe timeout to 3s for zigbeed

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -24,7 +24,7 @@ import bellows.uart
 from . import v4, v5, v6, v7, v8
 
 EZSP_LATEST = v8.EZSP_VERSION
-PROBE_TIMEOUT = 2
+PROBE_TIMEOUT = 3
 NETWORK_OPS_TIMEOUT = 10
 LOGGER = logging.getLogger(__name__)
 MTOR_MIN_INTERVAL = 10


### PR DESCRIPTION
The Silicon Labs zigbee daemon restarts on reset. Restarts take some
time, and with a probe timeout of 2s probe often stops before the
zigbeed finished restarting. This is especially noticable since Gecko
SDK 4.0.2.0.