### PR TITLE
HUSBZB-1 config regression fix for Aqara devices

### DIFF
--- a/bellows/ezsp/config.py
+++ b/bellows/ezsp/config.py
@@ -14,20 +14,7 @@ class RuntimeConfig:
     minimum: bool = False
 
 
-DEFAULT_CONFIG = [
-    RuntimeConfig(
-        config_id=types_v4.EzspConfigId.CONFIG_SOURCE_ROUTE_TABLE_SIZE,
-        value=200,
-        minimum=True,
-    ),
-    RuntimeConfig(
-        config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT,
-        value=60,
-    ),
-    RuntimeConfig(
-        config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT,
-        value=8,
-    ),
+DEFAULT_CONFIG_COMMON = [
     RuntimeConfig(
         config_id=types_v4.EzspConfigId.CONFIG_INDIRECT_TRANSMISSION_TIMEOUT,
         value=7680,
@@ -61,10 +48,6 @@ DEFAULT_CONFIG = [
         minimum=True,
     ),
     RuntimeConfig(
-        config_id=types_v6.EzspConfigId.CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S,
-        value=90,
-    ),
-    RuntimeConfig(
         config_id=types_v4.EzspConfigId.CONFIG_PAN_ID_CONFLICT_REPORT_THRESHOLD,
         value=2,
     ),
@@ -78,3 +61,49 @@ DEFAULT_CONFIG = [
     # Must be set last
     RuntimeConfig(types_v4.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT, value=0xFF),
 ]
+
+DEFAULT_CONFIG_LEGACY = [
+    RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_SOURCE_ROUTE_TABLE_SIZE,
+        value=16,
+        minimum=True,
+    ),
+    RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT,
+        value=60,
+    ),
+    RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT,
+        value=8,
+    ),
+] + DEFAULT_CONFIG_COMMON
+
+
+DEFAULT_CONFIG_NEW = [
+    RuntimeConfig(
+        config_id=types_v6.EzspConfigId.CONFIG_SOURCE_ROUTE_TABLE_SIZE,
+        value=200,
+        minimum=True,
+    ),
+    RuntimeConfig(
+        config_id=types_v6.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT,
+        value=8,
+    ),
+    RuntimeConfig(
+        config_id=(
+            types_v6.EzspConfigId.CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S
+        ),
+        value=90,
+    ),
+] + DEFAULT_CONFIG_COMMON
+
+
+DEFAULT_CONFIG = {
+    4: DEFAULT_CONFIG_LEGACY,
+    5: DEFAULT_CONFIG_LEGACY,
+    6: DEFAULT_CONFIG_LEGACY,
+    7: DEFAULT_CONFIG_NEW,
+    8: DEFAULT_CONFIG_NEW,
+    9: DEFAULT_CONFIG_NEW,
+    10: DEFAULT_CONFIG_NEW,
+}

--- a/bellows/ezsp/config.py
+++ b/bellows/ezsp/config.py
@@ -52,6 +52,16 @@ DEFAULT_CONFIG_COMMON = [
         value=2,
     ),
     RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_KEY_TABLE_SIZE,
