### PR TITLE
Restart on any startup failure, not just timeouts and serial errors

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -5,7 +5,6 @@ import logging
 import os
 from typing import Dict, Optional
 
-from serial import SerialException
 import zigpy.application
 import zigpy.config
 import zigpy.device
@@ -650,8 +649,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             try:
                 await self._reset_controller()
                 break
-            except (asyncio.TimeoutError, SerialException) as exc:
-                LOGGER.debug("ControllerApplication reset unsuccessful: %s", str(exc))
+            except Exception as exc:
+                LOGGER.warning(
+                    "ControllerApplication reset unsuccessful: %s",
+                    str(exc),
+                    exc_info=exc,
+                )
             await asyncio.sleep(RESET_ATTEMPT_BACKOFF_TIME)
 
         self._reset_task = None

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -652,7 +652,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             except Exception as exc:
                 LOGGER.warning(
                     "ControllerApplication reset unsuccessful: %s",
-                    str(exc),
+                    repr(exc),
                     exc_info=exc,
                 )
             await asyncio.sleep(RESET_ATTEMPT_BACKOFF_TIME)


### PR DESCRIPTION
Possible fix for https://github.com/home-assistant/core/issues/75292

I believe the new zigpy startup sequence can throw new types of errors, which bellows was not handling. This would cause the watchdog re-connect task to crash, which will prevent any future reconnects.