### PR TITLE
Write custom EUI64 to NV3 storage if available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           - --quiet-level=2
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -679,16 +679,16 @@ COMMANDS = {
     "getSecurityKeyStatus": (0x00CD, (), (t.EzspStatus, t.SecureEzspSecurityType)),
     # 18 Token Interface Frames
     "getTokenCount": (0x0100, (), (t.uint8_t,)),
-    "getTokenInfo": (0x0101, (t.uint8_t,), (t.EmberStatus)),
+    "getTokenInfo": (0x0101, (t.uint8_t,), (t.EmberStatus, t.EmberTokenInfo)),
     "getTokenData": (
         0x0102,
         (t.uint32_t, t.uint32_t),
-        (t.EmberStatus, t.EmberTokenData),
+        (t.EmberStatus, t.LVBytes32),
     ),
     "setTokenData": (
         0x0103,
-        (t.uint32_t, t.uint32_t, t.EmberTokenData),
-        (t.EmberStatus),
+        (t.uint32_t, t.uint32_t, t.LVBytes32),
+        (t.EmberStatus,),
     ),
     "resetNode": (0x0104, (), ()),
 }

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -675,16 +675,16 @@ COMMANDS = {
     "getSecurityKeyStatus": (0x00CD, (), (t.EzspStatus, t.SecureEzspSecurityType)),
     # 18 Token Interface Frames
     "getTokenCount": (0x0100, (), (t.uint8_t,)),
-    "getTokenInfo": (0x0101, (t.uint8_t,), (t.EmberStatus)),
+    "getTokenInfo": (0x0101, (t.uint8_t,), (t.EmberStatus, t.EmberTokenInfo)),
     "getTokenData": (
         0x0102,
         (t.uint32_t, t.uint32_t),
-        (t.EmberStatus, t.EmberTokenData),
+        (t.EmberStatus, t.LVBytes32),
     ),
     "setTokenData": (
         0x0103,
-        (t.uint32_t, t.uint32_t, t.EmberTokenData),
-        (t.EmberStatus),
+        (t.uint32_t, t.uint32_t, t.LVBytes32),
+        (t.EmberStatus,),
     ),
     "resetNode": (0x0104, (), ()),
 }

--- a/bellows/types/basic.py
+++ b/bellows/types/basic.py
@@ -97,6 +97,20 @@ class LVBytes(bytes):
         return s, data[bytes + 1 :]
 
 
+class LVBytes32(LVBytes):
+    def serialize(self):
+        return uint32_t(len(self)).serialize() + self
+
+    @classmethod
+    def deserialize(cls, data):
+        length, data = uint32_t.deserialize(data)
+
+        if len(data) < length:
+            raise ValueError(f"Data is too short: expected {length}, got {len(data)}")
+
+        return data[:length], data[length:]
+
+
 class _List(list):
     _length = None
 

--- a/bellows/types/named.py
+++ b/bellows/types/named.py
@@ -1893,3 +1893,115 @@ class EmberStackError(basic.enum16):
     ZIGBEE_NETWORK_STATUS_BAD_FRAME_COUNTER = 0x11
     ZIGBEE_NETWORK_STATUS_BAD_KEY_SEQUENCE_NUMBER = 0x12
     ZIGBEE_NETWORK_STATUS_UNKNOWN_COMMAND = 0x13
