### PR TITLE
Implement energy scanning via the ZDO interface

### DIFF
--- a/bellows/zigbee/device.py
+++ b/bellows/zigbee/device.py
@@ -1,0 +1,168 @@
+import asyncio
+import logging
+
+import zigpy.device
+import zigpy.endpoint
+import zigpy.zdo
+import zigpy.zdo.types as zdo_t
+
+import bellows.types as t
+
+# Test tone at 8dBm power level produced a max RSSI of -3dB
+# -21dB corresponds to 100% LQI on the ZZH!
+RSSI_MAX = -21
+
+# Grounded antenna and then shielded produced a min RSSI of -92
+# -89dB corresponds to 0% LQI on the ZZH!
+RSSI_MIN = -89
+
+SCAN_RETRIES = 3
+SCAN_FAILURE_DELAY = 1.0  # seconds
+
+ZDO_PROFILE = 0x0000
+ZDO_ENDPOINT = 0
+
+LOGGER = logging.getLogger(__name__)
+
+
+def clamp(v: float, minimum: float, maximum: float) -> float:
+    """
+    Restricts `v` to be between `minimum` and `maximum`.
+    """
+
+    return min(max(minimum, v), maximum)
+
+
+class EZSPEndpoint(zigpy.endpoint.Endpoint):
+    @property
+    def manufacturer(self) -> str:
+        """Manufacturer."""
+        return "Silicon Labs"
+
+    @property
+    def model(self) -> str:
+        """Model."""
+        return "EZSP"
+
+    async def add_to_group(self, grp_id: int, name: str = None) -> t.EmberStatus:
+        if grp_id in self.member_of:
+            return t.EmberStatus.SUCCESS
+
+        app = self.device.application
+        status = await app.multicast.subscribe(grp_id)
+        if status != t.EmberStatus.SUCCESS:
+            self.debug("Couldn't subscribe to 0x%04x group", grp_id)
+            return status
+
+        group = app.groups.add_group(grp_id, name)
+        group.add_member(self)
+        return status
+
+    async def remove_from_group(self, grp_id: int) -> t.EmberStatus:
+        if grp_id not in self.member_of:
+            return t.EmberStatus.SUCCESS
+
+        app = self.device.application
+        status = await app.multicast.unsubscribe(grp_id)
+        if status != t.EmberStatus.SUCCESS:
+            self.debug("Couldn't unsubscribe 0x%04x group", grp_id)
+            return status
+
+        app.groups[grp_id].remove_member(self)
+        return status
+
+
+class EZSPZDOEndpoint(zigpy.zdo.ZDO):
+    @property
+    def app(self) -> zigpy.application.ControllerApplication:
+        return self.device.application
+
+    def _send_loopback_reply(
+        self, command_id: zdo_t.ZDOCmd, *, tsn: t.uint8_t, **kwargs
+    ):
+        """
+        Constructs and sends back a loopback ZDO response.
+        """
+
+        message = t.uint8_t(tsn).serialize() + self._serialize(
+            command_id, *kwargs.values()
+        )
+
+        LOGGER.debug("Sending loopback reply %s (%s), tsn=%s", command_id, kwargs, tsn)
+
+        self.app.handle_message(
+            sender=self.app._device,
+            profile=ZDO_PROFILE,
+            cluster=command_id,
+            src_ep=ZDO_ENDPOINT,
+            dst_ep=ZDO_ENDPOINT,
+            message=message,
+        )
+
+    def handle_mgmt_nwk_update_req(
+        self, hdr: zdo_t.ZDOHeader, NwkUpdate: zdo_t.NwkUpdate, *, dst_addressing
+    ):
+        """
+        Handles ZDO `Mgmt_NWK_Update_req` sent to the coordinator.
+        """
+
+        self.create_catching_task(
+            self.async_handle_mgmt_nwk_update_req(
+                hdr, NwkUpdate, dst_addressing=dst_addressing
+            )
+        )
+
+    async def async_handle_mgmt_nwk_update_req(
+        self, hdr: zdo_t.ZDOHeader, NwkUpdate: zdo_t.NwkUpdate, *, dst_addressing
+    ):
+        if NwkUpdate.ScanDuration == zdo_t.NwkUpdate.CHANNEL_CHANGE_REQ:
+            return
+        elif (
+            NwkUpdate.ScanDuration
+            == zdo_t.NwkUpdate.CHANNEL_MASK_MANAGER_ADDR_CHANGE_REQ
+        ):
+            return
+
+        # XXX: EmberZNet bug causes every other scan to:
+        # 1. Immediately fail because a scan is already running (one shouldn't be).
+        # 2. Actually start a scan.
+        # 3. Never send the "scan completed" command, just the intermediate values.
+        for i in range(SCAN_RETRIES):
+            try:
+                results = await self.app._ezsp.startScan(
+                    t.EzspNetworkScanType.ENERGY_SCAN,
+                    NwkUpdate.ScanChannels,
+                    NwkUpdate.ScanDuration,
+                )
+                break
+            except Exception:
+                await asyncio.sleep(SCAN_FAILURE_DELAY)
+        else:
+            raise RuntimeError("Failed to scan")
+
+        # Linearly remap RSSI to LQI
+        rescaled_values = [
+            int(100 * (clamp(v, RSSI_MIN, RSSI_MAX) - RSSI_MIN) / (RSSI_MAX - RSSI_MIN))
+            for _, v in results
+        ]
+
+        self._send_loopback_reply(
+            zdo_t.ZDOCmd.Mgmt_NWK_Update_rsp,
+            Status=zdo_t.Status.SUCCESS,
+            ScannedChannels=NwkUpdate.ScanChannels,
+            TotalTransmissions=0,
+            TransmissionFailures=0,
+            EnergyValues=rescaled_values,
+            tsn=hdr.tsn,
+        )
+
+
+class EZSPCoordinator(zigpy.device.Device):
+    """Zigpy Device representing Coordinator."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        assert hasattr(self, "zdo")
+        self.zdo = EZSPZDOEndpoint(self)
+        self.endpoints[0] = self.zdo

--- a/bellows/zigbee/device.py
+++ b/bellows/zigbee/device.py
@@ -12,7 +12,7 @@ import zigpy.zdo.types as zdo_t
 import bellows.types as t
 
 if typing.TYPE_CHECKING:
-    import zigpy.application
+    import zigpy.application  # pragma: no cover
 
 # Test tone at 8dBm power level produced a max RSSI of -3dB
 # -21dB corresponds to 100% LQI on the ZZH!

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -17,6 +17,7 @@ import bellows.ezsp.v8.types as ezsp_t8
 import bellows.types.struct
 import bellows.uart as uart
 import bellows.zigbee.application
+import bellows.zigbee.device
 
 from .async_mock import AsyncMock, MagicMock, PropertyMock, patch, sentinel
 
@@ -1090,8 +1091,8 @@ async def test_shutdown(app):
 
 @pytest.fixture
 def coordinator(app, ieee):
-    dev = bellows.zigbee.application.EZSPCoordinator(app, ieee, 0x0000)
-    dev.endpoints[1] = bellows.zigbee.application.EZSPCoordinator.EZSPEndpoint(dev, 1)
+    dev = bellows.zigbee.device.EZSPCoordinator(app, ieee, 0x0000)
+    dev.endpoints[1] = bellows.zigbee.device.EZSPEndpoint(dev, 1)
     dev.model = dev.endpoints[1].model
     dev.manufacturer = dev.endpoints[1].manufacturer
 

--- a/tests/test_application_device.py
+++ b/tests/test_application_device.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+import zigpy.endpoint
+import zigpy.types as t
+import zigpy.zdo.types as zdo_t
+
+from bellows.zigbee.device import EZSPCoordinator, EZSPEndpoint
+
+from tests.async_mock import AsyncMock
+from tests.test_application import app, ezsp_mock
+
+
+@pytest.fixture
+def app_and_coordinator(app):
+    app.state.node_info.ieee = t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11")
+    app.state.node_info.nwk = t.NWK(0x0000)
+
+    coordinator = EZSPCoordinator(
+        application=app,
+        ieee=app.state.node_info.ieee,
+        nwk=app.state.node_info.nwk,
+    )
+    coordinator.node_desc = zdo_t.NodeDescriptor()
+
+    app.devices[app.state.node_info.ieee] = coordinator
+
+    # The coordinator device does not respond to attribute reads
+    coordinator.endpoints[1] = EZSPEndpoint(coordinator, 1)
+    coordinator.endpoints[1].status = zigpy.endpoint.Status.ZDO_INIT
+
+    return app, coordinator
+
+
+@pytest.mark.parametrize(
+    "scan_results",
+    [
+        # Normal
+        [
+            -39,
+            -30,
+            -26,
+            -33,
+            -23,
+            -53,
+            -42,
+            -46,
+            -69,
+            -75,
+            -49,
+            -67,
+            -57,
+            -81,
+            -29,
+            -40,
+        ],
+        # Maximum
+        [1] * (26 - 11),
+        # Minimum
+        [-200] * (26 - 11),
+    ],
+)
+async def test_energy_scanning(app_and_coordinator, scan_results):
+    app, coordinator = app_and_coordinator
+
+    app._ezsp.startScan = AsyncMock(
+        return_value=list(zip(range(11, 26 + 1), scan_results))
+    )
+
+    _, scanned_channels, *_, energy_values = await coordinator.zdo.Mgmt_NWK_Update_req(
+        zdo_t.NwkUpdate(
+            ScanChannels=t.Channels.ALL_CHANNELS,
+            ScanDuration=0x02,
+            ScanCount=1,
+        )
+    )
+
+    assert scanned_channels == t.Channels.ALL_CHANNELS
+    assert len(energy_values) == len(scan_results)


### PR DESCRIPTION
This allows for energy scans to be performed via zigpy-cli (and soon ZHA) on all Z-Stack, EZSP, and deCONZ radios:

```
$ zigpy radio --baudrate 115200 ezsp /dev/cu.SLAB_USBtoUART energy-scan
Channel energy (mean of 1 / 5):
------------------------------------------------
 + Lower energy is better
 + Active Zigbee networks on a channel may still cause congestion
 + TX on 26 in North America may be with lower power due to regulations
 + Zigbee channels 15, 20, 25 fall between WiFi channels 1, 6, 11
 + Some Zigbee devices only join networks on channels 15, 20, and 25
 + Current channel is enclosed in [square brackets]
------------------------------------------------
 -  11      33.73%  #################################
 -  12      33.33%  #################################
 -  13      36.08%  ####################################
 -  14      29.41%  #############################
 - [15 ]    16.08%  ################
 -  16      15.29%  ###############
 -  17      16.47%  ################
 -  18      20.00%  ####################
 -  19       8.63%  ########
 -  20       3.92%  ###
 -  21      20.00%  ####################
 -  22      13.73%  #############
 -  23      17.65%  #################
 -  24       3.14%  ###
 -  25      11.37%  ###########
 -  26*      1.96%  #
```