+        value=4,
+        minimum=True,
+    ),
+    RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN,
+        value=32,
+        minimum=True,
+    ),
+    RuntimeConfig(
         config_id=types_v4.EzspConfigId.CONFIG_APPLICATION_ZDO_FLAGS,
         value=(
             t.EmberZdoConfigurationFlags.APP_RECEIVES_SUPPORTED_ZDO_REQUESTS

--- a/bellows/ezsp/config.py
+++ b/bellows/ezsp/config.py
@@ -22,6 +22,10 @@ DEFAULT_CONFIG = [
     ),
     RuntimeConfig(
         config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT,
+        value=60,
+    ),
+    RuntimeConfig(
+        config_id=types_v4.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT,
         value=8,
     ),
     RuntimeConfig(

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -71,15 +71,11 @@ class ProtocolHandler(abc.ABC):
         # Not all config will be present in every EZSP version so only use valid keys
         ezsp_config = {}
 
-        for cfg in DEFAULT_CONFIG:
-            try:
-                config_id = self.types.EzspConfigId[cfg.config_id.name]
-            except KeyError:
-                pass
-            else:
-                ezsp_config[cfg.config_id.name] = dataclasses.replace(
-                    cfg, config_id=config_id
-                )
+        for cfg in DEFAULT_CONFIG[self.EZSP_VERSION]:
+            config_id = self.types.EzspConfigId[cfg.config_id.name]
+            ezsp_config[cfg.config_id.name] = dataclasses.replace(
+                cfg, config_id=config_id
+            )
 
         # Override the defaults with user-specified values (or `None` for deletions)
         for name, value in self.SCHEMAS[CONF_EZSP_CONFIG](

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -96,14 +96,33 @@ async def test_cfg_initialize(prot_hndl, caplog):
 async def test_config_initialize_husbzb1(prot_hndl):
     """Test timeouts are properly set for HUSBZB-1."""
 
-    prot_hndl.getConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, 22))
+    prot_hndl.getConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, 0))
     prot_hndl.setConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
 
     await prot_hndl.initialize({"ezsp_config": {}})
     prot_hndl.setConfigurationValue.assert_has_calls(
         [
+            call(t.EzspConfigId.CONFIG_SOURCE_ROUTE_TABLE_SIZE, 16),
             call(t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT, 60),
             call(t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, 8),
+            call(t.EzspConfigId.CONFIG_INDIRECT_TRANSMISSION_TIMEOUT, 7680),
+            call(t.EzspConfigId.CONFIG_STACK_PROFILE, 2),
+            call(t.EzspConfigId.CONFIG_SUPPORTED_NETWORKS, 1),
+            call(t.EzspConfigId.CONFIG_MULTICAST_TABLE_SIZE, 16),
+            call(t.EzspConfigId.CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE, 2),
+            call(t.EzspConfigId.CONFIG_SECURITY_LEVEL, 5),
+            call(t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE, 16),
+            call(t.EzspConfigId.CONFIG_PAN_ID_CONFLICT_REPORT_THRESHOLD, 2),
+            call(t.EzspConfigId.CONFIG_KEY_TABLE_SIZE, 4),
+            call(t.EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN, 32),
+            call(
+                t.EzspConfigId.CONFIG_APPLICATION_ZDO_FLAGS,
+                (
+                    t.EmberZdoConfigurationFlags.APP_HANDLES_UNSUPPORTED_ZDO_REQUESTS
+                    | t.EmberZdoConfigurationFlags.APP_RECEIVES_SUPPORTED_ZDO_REQUESTS
+                ),
+            ),
+            call(t.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT, 255),
         ]
     )
 


### PR DESCRIPTION
#550 introduced a major regression for older coordinators. Below are the previous EZSP configurations:

```python
v4 set CONFIG_ADDRESS_TABLE_SIZE = 16
v4 set CONFIG_APPLICATION_ZDO_FLAGS = 3
v4 set CONFIG_END_DEVICE_POLL_TIMEOUT = 60
v4 set CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT = 8
v4 set CONFIG_INDIRECT_TRANSMISSION_TIMEOUT = 7680
v4 set CONFIG_KEY_TABLE_SIZE = 4
v4 set CONFIG_MAX_END_DEVICE_CHILDREN = 32
v4 set CONFIG_MULTICAST_TABLE_SIZE = 16
v4 set CONFIG_PACKET_BUFFER_COUNT = 255
v4 set CONFIG_PAN_ID_CONFLICT_REPORT_THRESHOLD = 2
v4 set CONFIG_SECURITY_LEVEL = 5
v4 set CONFIG_SOURCE_ROUTE_TABLE_SIZE = 16
v4 set CONFIG_STACK_PROFILE = 2
v4 set CONFIG_SUPPORTED_NETWORKS = 1
v4 set CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE = 2

v7 changed CONFIG_END_DEVICE_POLL_TIMEOUT = 8 (was 60)
v7 changed CONFIG_KEY_TABLE_SIZE = 12 (was 4)

v8 set CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S = 90
```

EZSP v7 renamed `CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT` to `CONFIG_END_DEVICE_POLL_TIMEOUT`. The earlier PR missed this and the end result is that child devices that poll very infrequently (i.e. Aqara) will be aged out quickly by the coordinator.

---

https://github.com/home-assistant/core/issues/92581