### PR TITLE
Fix zigbeed network settings persistence bug

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -55,6 +55,11 @@ class EZSP:
         self._gw = None
         self._protocol = None
 
+    @property
+    def is_network_coordinator(self) -> bool:
+        parsed_path = urllib.parse.urlparse(self._config[conf.CONF_DEVICE_PATH])
+        return parsed_path.scheme == "socket"
+
     @classmethod
     async def probe(cls, device_config: dict) -> bool | dict[str, int | str | bool]:
         """Probe port for the device presence."""
@@ -88,8 +93,7 @@ class EZSP:
     async def _startup_reset(self):
         """Start EZSP and reset the stack."""
         # `zigbeed` resets on startup
-        parsed_path = urllib.parse.urlparse(self._config[conf.CONF_DEVICE_PATH])
-        if parsed_path.scheme == "socket":
+        if self.is_network_coordinator:
             try:
                 async with asyncio_timeout(NETWORK_COORDINATOR_STARTUP_RESET_WAIT):
                     await self._gw.wait_for_startup_reset()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -70,7 +70,8 @@ def make_app(monkeypatch, event_loop, ezsp_mock):
 
         return app
 
-    return inner
+    with patch("bellows.zigbee.application.RECONNECT_DELAY_TIME_S", 0):
+        yield inner
 
 
 @pytest.fixture

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -371,6 +371,9 @@ def _mock_app_for_write(app, network_info, node_info, ezsp_ver=None):
     ezsp.setMfgToken = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
     ezsp.can_write_custom_eui64 = AsyncMock(return_value=True)
 
+    app.connect = AsyncMock()
+    app.disconnect = AsyncMock()
+
 
 async def test_write_network_info_failed_leave1(app, network_info, node_info):
     _mock_app_for_write(app, network_info, node_info)


### PR DESCRIPTION
Zigbeed has broken behavior when you try to form a network twice in a row, like we do when forming an initial one when energy scanning. For zigpy, this means that the temporary network we form when running an initial energy scan *is* the main network, ignoring the channel config and other settings we provide.

The only way I could find to fix this behavior (short of an upstream fix) is to disconnect from the serial port and reconnect.