### PR TITLE
Treat TCP disconnects as lost connections

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -199,8 +199,15 @@ class Gateway(asyncio.Protocol):
         """Delete reset future."""
         self._reset_future = None
 
+    def eof_received(self):
+        """Server gracefully closed its side of the connection."""
+        self.connection_lost(OSError("Server closed connection"))
+
     def connection_lost(self, exc):
         """Port was closed unexpectedly."""
+
+        LOGGER.debug("Connection lost: %r", exc)
+
         if self._connection_done_future:
             self._connection_done_future.set_result(exc)
             self._connection_done_future = None

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -318,6 +318,12 @@ def test_connection_closed(gw):
     assert gw._application.connection_lost.call_count == 0
 
 
+def test_eof_received(gw):
+    gw.eof_received()
+
+    assert gw._application.connection_lost.call_count == 1
+
+
 async def test_connection_lost_reset_error_propagation(monkeypatch):
     app = MagicMock()
     transport = MagicMock()


### PR DESCRIPTION
`protocol.eof_received()` is called when the other side closes the connection. It implicitly calls `protocol.connection_lost(None)`, which breaks reconnection logic.