### PR TITLE
Wait for explicit stack messages for network state

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -161,6 +161,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             async with asyncio_timeout(NETWORK_UP_TIMEOUT_S):
                 await stack_status
 
+        return True
+
     async def start_network(self):
         ezsp = self._ezsp
 

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -15,7 +15,7 @@ import zigpy.application
 import zigpy.config
 import zigpy.device
 import zigpy.endpoint
-from zigpy.exceptions import FormationFailure, NetworkNotFormed
+from zigpy.exceptions import NetworkNotFormed
 import zigpy.state
 import zigpy.types
 import zigpy.util
@@ -54,6 +54,7 @@ EZSP_DEFAULT_RADIUS = 0
 EZSP_MULTICAST_NON_MEMBER_RADIUS = 3
 MFG_ID_RESET_DELAY = 180
 RESET_ATTEMPT_BACKOFF_TIME = 5
+NETWORK_UP_TIMEOUT_S = 10
 WATCHDOG_WAKE_PERIOD = 10
 IEEE_PREFIX_MFG_ID = {
     "04:CF:8C": 0x115F,  # Xiaomi
@@ -147,13 +148,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if state == self._ezsp.types.EmberNetworkStatus.JOINED_NETWORK:
             return False
 
-        (init_status,) = await self._ezsp.networkInit()
-        if init_status == t.EmberStatus.SUCCESS:
-            return True
-        elif init_status == t.EmberStatus.NOT_JOINED:
-            raise NetworkNotFormed("Node is not part of a network")
-        else:
-            raise ControllerError(f"Failed to initialize network: {init_status!r}")
+        async with self._ezsp.wait_for_stack_status(
+            t.EmberStatus.NETWORK_UP
+        ) as stack_status:
+            (init_status,) = await self._ezsp.networkInit()
+
+            if init_status == t.EmberStatus.NOT_JOINED:
+                raise NetworkNotFormed("Node is not part of a network")
+            elif init_status != t.EmberStatus.SUCCESS:
+                raise ControllerError(f"Failed to initialize network: {init_status!r}")
+
+            async with asyncio_timeout(NETWORK_UP_TIMEOUT_S):
+                await stack_status
 
     async def start_network(self):
         ezsp = self._ezsp
@@ -387,10 +393,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         (status,) = await ezsp.setInitialSecurityState(initial_security_state)
         assert status == t.EmberStatus.SUCCESS
 
-        # Clear the key table
-        (status,) = await ezsp.clearKeyTable()
-        assert status == t.EmberStatus.SUCCESS
-
         # Write APS link keys
         for key in network_info.key_table:
             ember_key = util.zigpy_key_to_ezsp_key(key, ezsp)
@@ -429,7 +431,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         parameters.channels = t.Channels(network_info.channel_mask)
 
         await ezsp.formNetwork(parameters)
-        await ezsp.setValue(ezsp.types.EzspValueId.VALUE_STACK_TOKEN_WRITING, 1)
 
     async def reset_network_info(self):
         # The network must be running before we can leave it
@@ -438,13 +439,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         except zigpy.exceptions.NetworkNotFormed:
             return
 
-        try:
-            (status,) = await self._ezsp.leaveNetwork()
-        except bellows.exception.EzspError:
-            pass
-        else:
-            if status != t.EmberStatus.NETWORK_DOWN:
-                raise FormationFailure("Couldn't leave network")
+        await self._ezsp.leaveNetwork()
+
+        # Clear the key table
+        (status,) = await self._ezsp.clearKeyTable()
+        assert status == t.EmberStatus.SUCCESS
 
     async def disconnect(self):
         # TODO: how do you shut down the stack?

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -47,6 +47,11 @@ def ezsp_mock():
     ezsp.get_board_info = AsyncMock(
         return_value=("Mock Manufacturer", "Mock board", "Mock version")
     )
+    ezsp.wait_for_stack_status = MagicMock()
+    ezsp.wait_for_stack_status.return_value.__aenter__.return_value = AsyncMock(
+        return_value=t.EmberStatus.NETWORK_UP
+    )()
+
     type(ezsp).types = ezsp_t7
     type(ezsp).is_ezsp_running = PropertyMock(return_value=True)
 

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -372,23 +372,6 @@ def _mock_app_for_write(app, network_info, node_info, ezsp_ver=None):
     ezsp.can_write_custom_eui64 = AsyncMock(return_value=True)
 
 
-async def test_write_network_info_failed_leave1(app, network_info, node_info):
-    _mock_app_for_write(app, network_info, node_info)
-
-    app._ezsp.leaveNetwork.return_value = [t.EmberStatus.BAD_ARGUMENT]
-
-    with pytest.raises(zigpy.exceptions.FormationFailure):
-        await app.write_network_info(network_info=network_info, node_info=node_info)
-
-
-async def test_write_network_info_failed_leave2(app, network_info, node_info):
-    _mock_app_for_write(app, network_info, node_info)
-
-    app._ezsp.leaveNetwork.side_effect = EzspError("failed to leave network")
-
-    await app.write_network_info(network_info=network_info, node_info=node_info)
-
-
 @pytest.mark.parametrize("ezsp_ver", [4, 7])
 async def test_write_network_info(app, network_info, node_info, ezsp_ver):
     _mock_app_for_write(app, network_info, node_info, ezsp_ver)


### PR DESCRIPTION
Looks like #553 affected more than just zigbeed, as I've been able to replicate it on EmberZNet 6.9 and 7.1 with NCP USB coordinators...

The root cause appears to be us not properly waiting for stack events to happen (i.e. `NETWORK_UP` and `NETWORK_DOWN`), leading to race conditions or outright failures at random.