### PR TITLE
Force TX after CCA failure on EZSP v7+

### DIFF
--- a/bellows/ezsp/config.py
+++ b/bellows/ezsp/config.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import dataclasses
+import typing
 
 import bellows.ezsp.v4.types as types_v4
 import bellows.ezsp.v6.types as types_v6
+import bellows.ezsp.v7.types as types_v7
 import bellows.types as t
 
 
@@ -12,6 +14,12 @@ class RuntimeConfig:
     config_id: t.enum8
     value: int
     minimum: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class ValueConfig:
+    value_id: t.enum8
+    value: typing.Any
 
 
 DEFAULT_CONFIG_COMMON = [
@@ -104,6 +112,10 @@ DEFAULT_CONFIG_NEW = [
             types_v6.EzspConfigId.CONFIG_TC_REJOINS_USING_WELL_KNOWN_KEY_TIMEOUT_S
         ),
         value=90,
+    ),
+    ValueConfig(
+        value_id=types_v7.EzspValueId.VALUE_FORCE_TX_AFTER_FAILED_CCA_ATTEMPTS,
+        value=t.uint8_t(1),
     ),
 ] + DEFAULT_CONFIG_COMMON
 

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -99,13 +99,13 @@ class ProtocolHandler(abc.ABC):
 
         # First, set the values
         for cfg in ezsp_values.values():
+            # XXX: A read failure does not mean the value is not writeable!
             status, current_value = await self.getValue(cfg.value_id)
 
-            if status != self.types.EmberStatus.SUCCESS:
-                LOGGER.debug("Could not read value %s, ignoring", cfg.value_id.name)
-                continue
-
-            current_value, _ = type(cfg.value).deserialize(current_value)
+            if status == self.types.EmberStatus.SUCCESS:
+                current_value, _ = type(cfg.value).deserialize(current_value)
+            else:
+                current_value = None
 
             LOGGER.debug(
                 "Setting value %s = %s (old value %s)",

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -123,11 +123,11 @@ async def test_config_initialize(prot_hndl_cls, caplog):
     if prot_hndl_cls.VERSION < 7:
         return
 
-    with caplog.at_level(logging.DEBUG):
-        prot_hndl.getValue.return_value = (t.EzspStatus.ERROR_INVALID_ID, b"")
-        await prot_hndl.initialize({"ezsp_config": {}})
+    prot_hndl.setValue.reset_mock()
+    prot_hndl.getValue.return_value = (t.EzspStatus.ERROR_INVALID_ID, b"")
+    await prot_hndl.initialize({"ezsp_config": {}})
+    assert len(prot_hndl.setValue.mock_calls) == 1
 
-    assert "Could not read value" in caplog.text
     prot_hndl.getValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, b"\xFF"))
     caplog.clear()
 


### PR DESCRIPTION
`EMBER_VALUE_FORCE_TX_AFTER_FAILED_CCA_ATTEMPTS` seems to work in the latest Gecko SDK release! This allows the radio to force a transmit, even after CCA failures.

Normally this sounds like a bad idea but the alternative is to allow the radio to silently fail with a generic "delivery error" (TODO: figure out a way to infer the actual error code).