### PR TITLE
Fix `getChildData` schema in v9 to match v7 and v8

### DIFF
--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -124,12 +124,12 @@ COMMANDS = {
     "getChildData": (
         0x004A,
         (t.uint8_t,),
-        (t.EmberStatus, t.EmberNodeId, t.EmberEUI64, t.EmberNodeType),
+        (t.EmberStatus, t.EmberChildData),
     ),
     "setChildData": (
         0x00AC,
         (t.uint8_t,),
-        (t.EmberStatus, t.EmberNodeId, t.EmberEUI64, t.EmberNodeType),
+        (t.EmberStatus, t.EmberChildData),
     ),
     "getSourceRouteTableTotalSize": (0x00C3, (), (t.uint8_t,)),
     "getSourceRouteTableFilledSize": (0x00C2, (), (t.uint8_t,)),

--- a/bellows/ezsp/v9/types/struct.py
+++ b/bellows/ezsp/v9/types/struct.py
@@ -202,3 +202,25 @@ class EmberTransientKeyData(EzspStruct):
     # The number of seconds remaining before the key is automatically timed out of the
     # transient key table.
     remainingTimeSeconds: basic.uint16_t
+
+
+class EmberChildData(EzspStruct):
+    """A structure containing a child node's data."""
+
+    # The EUI64 of the child
+    eui64: named.EmberEUI64
+    # The node type of the child
+    type: named.EmberNodeType
+    # The short address of the child
+    id: named.EmberNodeId
+    # The phy of the child
+    phy: basic.uint8_t
+    # The power of the child
+    power: basic.uint8_t
+    # The timeout of the child
+    timeout: basic.uint8_t
+
+    # The GPD's EUI64.
+    # gpdIeeeAddress: named.EmberEUI64
+    # The GPD's source ID.
+    # sourceId: basic.uint32_t


### PR DESCRIPTION
I forgot to update `v9/commands.py` after rebasing #462