### PR TITLE
Properly handle failures after connect, during startup

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -198,8 +198,9 @@ class Gateway(asyncio.Protocol):
         if self._reset_future:
             self._reset_future.cancel()
 
-        self._send_task.cancel()
-        self._send_task = None
+        if self._send_task:
+            self._send_task.cancel()
+            self._send_task = None
 
         if exc is None:
             LOGGER.debug("Closed serial connection")

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -194,9 +194,11 @@ class Gateway(asyncio.Protocol):
         """Port was closed unexpectedly."""
         if self._connection_done_future:
             self._connection_done_future.set_result(exc)
+            self._connection_done_future = None
 
         if self._reset_future:
             self._reset_future.cancel()
+            self._reset_future = None
 
         if self._send_task:
             self._send_task.cancel()

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -671,7 +671,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self._ezsp = None
 
         await asyncio.sleep(0.5)
-        await self.startup()
+        await self.connect()
+        await self.initialize()
 
     async def mrequest(
         self,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "pyserial",
         "pyserial-asyncio",
         "voluptuous",
-        "zigpy>=0.47.0",
+        "zigpy>=0.50.0",
     ],
     dependency_links=[
         "https://codeload.github.com/rcloran/pure-pcapy-3/zip/master",

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -306,7 +306,7 @@ def test_data(gw):
     gw._sendq.put_nowait(gw.Terminator)
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(gw._send_task())
+    loop.run_until_complete(gw._send_loop())
     assert write_call_count == 4
 
 

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -339,7 +339,7 @@ async def test_connection_lost_reset_error_propagation(monkeypatch):
             {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
         ),
         app,
-        use_thread=False,
+        use_thread=False,  # required until #484 is merged
     )
 
     asyncio.get_running_loop().call_later(0.1, gw.connection_lost, ValueError())

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -39,7 +39,6 @@ async def test_connect(flow_control, monkeypatch):
 
 
 async def test_connect_threaded(monkeypatch):
-
     appmock = MagicMock()
     transport = MagicMock()
 
@@ -71,7 +70,6 @@ async def test_connect_threaded(monkeypatch):
 
 
 async def test_connect_threaded_failure(monkeypatch):
-
     appmock = MagicMock()
     transport = MagicMock()
 
@@ -249,7 +247,6 @@ def test_close(gw):
 
 
 async def test_reset(gw):
-    gw._loop = asyncio.get_event_loop()
     gw._sendq.put_nowait(sentinel.queue_item)
     fut = asyncio.Future()
     gw._pending = (sentinel.seq, fut)
@@ -270,14 +267,12 @@ async def test_reset(gw):
 
 
 async def test_reset_timeout(gw, monkeypatch):
-    gw._loop = asyncio.get_event_loop()
     monkeypatch.setattr(uart, "RESET_TIMEOUT", 0.1)
     with pytest.raises(asyncio.TimeoutError):
         await gw.reset()
 
 
 async def test_reset_old(gw):
-    gw._loop = asyncio.get_event_loop()
     future = asyncio.get_event_loop().create_future()
     future.set_result(sentinel.result)
     gw._reset_future = future


### PR DESCRIPTION
`startup` internally called `disconnect` in the event of a failure *after* connect but *during* initialization. `disconnect` cancels the reconnect task.

This can be replicated by yanking out a USB coordinator once to get bellows to start reconnecting, and then yanking it out halfway through startup. This problem does not really affect USB coordinators though: if their serial port is present, they probably will work. Only networked coordinators really end up in a situation where the TCP connection succeeds but the port is unusable.

https://github.com/home-assistant/core/issues/75292