+
+
+class NV3KeyId(basic.enum32):
+    """NV3 key IDs."""
+
+    # Creator keys
+    CREATOR_STACK_NVDATA_VERSION = 0x0000_FF01
+    CREATOR_STACK_BOOT_COUNTER = 0x0000_E263
+    CREATOR_STACK_NONCE_COUNTER = 0x0000_E563
+    CREATOR_STACK_ANALYSIS_REBOOT = 0x0000_E162
+    CREATOR_STACK_KEYS = 0x0000_EB79
+    CREATOR_STACK_NODE_DATA = 0x0000_EE64
+    CREATOR_STACK_CLASSIC_DATA = 0x0000_E364
+    CREATOR_STACK_ALTERNATE_KEY = 0x0000_E475
+    CREATOR_STACK_APS_FRAME_COUNTER = 0x0000_E123
+    CREATOR_STACK_TRUST_CENTER = 0x0000_E124
+    CREATOR_STACK_NETWORK_MANAGEMENT = 0x0000_E125
+    CREATOR_STACK_PARENT_INFO = 0x0000_E126
+    CREATOR_STACK_PARENT_ADDITIONAL_INFO = 0x0000_E127
+    CREATOR_STACK_MULTI_PHY_NWK_INFO = 0x0000_E128
+    CREATOR_STACK_MIN_RECEIVED_RSSI = 0x0000_E129
+    CREATOR_STACK_RESTORED_EUI64 = 0x0000_E12A
+
+    CREATOR_MULTI_NETWORK_STACK_KEYS = 0x0000_E210
+    CREATOR_MULTI_NETWORK_STACK_NODE_DATA = 0x0000_E211
+    CREATOR_MULTI_NETWORK_STACK_ALTERNATE_KEY = 0x0000_E212
+    CREATOR_MULTI_NETWORK_STACK_TRUST_CENTER = 0x0000_E213
+    CREATOR_MULTI_NETWORK_STACK_NETWORK_MANAGEMENT = 0x0000_E214
+    CREATOR_MULTI_NETWORK_STACK_PARENT_INFO = 0x0000_E215
+
+    # A temporary solution for multi-network nwk counters:
+    # This counter will be used on the network with index 1.
+    CREATOR_MULTI_NETWORK_STACK_NONCE_COUNTER = 0x0000_E220
+    CREATOR_MULTI_NETWORK_STACK_PARENT_ADDITIONAL_INFO = 0x0000_E221
+
+    CREATOR_STACK_GP_DATA = 0x0000_E258
+    CREATOR_STACK_GP_PROXY_TABLE = 0x0000_E259
+    CREATOR_STACK_GP_SINK_TABLE = 0x0000_E25A
+    CREATOR_STACK_GP_INCOMING_FC = 0x0000_E25B
+    CREATOR_STACK_GP_INCOMING_FC_IN_SINK = 0x0000_E25C
+
+    CREATOR_STACK_BINDING_TABLE = 0x0000_E274
+    CREATOR_STACK_CHILD_TABLE = 0x0000_FF0D
+    CREATOR_STACK_KEY_TABLE = 0x0000_E456
+    CREATOR_STACK_CERTIFICATE_TABLE = 0x0000_E500
+    CREATOR_STACK_ZLL_DATA = 0x0000_E501
+    CREATOR_STACK_ZLL_SECURITY = 0x0000_E502
+    CREATOR_STACK_ADDITIONAL_CHILD_DATA = 0x0000_E503
+
+    # Stack keys
+    NVM3KEY_STACK_NVDATA_VERSION = 0x0001_FF01
+    NVM3KEY_STACK_BOOT_COUNTER = 0x0001_E263
+    NVM3KEY_STACK_NONCE_COUNTER = 0x0001_E563
+    NVM3KEY_STACK_ANALYSIS_REBOOT = 0x0001_E162
+    NVM3KEY_STACK_KEYS = 0x0001_EB79
+    NVM3KEY_STACK_NODE_DATA = 0x0001_EE64
+    NVM3KEY_STACK_CLASSIC_DATA = 0x0001_E364
+    NVM3KEY_STACK_ALTERNATE_KEY = 0x0001_E475
+    NVM3KEY_STACK_APS_FRAME_COUNTER = 0x0001_E123
+    NVM3KEY_STACK_TRUST_CENTER = 0x0001_E124
+    NVM3KEY_STACK_NETWORK_MANAGEMENT = 0x0001_E125
+    NVM3KEY_STACK_PARENT_INFO = 0x0001_E126
+    NVM3KEY_STACK_PARENT_ADDITIONAL_INFO = 0x0001_E127
+    NVM3KEY_STACK_MULTI_PHY_NWK_INFO = 0x0001_E128
+    NVM3KEY_STACK_MIN_RECEIVED_RSSI = 0x0001_E129
+    NVM3KEY_STACK_RESTORED_EUI64 = 0x0001_E12A
+
+    # MULTI-NETWORK STACK KEYS
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_KEYS = 0x0001_0000
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_NODE_DATA = 0x0001_0080
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_ALTERNATE_KEY = 0x0001_0100
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_TRUST_CENTER = 0x0001_0180
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_NETWORK_MANAGEMENT = 0x0001_0200
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_MULTI_NETWORK_STACK_PARENT_INFO = 0x0001_0280
+
+    # Temporary solution for multi-network nwk counters:
+    # This counter will be used on the network with index 1.
+    NVM3KEY_MULTI_NETWORK_STACK_NONCE_COUNTER = 0x0001_E220
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved
+    NVM3KEY_MULTI_NETWORK_STACK_PARENT_ADDITIONAL_INFO = 0x0001_0300
+
+    # GP stack tokens.
+    NVM3KEY_STACK_GP_DATA = 0x0001_E258
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_GP_PROXY_TABLE = 0x0001_0380
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_GP_SINK_TABLE = 0x0001_0400
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved
+    NVM3KEY_STACK_GP_INCOMING_FC = 0x0001_0480
+
+    # APP KEYS
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_BINDING_TABLE = 0x0001_0500
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_CHILD_TABLE = 0x0001_0580
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_KEY_TABLE = 0x0001_0600
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_CERTIFICATE_TABLE = 0x0001_0680
+    NVM3KEY_STACK_ZLL_DATA = 0x0001_E501
+    NVM3KEY_STACK_ZLL_SECURITY = 0x0001_E502
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved.
+    NVM3KEY_STACK_ADDITIONAL_CHILD_DATA = 0x0001_0700
+
+    # This key is used for an indexed token and the subsequent 0x7F keys are also reserved
+    NVM3KEY_STACK_GP_INCOMING_FC_IN_SINK = 0x0001_0780

