### PR TITLE
Recalculate bad FCS for protocol versions 8 or newer

### DIFF
--- a/bellows/cli/dump.py
+++ b/bellows/cli/dump.py
@@ -80,7 +80,7 @@ async def _dump(ctx, channel, outfile):
 
             # Later releases of EmberZNet incorrectly use a static FCS
             fcs = data[-2:]
-            if s.ezsp_version == 8:
+            if s.ezsp_version >= 8:
                 computed_fcs = ieee_15_4_fcs(data[0:-2])
                 LOGGER.debug("Fixing FCS (expected %s, got %s)", computed_fcs, fcs)
                 data = data[0:-2] + computed_fcs


### PR DESCRIPTION
Recalculate FCS for EZSP version 8, 9 or newer when capturing ZigBee traffic. 