### PR TITLE
Handle startup reset exception being `None`

### DIFF
--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -213,7 +213,9 @@ class Gateway(asyncio.Protocol):
         # callback to stop itself, which will cause the a future to propagate a
         # `CancelledError` into the active event loop, breaking everything!
         if self._startup_reset_future:
-            self._startup_reset_future.set_exception(exc)
+            self._startup_reset_future.set_exception(
+                exc or OSError("Server closed connection")
+            )
 
         if self._connection_done_future:
             self._connection_done_future.set_result(exc)


### PR DESCRIPTION
https://github.com/zigpy/bellows/pull/524 fails to apply when the connection is gracefully closed by the server and `exc=None`.

Related: https://github.com/home-assistant/core/issues/86800