### PR TITLE
Fix black with latest click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{
             steps.python.outputs.python-version }}-${{
             hashFiles('setup.py') }}-${{
-            hashFiles('requirements_test.txt') }}
+            hashFiles('requirements_test.txt')-${{
+            hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-venv-${{ steps.python.outputs.python-version }}-
       - name: Create Python virtual environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args:


### PR DESCRIPTION
Latest click broke black (see https://github.com/psf/black/issues/2964
for details). Use latest black to fix black in our CI environment. Also
add .pre-commit-config.yaml to the key of the cache.