### PR TITLE
Fix thread shutdown proxied future race condition

### DIFF
--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -63,7 +63,7 @@ class EventLoopThread:
             self.loop.call_soon_threadsafe(task.cancel)
 
         # Scheduling with `call_later` gives the loop time to propagate cancellation
-        self.loop.call_soon_threadsafe(self.loop.call_later, 0, self.loop.stop)
+        self.loop.call_soon_threadsafe(self.loop.call_later, 0.1, self.loop.stop)
 
 
 class ThreadsafeProxy:

--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -59,11 +59,17 @@ class EventLoopThread:
         if self.loop is None:
             return
 
+        task = None
+
         for task in asyncio.all_tasks(loop=self.loop):
             self.loop.call_soon_threadsafe(task.cancel)
 
-        # Scheduling with `call_later` gives the loop time to propagate cancellation
-        self.loop.call_soon_threadsafe(self.loop.call_later, 0.1, self.loop.stop)
+        if task is not None:
+            # Stop the loop when the last task is done
+            task.add_done_callback(lambda _: self.loop.stop())
+        else:
+            # Scheduling with `call_later` gives the loop time to propagate cancellation
+            self.loop.call_soon_threadsafe(self.loop.call_later, 0, self.loop.stop)
 
 
 class ThreadsafeProxy:


### PR DESCRIPTION
If a proxied future is cancelled by a thread shutdown, the cancellation may not have time to propagate to the outer event loop. This will stall the outer `await`.