### PR TITLE
Add support for tcp protocol

### DIFF
--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -111,11 +111,12 @@ async def setup(dev, baudrate, cbh=None, configure=True):
         s.add_callback(cbh)
     try:
         await s.connect()
+        await s._startup_reset()
     except Exception as e:
         LOGGER.error(e)
+        s.close()
         raise click.Abort()
-    LOGGER.debug("Connected. Resetting.")
-    await s.reset()
+    LOGGER.debug("Connected")
     await s.version()
 
     async def cfg(config_id, value):

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import functools
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union
+import urllib.parse
 
 from zigpy.typing import DeviceType
 
@@ -80,7 +81,8 @@ class EZSP:
     async def _startup_reset(self):
         """Start EZSP and reset the stack."""
         # `zigbeed` resets on startup
-        if self._config[CONF_DEVICE_PATH].startswith("socket://"):
+        parsed_path = urllib.parse.urlparse(self._config[CONF_DEVICE_PATH])
+        if parsed_path.scheme == "socket":
             try:
                 await asyncio.wait_for(
                     self._gw.wait_for_startup_reset(),

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -74,7 +74,26 @@ class EZSP:
     async def _probe(self) -> None:
         """Open port and try sending a command"""
         await self.connect()
+        await self._startup_reset()
         await self.version()
+
+    async def _startup_reset(self):
+        """Start EZSP and reset the stack."""
+        # `zigbeed` resets on startup
+        if self._config[CONF_DEVICE_PATH].startswith("socket://"):
+            try:
+                await asyncio.wait_for(
+                    self._gw.wait_for_startup_reset(),
+                    NETWORK_COORDINATOR_STARTUP_RESET_WAIT,
+                )
+            except asyncio.TimeoutError:
+                pass
+            else:
+                LOGGER.debug("Received a reset on startup, not resetting again")
+                self.start_ezsp()
+
+        if not self.is_ezsp_running:
+            await self.reset()
 
     @classmethod
     async def initialize(cls, zigpy_config: Dict) -> "EZSP":
@@ -82,23 +101,8 @@ class EZSP:
         ezsp = cls(zigpy_config[CONF_DEVICE])
         await ezsp.connect()
 
-        # `zigbeed` resets on startup
-        if zigpy_config[CONF_DEVICE][CONF_DEVICE_PATH].startswith("socket://"):
-            try:
-                await asyncio.wait_for(
-                    ezsp._gw.wait_for_startup_reset(),
-                    NETWORK_COORDINATOR_STARTUP_RESET_WAIT,
-                )
-            except asyncio.TimeoutError:
-                pass
-            else:
-                LOGGER.debug("Received a reset on startup, not resetting again")
-                ezsp.start_ezsp()
-
         try:
-            if not ezsp.is_ezsp_running:
-                await ezsp.reset()
-
+            await ezsp._startup_reset()
             await ezsp.version()
             await ezsp._protocol.initialize(zigpy_config)
 

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -1,10 +1,10 @@
 import asyncio
 import binascii
 import logging
+import urllib.parse
 
 import serial
 import serial_asyncio
-import urllib.parse
 
 from bellows.config import (
     CONF_DEVICE_BAUDRATE,


### PR DESCRIPTION
Add tcp:// protocol to talk to EZSP radio via TCP/IP. Compared to the
existing socket:// protocol this uses Python's loop.create_connection()
instead of pyserial. In tests this makes `bellows info` to complete
about 50x faster (measured after reset, from 0.6s to 0.012s).