### PR TITLE
Explicitly close serial port after connection and startup failures

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -19,6 +19,7 @@ from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
 CONF_DEVICE_BAUDRATE = "baudrate"
 CONF_EZSP_CONFIG = "ezsp_config"
 CONF_EZSP_POLICIES = "ezsp_policies"
+CONF_PARAM_MAX_WATCHDOG_FAILURES = "max_watchdog_failures"
 CONF_PARAM_SRC_RTG = "source_routing"
 CONF_PARAM_UNK_DEV = "handle_unknown_devices"
 CONF_FLOW_CONTROL = "flow_control"
@@ -36,6 +37,7 @@ SCHEMA_DEVICE = SCHEMA_DEVICE.extend(
 CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
         vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
+        vol.Optional(CONF_PARAM_MAX_WATCHDOG_FAILURES, default=4): int,
         vol.Optional(CONF_PARAM_SRC_RTG, default=False): cv_boolean,
         vol.Optional(CONF_PARAM_UNK_DEV, default=False): cv_boolean,
         vol.Optional(CONF_EZSP_CONFIG, default={}): dict,

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -226,7 +226,7 @@ class EZSP:
         LOGGER.debug(
             "%s connection lost unexpectedly: %s", self._config[CONF_DEVICE_PATH], exc
         )
-        self.enter_failed_state("Serial connection loss: {}".format(exc))
+        self.enter_failed_state(f"Serial connection loss: {exc!r}")
 
     def enter_failed_state(self, error):
         """UART received error frame."""

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -7,7 +7,6 @@ import functools
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union
 
-import serial
 from zigpy.typing import DeviceType
 
 from bellows.config import (
@@ -17,7 +16,7 @@ from bellows.config import (
     CONF_PARAM_SRC_RTG,
     SCHEMA_DEVICE,
 )
-from bellows.exception import APIException, EzspError
+from bellows.exception import EzspError
 import bellows.types as t
 import bellows.uart
 
@@ -59,7 +58,7 @@ class EZSP:
             try:
                 await asyncio.wait_for(ezsp._probe(), timeout=PROBE_TIMEOUT)
                 return config
-            except (asyncio.TimeoutError, serial.SerialException, APIException) as exc:
+            except Exception as exc:
                 LOGGER.debug(
                     "Unsuccessful radio probe of '%s' port",
                     device_config[CONF_DEVICE_PATH],

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -204,7 +204,7 @@ class Gateway(asyncio.Protocol):
         LOGGER.debug("Resetting ASH")
         if self._reset_future is not None:
             LOGGER.error(
-                ("received new reset request while an existing " "one is in progress")
+                "received new reset request while an existing one is in progress"
             )
             return await self._reset_future
 

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -636,7 +636,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     def _handle_reset_request(self, error):
         """Reinitialize application controller."""
-        LOGGER.debug("Resetting ControllerApplication. Cause: '%s'", error)
+        LOGGER.debug("Resetting ControllerApplication. Cause: %r", error)
         self.controller_event.clear()
         if self._reset_task:
             LOGGER.debug("Preempting ControllerApplication reset")
@@ -653,8 +653,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 break
             except Exception as exc:
                 LOGGER.warning(
-                    "ControllerApplication reset unsuccessful: %s",
-                    repr(exc),
+                    "ControllerApplication reset unsuccessful: %r",
+                    exc,
                     exc_info=exc,
                 )
             await asyncio.sleep(RESET_ATTEMPT_BACKOFF_TIME)
@@ -957,7 +957,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
                 failures = 0
             except (asyncio.TimeoutError, EzspError) as exc:
-                LOGGER.warning("Watchdog heartbeat timeout: %s", str(exc))
+                LOGGER.warning("Watchdog heartbeat timeout: %s", repr(exc))
                 failures += 1
                 if failures > MAX_WATCHDOG_FAILURES:
                     break
@@ -972,9 +972,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await asyncio.sleep(WATCHDOG_WAKE_PERIOD)
 
         self.state.counters[COUNTERS_CTRL][COUNTER_WATCHDOG].increment()
-        self._handle_reset_request(
-            "Watchdog timeout. Heartbeat timeouts: {}".format(failures)
-        )
+        self._handle_reset_request(f"Watchdog timeout. Heartbeat timeouts: {failures}")
 
     async def _get_free_buffers(self) -> Optional[int]:
         status, value = await self._ezsp.getValue(

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -455,6 +455,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self._reset_task.cancel()
         if self._ezsp is not None:
             self._ezsp.close()
+            self._ezsp = None
 
     async def force_remove(self, dev):
         # This should probably be delivered to the parent device instead
@@ -665,7 +666,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def _reset_controller(self):
         """Reset Controller."""
-        self._ezsp.close()
+        if self._ezsp is not None:
+            self._ezsp.close()
+            self._ezsp = None
+
         await asyncio.sleep(0.5)
         await self.startup()
 

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -17,6 +17,7 @@ import zigpy.zdo.types as zdo_t
 
 import bellows
 from bellows.config import (
+    CONF_PARAM_MAX_WATCHDOG_FAILURES,
     CONF_PARAM_SRC_RTG,
     CONF_PARAM_UNK_DEV,
     CONFIG_SCHEMA,
@@ -46,7 +47,6 @@ DEFAULT_MFG_ID = 0x1049
 EZSP_COUNTERS_CLEAR_IN_WATCHDOG_PERIODS = 180
 EZSP_DEFAULT_RADIUS = 0
 EZSP_MULTICAST_NON_MEMBER_RADIUS = 3
-MAX_WATCHDOG_FAILURES = 4
 MFG_ID_RESET_DELAY = 180
 RESET_ATTEMPT_BACKOFF_TIME = 5
 WATCHDOG_WAKE_PERIOD = 10
@@ -963,7 +963,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             except (asyncio.TimeoutError, EzspError) as exc:
                 LOGGER.warning("Watchdog heartbeat timeout: %s", repr(exc))
                 failures += 1
-                if failures > MAX_WATCHDOG_FAILURES:
+                if failures > self.config[CONF_PARAM_MAX_WATCHDOG_FAILURES]:
                     break
             except asyncio.CancelledError:
                 raise

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -912,10 +912,11 @@ async def test_reset_controller_loop(app, monkeypatch):
 async def test_reset_controller_routine(app):
     app._ezsp.reconnect = AsyncMock()
     app.startup = AsyncMock()
+    ezsp = app._ezsp
 
     await app._reset_controller()
 
-    assert app._ezsp.close.call_count == 1
+    assert ezsp.close.call_count == 1
     assert app.startup.call_count == 1
 
 
@@ -1079,6 +1080,7 @@ async def test_shutdown(app):
     watchdog_f = asyncio.Future()
     app._reset_task = reset_f
     app._watchdog_task = watchdog_f
+    ezsp = app._ezsp
 
     await app.shutdown()
     assert app.controller_event.is_set() is False
@@ -1086,7 +1088,7 @@ async def test_shutdown(app):
     assert reset_f.cancelled() is True
     assert watchdog_f.done() is True
     assert watchdog_f.cancelled() is True
-    assert app._ezsp.close.call_count == 1
+    assert ezsp.close.call_count == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
Another possible fix for https://github.com/home-assistant/core/issues/75292.

With the new logging introduced in https://github.com/zigpy/bellows/pull/476, I was able to simulate the exact errors received by a user and then get bellows into a state where it stopped trying to reconnect after a couple of attempts. I believe this is caused by the serial port not being properly closed before it is re-opened in some circumstances, since I have been unable to break the reconnect/watchdog loop since.