### PR TITLE
Fix UART port close on RSTACK message during startup

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -224,7 +224,9 @@ class EZSP:
             self.close()
             self.handle_callback("_reset_controller_application", (error,))
         else:
-            LOGGER.info("NCP entered failed state. No application handler registered, ignoring...")
+            LOGGER.info(
+                "NCP entered failed state. No application handler registered, ignoring..."
+            )
 
     def __getattr__(self, name: str) -> Callable:
         if name not in self._protocol.COMMANDS:

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -219,9 +219,12 @@ class EZSP:
 
     def enter_failed_state(self, error):
         """UART received error frame."""
-        LOGGER.error("NCP entered failed state. Requesting APP controller restart")
-        self.close()
-        self.handle_callback("_reset_controller_application", (error,))
+        if self._callbacks:
+            LOGGER.error("NCP entered failed state. Requesting APP controller restart")
+            self.close()
+            self.handle_callback("_reset_controller_application", (error,))
+        else:
+            LOGGER.info("NCP entered failed state. No application handler registered, ignoring...")
 
     def __getattr__(self, name: str) -> Callable:
         if name not in self._protocol.COMMANDS:

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -249,6 +249,13 @@ async def test_enter_failed_state(ezsp_f):
     assert cb.call_count == 1
     assert cb.call_args[0][1][0] == sentinel.error
 
+async def test_no_close_without_callback(ezsp_f):
+    ezsp_f.stop_ezsp = MagicMock(spec_set=ezsp_f.stop_ezsp)
+    ezsp_f.close = MagicMock(spec_set=ezsp_f.close)
+    ezsp_f.enter_failed_state(sentinel.error)
+    await asyncio.sleep(0)
+    assert ezsp_f.stop_ezsp.call_count == 0
+    assert ezsp_f.close.call_count == 0
 
 @patch.object(ezsp.EZSP, "reset", new_callable=AsyncMock)
 @patch("bellows.uart.connect", return_value=MagicMock(spec_set=uart.Gateway))

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -241,12 +241,13 @@ def test_connection_lost(ezsp_f):
 
 async def test_enter_failed_state(ezsp_f):
     ezsp_f.stop_ezsp = MagicMock(spec_set=ezsp_f.stop_ezsp)
-    ezsp_f.handle_callback = MagicMock(spec_set=ezsp_f.handle_callback)
+    cb = MagicMock(spec_set=ezsp_f.handle_callback)
+    ezsp_f.add_callback(cb)
     ezsp_f.enter_failed_state(sentinel.error)
     await asyncio.sleep(0)
     assert ezsp_f.stop_ezsp.call_count == 1
-    assert ezsp_f.handle_callback.call_count == 1
-    assert ezsp_f.handle_callback.call_args[0][1][0] == sentinel.error
+    assert cb.call_count == 1
+    assert cb.call_args[0][1][0] == sentinel.error
 
 
 @patch.object(ezsp.EZSP, "reset", new_callable=AsyncMock)

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -249,6 +249,7 @@ async def test_enter_failed_state(ezsp_f):
     assert cb.call_count == 1
     assert cb.call_args[0][1][0] == sentinel.error
 
+
 async def test_no_close_without_callback(ezsp_f):
     ezsp_f.stop_ezsp = MagicMock(spec_set=ezsp_f.stop_ezsp)
     ezsp_f.close = MagicMock(spec_set=ezsp_f.close)
@@ -256,6 +257,7 @@ async def test_no_close_without_callback(ezsp_f):
     await asyncio.sleep(0)
     assert ezsp_f.stop_ezsp.call_count == 0
     assert ezsp_f.close.call_count == 0
+
 
 @patch.object(ezsp.EZSP, "reset", new_callable=AsyncMock)
 @patch("bellows.uart.connect", return_value=MagicMock(spec_set=uart.Gateway))


### PR DESCRIPTION
When a RSTACK message is processed right after the UART has been opened,
it causes EZSP.enter_failed_state() getting called at a point where the
application callbacks are not registered yet. In that case the UART
will get closed and it won't get opened again. Bellows is stuck with a
closed transport.

Avoid this issue by not closing the port in case there is no application
callback registered yet.

Typically, it is unlikely that a RSTACK message arrives right when
the port gets opened (the race window is very narrow). However, with
hardware flow control opening the port leads to RTS signal to get
asserted which causes the radio to send pending messages, e.g. resets
caused by EmberZNet watchdog.

Note: With hardware flow control this is only the case if the tty "hupcl"
option is set. The option is set by default, but cleared by tools like
GNU screen. This option makes sure that the RTS signal is deasserted
while the port is closed. Pyserial/bellows does not change the state
of that option.

Fixes: https://github.com/home-assistant/core/issues/71575