### PR TITLE
Update README.md to mention EZSP v9 and EZSP v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The largest change was between EZSP v4 (first added in EmberZNet 4.7.2 SDK) and 
 
 Perhaps more important to know today is that EZSP v5, v6 and v7 (EmberZNet 6.6.x.x) use the same framing format, but EmberZNet 6.7.x.x/EZSP v8 introduced new framing format and expanded command id field from 8 bits to 16 bits and is and is not backward compatible.
 
+EZSP v9 protocol is largely the same as EZSP v8, though there are breaking changes in some responses and bellows has been updated to handle the new additions.
+
 ## Project status
 
 This project is in early stages, so it is likely that APIs will change.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The project can be used as a stand-alone library, however, the main goal of this
 
 - https://www.home-assistant.io/integrations/zha/
 
-bellows interacts with the Zigbee Network Coprocessor (NCP) with EmberZNet PRO Zigbee coordinator firmware using the EZSP protocol serial interface APIs via via UART for Silicon Labs EM35x and EFR32 Zigbee radio module/chips hardware. The library currently supports the Silicon Labs EZSP (EmberZNet Serial Protocol) API versions v4/v5/v6/v7/v8 for Silabs older EM35x "Ember" and their newer EFR32 "Mighty Gecko" SoCs using ASH protocols over a serial interface.
+bellows interacts with the Zigbee Network Coprocessor (NCP) with EmberZNet PRO Zigbee coordinator firmware using the EZSP protocol serial interface APIs via via UART for Silicon Labs EM35x and EFR32 Zigbee radio module/chips hardware. The library currently supports the Silicon Labs EZSP (EmberZNet Serial Protocol) API versions v4/v5/v6/v7/v8/v9/v10 for Silabs older EM35x "Ember" and their newer EFR32 "Mighty Gecko" SoCs using ASH protocols over a serial interface.
 
 ## Hardware requirement
 
@@ -52,7 +52,7 @@ The largest change was between EZSP v4 (first added in EmberZNet 4.7.2 SDK) and 
 
 Perhaps more important to know today is that EZSP v5, v6 and v7 (EmberZNet 6.6.x.x) use the same framing format, but EmberZNet 6.7.x.x/EZSP v8 introduced new framing format and expanded command id field from 8 bits to 16 bits and is and is not backward compatible.
 
-EZSP v9 protocol is largely the same as EZSP v8, though there are breaking changes in some responses and bellows has been updated to handle the new additions.
+EZSP v9 and EZSP v10 protocol versions are largely the same as EZSP v8, though there are a few minor breaking changes in some responses for which bellows has been updated to handle those new additions and differences.
 
 ## Project status
 


### PR DESCRIPTION
Update README.md to mention EZSP v9 Protocol Version as default in Silabs Zigbee EmberZNet 7.1.x firmware -> https://github.com/zigpy/bellows/pull/462

Update: Also updated this PR to in addition include mentioning of EZSP v10 as added in puddly's PR https://github.com/zigpy/bellows/pull/529

Silicon Labs Gecko SDK 4.1.0 (GSDK 4.1) was released a couple of days ago and with it Zigbee EmberZNet SDK 7.1.0.0 and tube0013 submitted a patch with initial support in PR https://github.com/zigpy/bellows/pull/462

https://github.com/SiliconLabs/gecko_sdk/releases

https://www.silabs.com/documents/public/release-notes/emberznet-release-notes-7.1.0.0.pdf

https://web.archive.org/web/20220401230237/https://www.silabs.com/documents/public/user-guides/ug100-ezsp-reference-guide.pdf

https://www.silabs.com/documents/public/user-guides/ug100-ezsp-reference-guide.pdf

EZSP protocol version has been incremented to EZSP v10 in Gecko SDK v4.2 / Zigbee EmberZNet v7.2 and EZSP v10 was not mentioned in the latest UG100 (EZSP Reference Guide) documentation from Silicon Labs which SiLabs only updated for EZSP v9 and state that no additions were added between EmberZNet PRO Release 7.1.1 and 7.2.0:

Gecko SDK v4.2:

https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.2/protocol/zigbee/app/util/ezsp/ezsp-protocol.h

* EZSP_PROTOCOL_VERSION = 10

https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.2/protocol/zigbee/app/util/ezsp/ezsp-protocol.h

https://www.silabs.com/documents/public/user-guides/ug100-ezsp-reference-guide.pdf