### PR TITLE
Internally rename LQI to Energy for energy scanning

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -688,9 +688,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             for channel, rssi in results:
                 all_results.setdefault(channel, []).append(rssi)
 
-        # Remap RSSI to LQI
+        # Remap RSSI to Energy
         return {
-            channel: util.remap_rssi_to_lqi(statistics.mean(rssis))
+            channel: util.map_rssi_to_energy(statistics.mean(rssis))
             for channel, rssis in all_results.items()
         }
 

--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -110,11 +110,25 @@ def logistic(x: float, *, L: float = 1, x_0: float = 0, k: float = 1) -> float:
     return L / (1 + math.exp(-k * (x - x_0)))
 
 
-def remap_rssi_to_lqi(rssi: int) -> float:
-    """Remaps RSSI (in dBm) to LQI (0-255)."""
-
+def map_rssi_to_energy(rssi: int) -> float:
+    """Remaps RSSI (in dBm) to Energy (0-255)."""
     return logistic(
         x=rssi,
+        L=255,
+        x_0=RSSI_MIN + 0.45 * (RSSI_MAX - RSSI_MIN),
+        k=0.13,
+    )
+
+
+def logit(y: float, *, L: float = 1, x_0: float = 0, k: float = 1) -> float:
+    """Logit function (inverse of logistic)."""
+    return x_0 - math.log(L / y - 1) / k
+
+
+def map_energy_to_rssi(lqi: float) -> float:
+    """Remaps Energy (0-255) back to RSSI (in dBm)."""
+    return logit(
+        y=lqi,
         L=255,
         x_0=RSSI_MIN + 0.45 * (RSSI_MAX - RSSI_MIN),
         k=0.13,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -145,6 +145,11 @@ def test_zigpy_key_to_ezsp_key(zigpy_key, ezsp_key, ezsp_mock):
     assert util.zigpy_key_to_ezsp_key(zigpy_key, ezsp_mock) == ezsp_key
 
 
-def test_remap_rssi_to_lqi():
-    assert 0 <= util.remap_rssi_to_lqi(-200) <= 0.01
-    assert 254 <= util.remap_rssi_to_lqi(100) <= 255
+def test_map_rssi_to_energy():
+    assert 0 <= util.map_rssi_to_energy(-200) <= 0.01
+    assert 254 <= util.map_rssi_to_energy(100) <= 255
+
+    # Make sure the two functions are inverses
+    for rssi in range(-100, 100):
+        energy = util.map_rssi_to_energy(rssi)
+        assert abs(util.map_energy_to_rssi(energy) - rssi) < 0.1


### PR DESCRIPTION
The units of the 0-255 value for energy scans is just "energy", not LQI. This is just an internal rename.