### PR TITLE
Log unknown commands

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -134,8 +134,20 @@ class ProtocolHandler(abc.ABC):
 
     def __call__(self, data: bytes) -> None:
         """Handler for received data frame."""
+        orig_data = data
         sequence, frame_id, data = self._ezsp_frame_rx(data)
-        frame_name = self.COMMANDS_BY_ID[frame_id][0]
+
+        try:
+            frame_name = self.COMMANDS_BY_ID[frame_id][0]
+        except KeyError:
+            LOGGER.warning(
+                "Unknown application frame 0x%04X received: %s (%s).  This is a bug!",
+                frame_id,
+                binascii.hexlify(data),
+                binascii.hexlify(orig_data),
+            )
+            return
+
         LOGGER.debug(
             "Application frame %s (%s) received: %s",
             frame_id,

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -121,3 +121,14 @@ async def test_get_free_buffers(prot_hndl, status, raw, expected_value):
             assert free_buffers is expected_value
         else:
             assert free_buffers == expected_value
+
+
+async def test_unknown_command(prot_hndl, caplog):
+    """Test receiving an unknown command."""
+
+    unregistered_command = 0x04
+
+    with caplog.at_level(logging.WARNING):
+        prot_hndl(bytes([0x00, 0x00, unregistered_command, 0xAB, 0xCD]))
+
+        assert "0x0004 received: b'abcd' (b'000004abcd')" in caplog.text


### PR DESCRIPTION
The Gecko SDKs seem to contain a few commands we never defined in the schemas. Currently bellows crashes, without logging enough to figure out what the command is.