### PR TITLE
Fix bind command

### DIFF
--- a/bellows/cli/application.py
+++ b/bellows/cli/application.py
@@ -200,7 +200,7 @@ async def bind(ctx, endpoint, cluster):
         return
 
     try:
-        v = await dev.zdo.bind(endpoint, cluster)
+        v = await dev.zdo.bind(clust)
         click.echo(v)
     except zigpy.exceptions.ZigbeeException as e:
         click.echo(e)


### PR DESCRIPTION
Using bind command returns error similar to "function takes 2 attributes but 3 were given".
In Zigpy it is defined as  

`def bind(self, cluster):`

So endpoint shouldn't be there and cluster should be "clust" returned from previous function and not "cluster" as the latter is a number from the cli and not a "cluster" class object.