### PR TITLE
Handle `getTokenData` command missing

### DIFF
--- a/bellows/exception.py
+++ b/bellows/exception.py
@@ -5,5 +5,9 @@ class EzspError(APIException):
     pass
 
 
+class InvalidCommandError(EzspError):
+    pass
+
+
 class ControllerError(ControllerException):
     pass

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -13,7 +13,7 @@ else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES
-from bellows.exception import EzspError
+from bellows.exception import InvalidCommandError
 from bellows.typing import GatewayType
 
 LOGGER = logging.getLogger(__name__)
@@ -192,7 +192,7 @@ class ProtocolHandler(abc.ABC):
                 if frame_name == "invalidCommand":
                     sent_cmd_name = self.COMMANDS_BY_ID[expected_id][0]
                     future.set_exception(
-                        EzspError(
+                        InvalidCommandError(
                             f"{sent_cmd_name} command is an {frame_name}, was sent "
                             f"under {sequence} sequence number: {result[0].name}"
                         )

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -504,7 +504,11 @@ async def test_leave_network(ezsp_f):
 
 @pytest.mark.parametrize(
     "value, expected_result",
-    [(b"\xFF" * 8, True), (bytes.fromhex("0846b8a11c004b1200"), False), (b"", False)],
+    [
+        (b"\xFF" * 8, True),
+        (bytes.fromhex("0846b8a11c004b1200"), False),
+        (b"", False),
+    ],
 )
 async def test_can_burn_userdata_custom_eui64(ezsp_f, value, expected_result):
     """Test detecting if a custom EUI64 has been written."""


### PR DESCRIPTION
Some versions of EmberZNet do not include the command at all, even if it is defined in the EZSP version.

https://github.com/home-assistant/core/issues/95632