--- a/bellows/types/struct.py
+++ b/bellows/types/struct.py
@@ -298,7 +298,7 @@ class EmberTokenData(EzspStruct):
 class EmberTokenInfo(EzspStruct):
     # Information of a token in the token table
     # NVM3 key of the token
-    nvm3Key: basic.uint32_t
+    nvm3Key: named.NV3KeyId
     # Token is a counter type
     isCnt: named.Bool
     # Token is an indexed token
@@ -306,7 +306,7 @@ class EmberTokenInfo(EzspStruct):
     # Size of the token
     size: basic.uint8_t
     # Array size of the token
-    arraSize: basic.uint8_t
+    arraySize: basic.uint8_t
 
 
 class EmberTokTypeStackZllData(EzspStruct):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -137,7 +137,8 @@ async def _test_startup(
     ezsp_mock.setConfigurationValue = AsyncMock(return_value=t.EmberStatus.SUCCESS)
     ezsp_mock.networkInit = AsyncMock(return_value=[init])
     ezsp_mock.getNetworkParameters = AsyncMock(return_value=[0, nwk_type, nwk_params])
-    ezsp_mock.can_write_custom_eui64 = AsyncMock(return_value=True)
+    ezsp_mock.can_burn_userdata_custom_eui64 = AsyncMock(return_value=True)
+    ezsp_mock.can_rewrite_custom_eui64 = AsyncMock(return_value=True)
     ezsp_mock.startScan = AsyncMock(return_value=[[c, 1] for c in range(11, 26 + 1)])
 
     if board_info:

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -370,6 +370,7 @@ def _mock_app_for_write(app, network_info, node_info, ezsp_ver=None):
     ezsp.setValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
     ezsp.setMfgToken = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
     ezsp.can_write_custom_eui64 = AsyncMock(return_value=True)
+    ezsp.getTokenData = AsyncMock(return_value=[t.EmberStatus.LIBRARY_NOT_PRESENT, b""])
 
 
 @pytest.mark.parametrize("ezsp_ver", [4, 7])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -23,6 +23,17 @@ def test_lvbytes():
 
     assert t.LVBytes.serialize(d) == b"\x041234"
 
+    with pytest.raises(ValueError):
+        t.LVBytes.deserialize(b"\x04123")
+
+
+def test_lvbytes32():
+    d, r = t.LVBytes32.deserialize(b"\x04\x00\x00\x0012345")
+    assert r == b"5"
+    assert d == b"1234"
+
+    assert t.LVBytes32.serialize(d) == b"\x04\x00\x00\x001234"
+
 
 def test_lvlist():
     d, r = t.LVList(t.uint8_t).deserialize(b"\x0412345")


### PR DESCRIPTION
From the Gecko SDK 4.3.0 release notes:


> Zigbeed now includes an implementation of `emberGetRestoredEui64()` which loads the `CREATOR_STACK_RESTORED_EUI64` token
> from the `host_token.nvm` file.

This finally bypasses the dreaded `i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it` limitation, allowing for a coordinator's IEEE address to be overwritten without any issues.

---

TODO:

- [x] Test with RCP firmware with `zigbeed`: works with the latest Gecko SDK release (v4.3.0).
- [x] Does it actually work? Is this IEEE address actually used in all tables and during network management?
- [x] Investigate if this works with NCP firmware (probably requires the NV3 component to be compiled into the firmware)