### PR TITLE
Use the correct indentation level for the concurrency manager

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -791,13 +791,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         status,
                     )
 
-            # Wait for `messageSentHandler` message
-            send_status, _ = await asyncio.wait_for(req.result, timeout=APS_ACK_TIMEOUT)
-
-            if send_status != t.EmberStatus.SUCCESS:
-                raise zigpy.exceptions.DeliveryError(
-                    f"Failed to deliver message: {send_status!r}", send_status
+                # Wait for `messageSentHandler` message
+                send_status, _ = await asyncio.wait_for(
+                    req.result, timeout=APS_ACK_TIMEOUT
                 )
+
+                if send_status != t.EmberStatus.SUCCESS:
+                    raise zigpy.exceptions.DeliveryError(
+                        f"Failed to deliver message: {send_status!r}", send_status
+                    )
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""


### PR DESCRIPTION
#494 contained a bug where the request concurrency was enforced only for the sending stage, not for the response notification stage.