### PR TITLE
Use shared PyPi release workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish distributions to PyPI
 on:
   release:
     types:
-      - released
+      - published
 
 jobs:
   shared-build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,5 @@ on:
 jobs:
   shared-build-and-publish:
     uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
-    with:
-      PYTHON_VERSION_DEFAULT: 3.9.15
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,26 +1,14 @@
-name: Publish distributions to PyPI and TestPyPI
+name: Publish distributions to PyPI
+
 on:
   release:
     types:
       - released
 
 jobs:
-  build-and-publish:
-    name: Build and publish distributions to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install wheel
-      run: >-
-        pip install wheel build
-    - name: Build
-      run: >-
-        python3 -m build
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
+  shared-build-and-publish:
+    uses: zigpy/workflows/.github/workflows/publish-to-pypi.yml@main
+    with:
+      PYTHON_VERSION_DEFAULT: 3.9.15
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Migrates the PyPi publishing workflow to the shared workflow. (Reference: https://github.com/zigpy/zigpy/pull/1239)

The previous publishing workflow for bellows used Python 3.8
However, bellows already uses the shared CI workflow with Python 3.9.15 (like the other repos), so it should be good to also change it here.