### PR TITLE
Ensure the network is running in `reset_network_info`

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -433,6 +433,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await ezsp.setValue(ezsp.types.EzspValueId.VALUE_STACK_TOKEN_WRITING, 1)
 
     async def reset_network_info(self):
+        # The network must be running before we can leave it
+        try:
+            await self._ensure_network_running()
+        except zigpy.exceptions.NetworkNotFormed:
+            return
+
         try:
             (status,) = await self._ezsp.leaveNetwork()
         except bellows.exception.EzspError:

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -485,3 +485,15 @@ async def test_write_network_info_generate_hashed_tclk(app, network_info, node_i
 
     # A new hashed key is randomly generated each time if none is provided
     assert len(seen_keys) == 10
+
+
+async def test_reset_network_with_no_formed_network(app):
+    _mock_app_for_write(app, network_info, node_info)
+
+    app._ezsp.networkState = AsyncMock(
+        return_value=[app._ezsp.types.EmberNetworkStatus.NO_NETWORK]
+    )
+
+    app._ezsp.networkInit = AsyncMock(return_value=[t.EmberStatus.NOT_JOINED])
+
+    await app.reset_network_info()

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -335,7 +335,9 @@ async def test_load_network_info_with_devices(app, network_info, node_info, ezsp
 
 def _mock_app_for_write(app, network_info, node_info, ezsp_ver=None):
     ezsp = app._ezsp
-
+    ezsp.networkState = AsyncMock(
+        return_value=[ezsp.types.EmberNetworkStatus.JOINED_NETWORK]
+    )
     ezsp.leaveNetwork = AsyncMock(return_value=[t.EmberStatus.NETWORK_DOWN])
     ezsp.getEui64 = AsyncMock(
         return_value=[t.EmberEUI64.convert("00:12:4b:00:1c:a1:b8:46")]


### PR DESCRIPTION
`ControllerApplication.reset_network_info` does not actually leave the current network if one isn't currently active.