### PR TITLE
Probe with 115200 baud first

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -54,7 +54,7 @@ class EZSP:
     @classmethod
     async def probe(cls, device_config: Dict) -> bool | dict[str, int | str | bool]:
         """Probe port for the device presence."""
-        for config in (device_config, {**device_config, CONF_DEVICE_BAUDRATE: 115200}):
+        for config in ({**device_config, CONF_DEVICE_BAUDRATE: 115200}, device_config):
             ezsp = cls(SCHEMA_DEVICE(config))
             try:
                 await asyncio.wait_for(ezsp._probe(), timeout=PROBE_TIMEOUT)


### PR DESCRIPTION
All newer adapters are using 115200 baud, not 57600 (which I believe is only used by the old HUSBZB-1?). Changing the default to 115200 will break CLI tools and require a ZHA configuration migration so this is a slightly more gradual change.