### PR TITLE
Fix frame counter bug with conversion between zigpy and EZSP key types

### DIFF
--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -86,7 +86,7 @@ def zigpy_key_to_ezsp_key(zigpy_key: zigpy.state.Key, ezsp):
         key.bitmask |= ezsp.types.EmberKeyStructBitmask.KEY_HAS_OUTGOING_FRAME_COUNTER
 
     if zigpy_key.rx_counter is not None:
-        key.outgoingFrameCounter = t.uint32_t(zigpy_key.rx_counter)
+        key.incomingFrameCounter = t.uint32_t(zigpy_key.rx_counter)
         key.bitmask |= ezsp.types.EmberKeyStructBitmask.KEY_HAS_INCOMING_FRAME_COUNTER
 
     if zigpy_key.partner_ieee is not None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -138,8 +138,8 @@ def test_zha_security_hashed_nonstandard_tclk_warning(network_info, node_info, c
 
 
 def test_ezsp_key_to_zigpy_key(zigpy_key, ezsp_key, ezsp_mock):
-    return util.ezsp_key_to_zigpy_key(ezsp_key, ezsp_mock) == zigpy_key
+    assert util.ezsp_key_to_zigpy_key(ezsp_key, ezsp_mock) == zigpy_key
 
 
 def test_zigpy_key_to_ezsp_key(zigpy_key, ezsp_key, ezsp_mock):
-    return util.zigpy_key_to_ezsp_key(zigpy_key, ezsp_mock) == ezsp_key
+    assert util.zigpy_key_to_ezsp_key(zigpy_key, ezsp_mock) == ezsp_key


### PR DESCRIPTION
The unit tests accidentally used `return` instead of `assert` and were actually failing.

The side effect of this bug existing is that the outgoing frame counter was set equal to the incoming frame counter, which is often quite low (or zero) 🤦‍♂️.