### PR TITLE
Replace `asyncio.wait_for` with `asyncio.timeout`

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -4,7 +4,13 @@ import asyncio
 import logging
 import os
 import statistics
+import sys
 from typing import Dict, Optional
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
+else:
+    from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 import zigpy.application
 import zigpy.config
@@ -814,9 +820,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     return
 
                 # Wait for `messageSentHandler` message
-                send_status, _ = await asyncio.wait_for(
-                    req.result, timeout=APS_ACK_TIMEOUT
-                )
+                async with asyncio_timeout(APS_ACK_TIMEOUT):
+                    send_status, _ = await req.result
 
                 if send_status != t.EmberStatus.SUCCESS:
                     raise zigpy.exceptions.DeliveryError(
@@ -878,9 +883,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await asyncio.sleep(WATCHDOG_WAKE_PERIOD)
         while True:
             try:
-                await asyncio.wait_for(
-                    self.controller_event.wait(), timeout=WATCHDOG_WAKE_PERIOD * 2
-                )
+                async with asyncio_timeout(WATCHDOG_WAKE_PERIOD * 2):
+                    await self.controller_event.wait()
+
                 if self._ezsp.ezsp_version == 4:
                     await self._ezsp.nop()
                 else:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "pure_pcapy3==1.0.1",
         "voluptuous",
         "zigpy>=0.54.0",
+        'async-timeout; python_version<"3.11"',
     ],
     dependency_links=[
         "https://codeload.github.com/rcloran/pure-pcapy-3/zip/master",

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -60,7 +60,7 @@ def make_app(monkeypatch, event_loop, ezsp_mock):
         app = bellows.zigbee.application.ControllerApplication(app_cfg)
 
         app._ezsp = ezsp_mock
-        monkeypatch.setattr(bellows.zigbee.application, "APS_ACK_TIMEOUT", 0.01)
+        monkeypatch.setattr(bellows.zigbee.application, "APS_ACK_TIMEOUT", 0.05)
         app._ctrl_event.set()
         app._in_flight_msg = asyncio.Semaphore()
         app.handle_message = MagicMock()

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -70,21 +70,21 @@ def test_attr(ezsp_f):
     assert callable(m)
 
 
-def test_non_existent_attr(ezsp_f):
+async def test_non_existent_attr(ezsp_f):
     with pytest.raises(AttributeError):
-        ezsp_f.nonexistentMethod()
+        await ezsp_f.nonexistentMethod()
 
 
-def test_command(ezsp_f):
+async def test_command(ezsp_f):
     ezsp_f.start_ezsp()
     with patch.object(ezsp_f._protocol, "command") as cmd_mock:
-        ezsp_f.nop()
+        await ezsp_f.nop()
     assert cmd_mock.call_count == 1
 
 
-def test_command_ezsp_stopped(ezsp_f):
+async def test_command_ezsp_stopped(ezsp_f):
     with pytest.raises(EzspError):
-        ezsp_f._command("version")
+        await ezsp_f._command("version")
 
 
 async def _test_list_command(ezsp_f, mockcommand):

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -29,7 +29,10 @@ def prot_hndl():
 
 async def test_command(prot_hndl):
     coro = prot_hndl.command("nop")
-    prot_hndl._awaiting[prot_hndl._seq - 1][2].set_result(True)
+    asyncio.get_running_loop().call_soon(
+        lambda: prot_hndl._awaiting[prot_hndl._seq - 1][2].set_result(True)
+    )
+
     await coro
     assert prot_hndl._gw.data.call_count == 1
 


### PR DESCRIPTION
See https://github.com/zigpy/zigpy/pull/1187.

This has the side effect of making `ezsp.Protocol.command` an async function instead of a sync function returning a future.