### PR TITLE
Repair incorrect TCLK partner IEEE address on startup

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -500,7 +500,9 @@ class EZSP:
         LOGGER.debug("Set concentrator type: %s", res)
         if res[0] != self.types.EmberStatus.SUCCESS:
             LOGGER.warning("Couldn't set concentrator type %s: %s", True, res)
-        await self._protocol.set_source_routing()
+
+        if self._ezsp_version >= 8:
+            await self.setSourceRouteDiscoveryMode(1)
 
     def start_ezsp(self):
         """Mark EZSP as running."""

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -419,6 +419,20 @@ class EZSP:
         """Checks if the device EUI64 can be written any number of times."""
         return await self._get_nv3_restored_eui64_key() is not None
 
+    async def reset_custom_eui64(self) -> None:
+        """Reset the custom EUI64, if possible."""
+
+        nv3_eui64_key = await self._get_nv3_restored_eui64_key()
+        if nv3_eui64_key is None:
+            return
+
+        (status,) = await self.setTokenData(
+            nv3_eui64_key,
+            0,
+            t.LVBytes32(t.EmberEUI64.convert("FF:FF:FF:FF:FF:FF:FF:FF").serialize()),
+        )
+        assert status == t.EmberStatus.SUCCESS
+
     async def write_custom_eui64(
         self, ieee: t.EUI64, *, burn_into_userdata: bool = False
     ) -> None:

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -529,12 +529,13 @@ class EZSP:
 
     async def write_config(self, config: dict) -> None:
         """Initialize EmberZNet Stack."""
+        config = self._protocol.SCHEMAS[conf.CONF_EZSP_CONFIG](config)
 
         # Not all config will be present in every EZSP version so only use valid keys
         ezsp_config = {}
         ezsp_values = {}
 
-        for cfg in DEFAULT_CONFIG[self.VERSION]:
+        for cfg in DEFAULT_CONFIG[self._ezsp_version]:
             if isinstance(cfg, RuntimeConfig):
                 ezsp_config[cfg.config_id.name] = dataclasses.replace(
                     cfg, config_id=self.types.EzspConfigId[cfg.config_id.name]
@@ -545,9 +546,7 @@ class EZSP:
                 )
 
         # Override the defaults with user-specified values (or `None` for deletions)
-        for name, value in self._protocol.SCHEMAS[conf.CONF_EZSP_CONFIG](
-            config
-        ).items():
+        for name, value in config.items():
             if value is None:
                 ezsp_config.pop(name)
                 continue

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -1,18 +1,17 @@
 import abc
 import asyncio
 import binascii
-import dataclasses
 import functools
 import logging
 import sys
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout  # pragma: no cover
 else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
-from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES
+from bellows.config import CONF_EZSP_POLICIES
 from bellows.exception import InvalidCommandError
 from bellows.typing import GatewayType
 
@@ -54,111 +53,6 @@ class ProtocolHandler(abc.ABC):
 
     async def pre_permit(self, time_s: int) -> None:
         """Schedule task before allowing new joins."""
-
-    async def initialize(self, zigpy_config: Dict) -> None:
-        """Initialize EmberZNet Stack."""
-
-        # Prevent circular import
-        from bellows.ezsp.config import DEFAULT_CONFIG, RuntimeConfig, ValueConfig
-
-        # Not all config will be present in every EZSP version so only use valid keys
-        ezsp_config = {}
-        ezsp_values = {}
-
-        for cfg in DEFAULT_CONFIG[self.VERSION]:
-            if isinstance(cfg, RuntimeConfig):
-                ezsp_config[cfg.config_id.name] = dataclasses.replace(
-                    cfg, config_id=self.types.EzspConfigId[cfg.config_id.name]
-                )
-            elif isinstance(cfg, ValueConfig):
-                ezsp_values[cfg.value_id.name] = dataclasses.replace(
-                    cfg, value_id=self.types.EzspValueId[cfg.value_id.name]
-                )
-
-        # Override the defaults with user-specified values (or `None` for deletions)
-        for name, value in self.SCHEMAS[CONF_EZSP_CONFIG](
-            zigpy_config[CONF_EZSP_CONFIG]
-        ).items():
-            if value is None:
-                ezsp_config.pop(name)
-                continue
-
-            ezsp_config[name] = RuntimeConfig(
-                config_id=self.types.EzspConfigId[name],
-                value=value,
-            )
-
-        # Make sure CONFIG_PACKET_BUFFER_COUNT is always set last
-        if self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name in ezsp_config:
-            ezsp_config = {
-                **ezsp_config,
-                self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name: ezsp_config[
-                    self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name
-                ],
-            }
-
-        # First, set the values
-        for cfg in ezsp_values.values():
-            # XXX: A read failure does not mean the value is not writeable!
-            status, current_value = await self.getValue(cfg.value_id)
-
-            if status == self.types.EmberStatus.SUCCESS:
-                current_value, _ = type(cfg.value).deserialize(current_value)
-            else:
-                current_value = None
-
-            LOGGER.debug(
-                "Setting value %s = %s (old value %s)",
-                cfg.value_id.name,
-                cfg.value,
-                current_value,
-            )
-
-            (status,) = await self.setValue(cfg.value_id, cfg.value.serialize())
-
-            if status != self.types.EmberStatus.SUCCESS:
-                LOGGER.debug(
-                    "Could not set value %s = %s: %s",
-                    cfg.value_id.name,
-                    cfg.value,
-                    status,
-                )
-                continue
-
-        # Finally, set the config
-        for cfg in ezsp_config.values():
-            (status, current_value) = await self.getConfigurationValue(cfg.config_id)
-
-            # Only grow some config entries, all others should be set
-            if (
-                status == self.types.EmberStatus.SUCCESS
-                and cfg.minimum
-                and current_value >= cfg.value
-            ):
-                LOGGER.debug(
-                    "Current config %s = %s exceeds the default of %s, skipping",
-                    cfg.config_id.name,
-                    current_value,
-                    cfg.value,
-                )
-                continue
-
-            LOGGER.debug(
-                "Setting config %s = %s (old value %s)",
-                cfg.config_id.name,
-                cfg.value,
-                current_value,
-            )
-
-            (status,) = await self.setConfigurationValue(cfg.config_id, cfg.value)
-            if status != self.types.EmberStatus.SUCCESS:
-                LOGGER.debug(
-                    "Could not set config %s = %s: %s",
-                    cfg.config_id,
-                    cfg.value,
-                    status,
-                )
-                continue
 
     async def get_free_buffers(self) -> Optional[int]:
         status, value = await self.getValue(self.types.EzspValueId.VALUE_FREE_BUFFERS)

--- a/bellows/ezsp/v10/__init__.py
+++ b/bellows/ezsp/v10/__init__.py
@@ -1,19 +1,17 @@
 """"EZSP Protocol version 10 protocol handler."""
-import asyncio
 import logging
-from typing import Tuple
 
 import voluptuous
 
 import bellows.config
 
 from . import commands, config, types as v10_types
-from .. import protocol
+from ..v9 import EZSPv9
 
 LOGGER = logging.getLogger(__name__)
 
 
-class EZSPv10(protocol.ProtocolHandler):
+class EZSPv10(EZSPv9):
     """EZSP Version 10 Protocol version handler."""
 
     VERSION = 10
@@ -23,36 +21,3 @@ class EZSPv10(protocol.ProtocolHandler):
         bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
     }
     types = v10_types
-
-    def _ezsp_frame_tx(self, name: str) -> bytes:
-        """Serialize the frame id."""
-        cmd_id = self.COMMANDS[name][0]
-        hdr = [self._seq, 0x00, 0x01]
-        return bytes(hdr) + self.types.uint16_t(cmd_id).serialize()
-
-    def _ezsp_frame_rx(self, data: bytes) -> Tuple[int, int, bytes]:
-        """Handler for received data frame."""
-        seq, data = data[0], data[3:]
-        frame_id, data = self.types.uint16_t.deserialize(data)
-
-        return seq, frame_id, data
-
-    async def pre_permit(self, time_s: int) -> None:
-        """Temporarily change TC policy while allowing new joins."""
-        wild_card_ieee = v10_types.EmberEUI64([0xFF] * 8)
-        tc_link_key = v10_types.EmberKeyData(b"ZigBeeAlliance09")
-        await self.addTransientLinkKey(wild_card_ieee, tc_link_key)
-        await self.setPolicy(
-            v10_types.EzspPolicyId.TRUST_CENTER_POLICY,
-            v10_types.EzspDecisionBitmask.ALLOW_JOINS
-            | v10_types.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
-        )
-        await asyncio.sleep(time_s + 2)
-        await self.setPolicy(
-            v10_types.EzspPolicyId.TRUST_CENTER_POLICY,
-            self.tc_policy,
-        )
-
-    async def set_source_routing(self) -> None:
-        """Enable source routing on NCP."""
-        await self.setSourceRouteDiscoveryMode(1)

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -31,3 +31,6 @@ class EZSPv4(protocol.ProtocolHandler):
     def _ezsp_frame_rx(self, data: bytes) -> Tuple[int, int, bytes]:
         """Handler for received data frame."""
         return data[0], data[2], data[3:]
+
+    async def pre_permit(self, time_s: int) -> None:
+        pass

--- a/bellows/ezsp/v7/__init__.py
+++ b/bellows/ezsp/v7/__init__.py
@@ -6,12 +6,12 @@ import voluptuous
 import bellows.config
 
 from . import commands, config, types as v7_types
-from ..v5 import EZSPv5
+from ..v6 import EZSPv6
 
 LOGGER = logging.getLogger(__name__)
 
 
-class EZSPv7(EZSPv5):
+class EZSPv7(EZSPv6):
     """EZSP Version 7 Protocol version handler."""
 
     VERSION = 7

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -8,12 +8,12 @@ import voluptuous
 import bellows.config
 
 from . import commands, config, types as v8_types
-from .. import protocol
+from ..v7 import EZSPv7
 
 LOGGER = logging.getLogger(__name__)
 
 
-class EZSPv8(protocol.ProtocolHandler):
+class EZSPv8(EZSPv7):
     """EZSP Version 8 Protocol version handler."""
 
     VERSION = 8
@@ -39,9 +39,7 @@ class EZSPv8(protocol.ProtocolHandler):
 
     async def pre_permit(self, time_s: int) -> None:
         """Temporarily change TC policy while allowing new joins."""
-        wild_card_ieee = v8_types.EmberEUI64([0xFF] * 8)
-        tc_link_key = v8_types.EmberKeyData(b"ZigBeeAlliance09")
-        await self.addTransientLinkKey(wild_card_ieee, tc_link_key)
+        await super().pre_permit(time_s)
         await self.setPolicy(
             v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
             v8_types.EzspDecisionBitmask.ALLOW_JOINS
@@ -52,7 +50,3 @@ class EZSPv8(protocol.ProtocolHandler):
             v8_types.EzspPolicyId.TRUST_CENTER_POLICY,
             self.tc_policy,
         )
-
-    async def set_source_routing(self) -> None:
-        """Enable source routing on NCP."""
-        await self.setSourceRouteDiscoveryMode(1)

--- a/bellows/ezsp/v9/__init__.py
+++ b/bellows/ezsp/v9/__init__.py
@@ -1,19 +1,17 @@
-""""EZSP Protocol version 8 protocol handler."""
-import asyncio
+""""EZSP Protocol version 9 protocol handler."""
 import logging
-from typing import Tuple
 
 import voluptuous
 
 import bellows.config
 
 from . import commands, config, types as v9_types
-from .. import protocol
+from ..v8 import EZSPv8
 
 LOGGER = logging.getLogger(__name__)
 
 
-class EZSPv9(protocol.ProtocolHandler):
+class EZSPv9(EZSPv8):
     """EZSP Version 9 Protocol version handler."""
 
     VERSION = 9
@@ -23,36 +21,3 @@ class EZSPv9(protocol.ProtocolHandler):
         bellows.config.CONF_EZSP_POLICIES: voluptuous.Schema(config.EZSP_POLICIES_SCH),
     }
     types = v9_types
-
-    def _ezsp_frame_tx(self, name: str) -> bytes:
-        """Serialize the frame id."""
-        cmd_id = self.COMMANDS[name][0]
-        hdr = [self._seq, 0x00, 0x01]
-        return bytes(hdr) + self.types.uint16_t(cmd_id).serialize()
-
-    def _ezsp_frame_rx(self, data: bytes) -> Tuple[int, int, bytes]:
-        """Handler for received data frame."""
-        seq, data = data[0], data[3:]
-        frame_id, data = self.types.uint16_t.deserialize(data)
-
-        return seq, frame_id, data
-
-    async def pre_permit(self, time_s: int) -> None:
-        """Temporarily change TC policy while allowing new joins."""
-        wild_card_ieee = v9_types.EmberEUI64([0xFF] * 8)
-        tc_link_key = v9_types.EmberKeyData(b"ZigBeeAlliance09")
-        await self.addTransientLinkKey(wild_card_ieee, tc_link_key)
-        await self.setPolicy(
-            v9_types.EzspPolicyId.TRUST_CENTER_POLICY,
-            v9_types.EzspDecisionBitmask.ALLOW_JOINS
-            | v9_types.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
-        )
-        await asyncio.sleep(time_s + 2)
-        await self.setPolicy(
-            v9_types.EzspPolicyId.TRUST_CENTER_POLICY,
-            self.tc_policy,
-        )
-
-    async def set_source_routing(self) -> None:
-        """Enable source routing on NCP."""
-        await self.setSourceRouteDiscoveryMode(1)

--- a/bellows/types/struct.py
+++ b/bellows/types/struct.py
@@ -349,3 +349,11 @@ class EmberGpAddress(EzspStruct):
     applicationId: basic.uint8_t
     # The GPD endpoint.
     endpoint: basic.uint8_t
+
+
+class NV3StackTrustCenterToken(EzspStruct):
+    """NV3 stack trust center token value."""
+
+    mode: basic.uint16_t
+    eui64: named.EmberEUI64
+    key: named.EmberKeyData

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -366,7 +366,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         stack_specific = network_info.stack_specific.get("ezsp", {})
         (current_eui64,) = await ezsp.getEui64()
-        failed_to_write_eui64 = False
+        wrote_eui64 = False
 
         if (
             node_info.ieee != zigpy.types.EUI64.UNKNOWN
@@ -374,6 +374,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         ):
             if await ezsp.can_rewrite_custom_eui64():
                 await ezsp.write_custom_eui64(node_info.ieee)
+                wrote_eui64 = True
             elif not stack_specific.get(
                 "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"
             ):
@@ -382,19 +383,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     current_eui64,
                     node_info.ieee,
                 )
-                failed_to_write_eui64 = True
             elif not await ezsp.can_burn_userdata_custom_eui64():
                 LOGGER.error(
                     "Current node's IEEE address has already been written once. It"
                     " cannot be written again without fully erasing the chip with JTAG."
                 )
-                failed_to_write_eui64 = True
             else:
                 await ezsp.write_custom_eui64(node_info.ieee, burn_into_userdata=True)
+                wrote_eui64 = True
 
         # If we cannot write the new EUI64, don't mess up key entries with the unwritten
         # EUI64 address
-        if failed_to_write_eui64:
+        if not wrote_eui64:
             node_info.ieee = current_eui64
             network_info.tc_link_key.partner_ieee = current_eui64
 
@@ -408,7 +408,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         initial_security_state = util.zha_security(
             network_info=network_info,
-            node_info=node_info,
             use_hashed_tclk=use_hashed_tclk,
         )
         (status,) = await ezsp.setInitialSecurityState(initial_security_state)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -453,6 +453,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         (status,) = await self._ezsp.clearKeyTable()
         assert status == t.EmberStatus.SUCCESS
 
+        # Reset the custom EUI64
+        await self._ezsp.reset_custom_eui64()
+
     async def disconnect(self):
         # TODO: how do you shut down the stack?
         self.controller_event.clear()

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -25,6 +25,7 @@ import zigpy.zdo.types as zdo_t
 
 import bellows
 from bellows.config import (
+    CONF_EZSP_POLICIES,
     CONF_PARAM_MAX_WATCHDOG_FAILURES,
     CONF_USE_THREAD,
     CONFIG_SCHEMA,
@@ -179,7 +180,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if self.config[zigpy.config.CONF_SOURCE_ROUTING]:
             await ezsp.set_source_routing()
 
-        await ezsp.update_policies(self.config)
+        await ezsp._protocol.update_policies(self.config[CONF_EZSP_POLICIES])
         await self.load_network_info(load_devices=False)
 
         for cnt_group in self.state.counters:

--- a/bellows/zigbee/repairs.py
+++ b/bellows/zigbee/repairs.py
@@ -1,0 +1,51 @@
+"""Coordinator state repairs."""
+
+import logging
+
+import zigpy.types
+
+from bellows.exception import InvalidCommandError
+from bellows.ezsp import EZSP
+import bellows.types as t
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def fix_invalid_tclk_partner_ieee(ezsp: EZSP) -> bool:
+    """Fix invalid TCLK partner IEEE address."""
+    (ieee,) = await ezsp.getEui64()
+    ieee = zigpy.types.EUI64(ieee)
+
+    (status, state) = await ezsp.getCurrentSecurityState()
+    assert status == t.EmberStatus.SUCCESS
+
+    if state.trustCenterLongAddress == ieee:
+        return False
+
+    LOGGER.warning(
+        "Fixing invalid TCLK partner IEEE (%s => %s)",
+        state.trustCenterLongAddress,
+        ieee,
+    )
+
+    try:
+        (status, value) = await ezsp.getTokenData(
+            t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER, 0
+        )
+        assert status == t.EmberStatus.SUCCESS
+    except InvalidCommandError:
+        LOGGER.warning("NV3 interface not available in this firmware, please upgrade!")
+        return False
+
+    token, remaining = t.NV3StackTrustCenterToken.deserialize(value)
+    assert not remaining
+    assert token.eui64 == state.trustCenterLongAddress
+
+    (status,) = await ezsp.setTokenData(
+        t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
+        0,
+        token.replace(eui64=ieee).serialize(),
+    )
+    assert status == t.EmberStatus.SUCCESS
+
+    return True

--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -20,7 +20,6 @@ RSSI_MIN = -92
 def zha_security(
     *,
     network_info: zigpy.state.NetworkInfo,
-    node_info: zigpy.state.NodeInfo,
     use_hashed_tclk: bool,
 ) -> t.EmberInitialSecurityState:
     """Construct an `EmberInitialSecurityState` out of zigpy network state."""

--- a/bellows/zigbee/util.py
+++ b/bellows/zigbee/util.py
@@ -3,7 +3,6 @@ import math
 
 import zigpy.state
 import zigpy.types as zigpy_t
-import zigpy.zdo.types as zdo_t
 
 import bellows.types as t
 
@@ -35,16 +34,15 @@ def zha_security(
     isc.networkKey = t.EmberKeyData(network_info.network_key.key)
     isc.networkKeySequenceNumber = t.uint8_t(network_info.network_key.seq)
 
-    if (
-        node_info.logical_type != zdo_t.LogicalType.Coordinator
-        and network_info.tc_link_key.partner_ieee != zigpy_t.EUI64.UNKNOWN
-    ):
+    if network_info.tc_link_key.partner_ieee != zigpy_t.EUI64.UNKNOWN:
         isc.bitmask |= t.EmberInitialSecurityBitmask.HAVE_TRUST_CENTER_EUI64
         isc.preconfiguredTrustCenterEui64 = t.EmberEUI64(
             network_info.tc_link_key.partner_ieee
         )
     else:
-        isc.preconfiguredTrustCenterEui64 = t.EmberEUI64([0x00] * 8)
+        isc.preconfiguredTrustCenterEui64 = t.EmberEUI64.convert(
+            "00:00:00:00:00:00:00:00"
+        )
 
     if use_hashed_tclk:
         if network_info.tc_link_key.key != zigpy_t.KeyData(b"ZigBeeAlliance09"):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch, sentinel
 
 import pytest
 import zigpy.config
@@ -22,8 +23,6 @@ import bellows.zigbee.application
 import bellows.zigbee.device
 from bellows.zigbee.util import map_rssi_to_energy
 
-from .async_mock import AsyncMock, MagicMock, PropertyMock, patch, sentinel
-
 APP_CONFIG = {
     config.CONF_DEVICE: {
         config.CONF_DEVICE_PATH: "/dev/null",
@@ -34,11 +33,31 @@ APP_CONFIG = {
 
 
 @pytest.fixture
-def ezsp_mock():
+def ieee(init=0):
+    return t.EmberEUI64(map(t.uint8_t, range(init, init + 8)))
+
+
+@pytest.fixture
+def ezsp_mock(ieee):
     """EZSP fixture"""
     mock_ezsp = MagicMock(spec=ezsp.EZSP)
     mock_ezsp.ezsp_version = 7
     mock_ezsp.setManufacturerCode = AsyncMock()
+    mock_ezsp.getEui64 = AsyncMock(return_value=[ieee])
+    mock_ezsp.getConfigurationValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS, 0])
+    mock_ezsp.getCurrentSecurityState = AsyncMock(
+        return_value=[
+            t.EmberStatus.SUCCESS,
+            t.EmberCurrentSecurityState(
+                bitmask=(
+                    t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
+                    | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
+                    | 224
+                ),
+                trustCenterLongAddress=ieee,
+            ),
+        ]
+    )
     mock_ezsp.set_source_route = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
     mock_ezsp.addTransientLinkKey = AsyncMock(return_value=[0])
     mock_ezsp.readCounters = AsyncMock(return_value=[[0] * 10])
@@ -50,6 +69,7 @@ def ezsp_mock():
     mock_ezsp.wait_for_stack_status.return_value.__enter__ = AsyncMock(
         return_value=t.EmberStatus.NETWORK_UP
     )
+    mock_ezsp._protocol = AsyncMock()
 
     type(mock_ezsp).types = ezsp_t7
     type(mock_ezsp).is_ezsp_running = PropertyMock(return_value=True)
@@ -93,11 +113,6 @@ def aps():
     return f
 
 
-@pytest.fixture
-def ieee(init=0):
-    return t.EmberEUI64(map(t.uint8_t, range(init, init + 8)))
-
-
 @patch("zigpy.device.Device._initialize", new=AsyncMock())
 @patch("bellows.zigbee.application.ControllerApplication._watchdog", new=AsyncMock())
 async def _test_startup(
@@ -126,12 +141,14 @@ async def _test_startup(
         return [t.EmberStatus.NETWORK_DOWN]
 
     app._in_flight_msg = None
-    ezsp_mock = MagicMock()
+    ezsp_mock = MagicMock(spec=ezsp.EZSP)
     ezsp_mock.types = ezsp_t7
     type(ezsp_mock).ezsp_version = PropertyMock(return_value=ezsp_version)
     ezsp_mock.initialize = AsyncMock(return_value=ezsp_mock)
     ezsp_mock.connect = AsyncMock()
+    ezsp_mock._protocol = AsyncMock()
     ezsp_mock.setConcentrator = AsyncMock()
+    ezsp_mock.getTokenData = AsyncMock(return_value=[t.EmberStatus.ERR_FATAL, b""])
     ezsp_mock._command = AsyncMock(return_value=t.EmberStatus.SUCCESS)
     ezsp_mock.addEndpoint = AsyncMock(return_value=t.EmberStatus.SUCCESS)
     ezsp_mock.setConfigurationValue = AsyncMock(return_value=t.EmberStatus.SUCCESS)
@@ -179,12 +196,15 @@ async def _test_startup(
         return_value=[
             t.EmberStatus.SUCCESS,
             t.EmberCurrentSecurityState(
-                bitmask=t.EmberCurrentSecurityBitmask.TRUST_CENTER_USES_HASHED_LINK_KEY,
-                trustCenterLongAddress=t.EmberEUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
+                bitmask=(
+                    t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
+                    | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
+                    | 224
+                ),
+                trustCenterLongAddress=ieee,
             ),
         ]
     )
-    ezsp_mock.pre_permit = AsyncMock()
     app.permit = AsyncMock()
 
     def form_network():
@@ -196,7 +216,7 @@ async def _test_startup(
 
     app.form_network = AsyncMock(side_effect=form_network)
 
-    p1 = patch.object(bellows.ezsp, "EZSP", new=ezsp_mock)
+    p1 = patch("bellows.ezsp.EZSP", return_value=ezsp_mock)
     p2 = patch.object(bellows.multicast.Multicast, "startup")
 
     with p1, p2 as multicast_mock:
@@ -1641,8 +1661,6 @@ async def test_startup_coordinator_existing_groups_joined(app, ieee):
     app._ensure_network_running = AsyncMock()
     app._ezsp.update_policies = AsyncMock()
     app.load_network_info = AsyncMock()
-
-    app._multicast = bellows.multicast.Multicast(app._ezsp)
     app.state.node_info.ieee = ieee
 
     db_device = app.add_device(ieee, 0x0000)
@@ -1666,8 +1684,6 @@ async def test_startup_new_coordinator_no_groups_joined(app, ieee):
     app._ensure_network_running = AsyncMock()
     app._ezsp.update_policies = AsyncMock()
     app.load_network_info = AsyncMock()
-
-    app._multicast = bellows.multicast.Multicast(app._ezsp)
     app.state.node_info.ieee = ieee
 
     p1 = patch.object(bellows.multicast.Multicast, "_initialize")
@@ -1691,9 +1707,6 @@ async def test_startup_source_routing(make_app, ieee, enable_source_routing):
     app._ensure_network_running = AsyncMock()
     app.load_network_info = AsyncMock()
     app.state.node_info.ieee = ieee
-
-    app._multicast = bellows.multicast.Multicast(app._ezsp)
-    app._multicast._initialize = AsyncMock()
 
     mock_device = MagicMock()
     mock_device.relays = sentinel.relays

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1803,3 +1803,17 @@ async def test_connect_failure(
     assert app._ezsp is None
 
     assert len(ezsp_mock.close.mock_calls) == 1
+
+
+async def test_repair_tclk_partner_ieee(app: ControllerApplication) -> None:
+    """Test that EZSP is reset after repairing TCLK."""
+    app._ensure_network_running = AsyncMock()
+    app.load_network_info = AsyncMock()
+
+    with patch(
+        "bellows.zigbee.repairs.fix_invalid_tclk_partner_ieee",
+        AsyncMock(return_value=True),
+    ):
+        await app.start_network()
+
+    assert len(app._ensure_network_running.mock_calls) == 2

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -9,7 +9,7 @@ from bellows.exception import EzspError
 import bellows.types as t
 
 from tests.async_mock import AsyncMock, PropertyMock
-from tests.test_application import app, ezsp_mock, make_app
+from tests.test_application import app, ezsp_mock, ieee, make_app
 
 
 @pytest.fixture

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -447,7 +447,7 @@ async def test_update_policies(ezsp_f):
         assert pol_mock.await_count == 1
 
 
-async def test_set_concentrator(ezsp_f):
+async def test_set_source_routing_set_concentrator(ezsp_f):
     """Test enabling source routing."""
     with patch.object(ezsp_f, "setConcentrator", new=AsyncMock()) as cnc_mock:
         cnc_mock.return_value = (ezsp_f.types.EmberStatus.SUCCESS,)
@@ -457,6 +457,17 @@ async def test_set_concentrator(ezsp_f):
         cnc_mock.return_value = (ezsp_f.types.EmberStatus.ERR_FATAL,)
         await ezsp_f.set_source_routing()
         assert cnc_mock.await_count == 2
+
+
+async def test_set_source_routing_ezsp_v8(ezsp_f):
+    """Test enabling source routing on EZSPv8."""
+
+    ezsp_f._ezsp_version = 8
+    ezsp_f.setConcentrator = AsyncMock(return_value=(ezsp_f.types.EmberStatus.SUCCESS,))
+    ezsp_f.setSourceRouteDiscoveryMode = AsyncMock()
+
+    await ezsp_f.set_source_routing()
+    assert len(ezsp_f.setSourceRouteDiscoveryMode.mock_calls) == 1
 
 
 async def test_leave_network_error(ezsp_f):

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -62,159 +62,17 @@ def test_receive_reply_invalid_command(prot_hndl):
     assert prot_hndl._handle_callback.call_count == 0
 
 
-async def test_config_initialize_husbzb1(prot_hndl):
-    """Test timeouts are properly set for HUSBZB-1."""
-
-    prot_hndl.getConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, 0))
-    prot_hndl.setConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
-
-    await prot_hndl.initialize({"ezsp_config": {}})
-    prot_hndl.setConfigurationValue.assert_has_calls(
-        [
-            call(t.EzspConfigId.CONFIG_SOURCE_ROUTE_TABLE_SIZE, 16),
-            call(t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT, 60),
-            call(t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT_SHIFT, 8),
-            call(t.EzspConfigId.CONFIG_INDIRECT_TRANSMISSION_TIMEOUT, 7680),
-            call(t.EzspConfigId.CONFIG_STACK_PROFILE, 2),
-            call(t.EzspConfigId.CONFIG_SUPPORTED_NETWORKS, 1),
-            call(t.EzspConfigId.CONFIG_MULTICAST_TABLE_SIZE, 16),
-            call(t.EzspConfigId.CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE, 2),
-            call(t.EzspConfigId.CONFIG_SECURITY_LEVEL, 5),
-            call(t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE, 16),
-            call(t.EzspConfigId.CONFIG_PAN_ID_CONFLICT_REPORT_THRESHOLD, 2),
-            call(t.EzspConfigId.CONFIG_KEY_TABLE_SIZE, 4),
-            call(t.EzspConfigId.CONFIG_MAX_END_DEVICE_CHILDREN, 32),
-            call(
-                t.EzspConfigId.CONFIG_APPLICATION_ZDO_FLAGS,
-                (
-                    t.EmberZdoConfigurationFlags.APP_HANDLES_UNSUPPORTED_ZDO_REQUESTS
-                    | t.EmberZdoConfigurationFlags.APP_RECEIVES_SUPPORTED_ZDO_REQUESTS
-                ),
-            ),
-            call(t.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT, 255),
-        ]
-    )
-
-
-@pytest.mark.parametrize("prot_hndl_cls", EZSP._BY_VERSION.values())
-async def test_config_initialize(prot_hndl_cls, caplog):
-    """Test config initialization for all protocol versions."""
-
-    prot_hndl = prot_hndl_cls(MagicMock(), MagicMock())
-    prot_hndl.getConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, 0))
-    prot_hndl.setConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
-
-    prot_hndl.setValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
-    prot_hndl.getValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, b"\xFF"))
-
-    await prot_hndl.initialize({"ezsp_config": {}})
-
-    with caplog.at_level(logging.DEBUG):
-        prot_hndl.setConfigurationValue.return_value = (
-            t.EzspStatus.ERROR_OUT_OF_MEMORY,
-        )
-        await prot_hndl.initialize({"ezsp_config": {}})
-
-    assert "Could not set config" in caplog.text
-    prot_hndl.setConfigurationValue.return_value = (t.EzspStatus.SUCCESS,)
-    caplog.clear()
-
-    # EZSPv6 does not set any values on startup
-    if prot_hndl_cls.VERSION < 7:
-        return
-
-    prot_hndl.setValue.reset_mock()
-    prot_hndl.getValue.return_value = (t.EzspStatus.ERROR_INVALID_ID, b"")
-    await prot_hndl.initialize({"ezsp_config": {}})
-    assert len(prot_hndl.setValue.mock_calls) == 1
-
-    prot_hndl.getValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, b"\xFF"))
-    caplog.clear()
-
-    with caplog.at_level(logging.DEBUG):
-        prot_hndl.setValue.return_value = (t.EzspStatus.ERROR_INVALID_ID,)
-        await prot_hndl.initialize({"ezsp_config": {}})
-
-    assert "Could not set value" in caplog.text
-    prot_hndl.setValue.return_value = (t.EzspStatus.SUCCESS,)
-    caplog.clear()
-
-
-async def test_cfg_initialize_skip(prot_hndl):
-    """Test initialization."""
-
-    p1 = patch.object(
-        prot_hndl,
-        "setConfigurationValue",
-        new=AsyncMock(return_value=(t.EzspStatus.SUCCESS,)),
-    )
-    p2 = patch.object(
-        prot_hndl,
-        "getConfigurationValue",
-        new=AsyncMock(return_value=(t.EzspStatus.SUCCESS, 22)),
-    )
-    p3 = patch.object(prot_hndl, "get_free_buffers", new=AsyncMock(22))
-    with p1, p2, p3:
-        await prot_hndl.initialize(
-            {"ezsp_config": {"CONFIG_END_DEVICE_POLL_TIMEOUT": None}}
-        )
-
-        # Config not set when it is explicitly disabled
-        with pytest.raises(AssertionError):
-            prot_hndl.setConfigurationValue.assert_called_with(
-                t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT, ANY
-            )
-
-    with p1, p2, p3:
-        await prot_hndl.initialize(
-            {"ezsp_config": {"CONFIG_MULTICAST_TABLE_SIZE": 123}}
-        )
-
-        # Config is overridden
-        prot_hndl.setConfigurationValue.assert_any_call(
-            t.EzspConfigId.CONFIG_MULTICAST_TABLE_SIZE, 123
-        )
-
-    with p1, p2, p3:
-        await prot_hndl.initialize({"ezsp_config": {}})
-
-        # Config is set by default
-        prot_hndl.setConfigurationValue.assert_any_call(
-            t.EzspConfigId.CONFIG_END_DEVICE_POLL_TIMEOUT, ANY
-        )
-
-
 async def test_update_policies(prot_hndl):
     """Test update_policies."""
 
     with patch.object(prot_hndl, "setPolicy", new=AsyncMock()) as pol_mock:
         pol_mock.return_value = (t.EzspStatus.SUCCESS,)
-        await prot_hndl.update_policies({"ezsp_policies": {}})
+        await prot_hndl.update_policies({})
 
+    with patch.object(prot_hndl, "setPolicy", new=AsyncMock()) as pol_mock:
         pol_mock.return_value = (t.EzspStatus.ERROR_OUT_OF_MEMORY,)
         with pytest.raises(AssertionError):
-            await prot_hndl.update_policies({"ezsp_policies": {}})
-
-
-@pytest.mark.parametrize(
-    "status, raw, expected_value",
-    (
-        (t.EzspStatus.ERROR_OUT_OF_MEMORY, b"", None),
-        (t.EzspStatus.ERROR_OUT_OF_MEMORY, b"\x02\x02", None),
-        (t.EzspStatus.SUCCESS, b"\x02\x02", 514),
-    ),
-)
-async def test_get_free_buffers(prot_hndl, status, raw, expected_value):
-    """Test getting free buffers."""
-
-    p1 = patch.object(prot_hndl, "getValue", new=AsyncMock())
-    with p1 as value_mock:
-        value_mock.return_value = (status, raw)
-        free_buffers = await prot_hndl.get_free_buffers()
-        if expected_value is None:
-            assert free_buffers is expected_value
-        else:
-            assert free_buffers == expected_value
+            await prot_hndl.update_policies({})
 
 
 async def test_unknown_command(prot_hndl, caplog):

--- a/tests/test_ezsp_protocol.py
+++ b/tests/test_ezsp_protocol.py
@@ -84,3 +84,13 @@ async def test_unknown_command(prot_hndl, caplog):
         prot_hndl(bytes([0x00, 0x00, unregistered_command, 0xAB, 0xCD]))
 
         assert "0x0004 received: b'abcd' (b'000004abcd')" in caplog.text
+
+
+async def test_logging_frame_parsing_failure(prot_hndl, caplog) -> None:
+    """Test logging when frame parsing fails."""
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError):
+            prot_hndl(b"\xAA\xAA\x71\x22")
+
+        assert "Failed to parse frame getKeyTableEntry: b'22'" in caplog.text

--- a/tests/test_ezsp_v10.py
+++ b/tests/test_ezsp_v10.py
@@ -25,15 +25,6 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
-async def test_set_source_routing(ezsp_f):
-    """Test setting source routing."""
-    with patch.object(
-        ezsp_f, "setSourceRouteDiscoveryMode", new=AsyncMock()
-    ) as src_mock:
-        await ezsp_f.set_source_routing()
-        assert src_mock.await_count == 1
-
-
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = patch.object(ezsp_f, "setPolicy", new=AsyncMock())

--- a/tests/test_ezsp_v11.py
+++ b/tests/test_ezsp_v11.py
@@ -25,15 +25,6 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
-async def test_set_source_routing(ezsp_f):
-    """Test setting source routing."""
-    with patch.object(
-        ezsp_f, "setSourceRouteDiscoveryMode", new=AsyncMock()
-    ) as src_mock:
-        await ezsp_f.set_source_routing()
-        assert src_mock.await_count == 1
-
-
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = patch.object(ezsp_f, "setPolicy", new=AsyncMock())

--- a/tests/test_ezsp_v12.py
+++ b/tests/test_ezsp_v12.py
@@ -25,15 +25,6 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
-async def test_set_source_routing(ezsp_f):
-    """Test setting source routing."""
-    with patch.object(
-        ezsp_f, "setSourceRouteDiscoveryMode", new=AsyncMock()
-    ) as src_mock:
-        await ezsp_f.set_source_routing()
-        assert src_mock.await_count == 1
-
-
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = patch.object(ezsp_f, "setPolicy", new=AsyncMock())

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -25,6 +25,11 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
+async def test_pre_permit(ezsp_f):
+    """Test pre permit."""
+    await ezsp_f.pre_permit(1.9)
+
+
 command_frames = {
     "addEndpoint": 0x02,
     "addOrUpdateKeyTableEntry": 0x66,

--- a/tests/test_ezsp_v8.py
+++ b/tests/test_ezsp_v8.py
@@ -25,15 +25,6 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
-async def test_set_source_routing(ezsp_f):
-    """Test setting source routing."""
-    with patch.object(
-        ezsp_f, "setSourceRouteDiscoveryMode", new=AsyncMock()
-    ) as src_mock:
-        await ezsp_f.set_source_routing()
-        assert src_mock.await_count == 1
-
-
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = patch.object(ezsp_f, "setPolicy", new=AsyncMock())

--- a/tests/test_ezsp_v9.py
+++ b/tests/test_ezsp_v9.py
@@ -25,15 +25,6 @@ def test_ezsp_frame_rx(ezsp_f):
     assert ezsp_f._handle_callback.call_args[0][1] == [0x01, 0x02, 0x1234]
 
 
-async def test_set_source_routing(ezsp_f):
-    """Test setting source routing."""
-    with patch.object(
-        ezsp_f, "setSourceRouteDiscoveryMode", new=AsyncMock()
-    ) as src_mock:
-        await ezsp_f.set_source_routing()
-        assert src_mock.await_count == 1
-
-
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
     p1 = patch.object(ezsp_f, "setPolicy", new=AsyncMock())

--- a/tests/test_zigbee_repairs.py
+++ b/tests/test_zigbee_repairs.py
@@ -1,0 +1,114 @@
+"""Test network state repairs."""
+
+import logging
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from bellows.exception import InvalidCommandError
+from bellows.ezsp import EZSP
+import bellows.types as t
+from bellows.zigbee import repairs
+
+from tests.test_ezsp import ezsp_f
+
+
+@pytest.fixture
+def ezsp_tclk_f(ezsp_f: EZSP) -> EZSP:
+    """Mock an EZSP instance with a valid TCLK."""
+    ezsp_f.getEui64 = AsyncMock(
+        return_value=[t.EmberEUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA")]
+    )
+    ezsp_f.getTokenData = AsyncMock(side_effect=InvalidCommandError())
+    ezsp_f.getCurrentSecurityState = AsyncMock(
+        return_value=[
+            t.EmberStatus.SUCCESS,
+            t.EmberCurrentSecurityState(
+                bitmask=(
+                    t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
+                    | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
+                    | 224
+                ),
+                trustCenterLongAddress=t.EmberEUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA"),
+            ),
+        ]
+    )
+    return ezsp_f
+
+
+async def test_fix_invalid_tclk_noop(ezsp_tclk_f: EZSP, caplog) -> None:
+    """Test that the TCLK is not rewritten unnecessarily."""
+
+    ezsp_tclk_f.getEui64.return_value[0] = t.EmberEUI64.convert(
+        "AA:AA:AA:AA:AA:AA:AA:AA"
+    )
+    ezsp_tclk_f.getCurrentSecurityState.return_value[
+        1
+    ].trustCenterLongAddress = t.EmberEUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA")
+
+    with caplog.at_level(logging.WARNING):
+        assert await repairs.fix_invalid_tclk_partner_ieee(ezsp_tclk_f) is False
+
+    assert "Fixing invalid TCLK" not in caplog.text
+
+
+async def test_fix_invalid_tclk_old_firmware(ezsp_tclk_f: EZSP, caplog) -> None:
+    """Test that the TCLK is not rewritten when the firmware is too old."""
+
+    ezsp_tclk_f.getTokenData = AsyncMock(side_effect=InvalidCommandError())
+    ezsp_tclk_f.getEui64.return_value[0] = t.EmberEUI64.convert(
+        "AA:AA:AA:AA:AA:AA:AA:AA"
+    )
+    ezsp_tclk_f.getCurrentSecurityState.return_value[
+        1
+    ].trustCenterLongAddress = t.EmberEUI64.convert("BB:BB:BB:BB:BB:BB:BB:BB")
+
+    with caplog.at_level(logging.WARNING):
+        assert await repairs.fix_invalid_tclk_partner_ieee(ezsp_tclk_f) is False
+
+    assert "Fixing invalid TCLK" in caplog.text
+    assert "NV3 interface not available in this firmware" in caplog.text
+
+
+async def test_fix_invalid_tclk(ezsp_tclk_f: EZSP, caplog) -> None:
+    """Test that the TCLK is not rewritten when the firmware is too old."""
+
+    ezsp_tclk_f.setTokenData = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
+    ezsp_tclk_f.getTokenData = AsyncMock(
+        return_value=[
+            t.EmberStatus.SUCCESS,
+            t.NV3StackTrustCenterToken(
+                mode=228,
+                eui64=t.EmberEUI64.convert("BB:BB:BB:BB:BB:BB:BB:BB"),
+                key=t.EmberKeyData.convert(
+                    "21:8e:df:b8:50:a0:4a:b6:8b:c6:10:25:bc:4e:93:6a"
+                ),
+            ).serialize(),
+        ]
+    )
+    ezsp_tclk_f.getEui64.return_value[0] = t.EmberEUI64.convert(
+        "AA:AA:AA:AA:AA:AA:AA:AA"
+    )
+    ezsp_tclk_f.getCurrentSecurityState.return_value[
+        1
+    ].trustCenterLongAddress = t.EmberEUI64.convert("BB:BB:BB:BB:BB:BB:BB:BB")
+
+    with caplog.at_level(logging.WARNING):
+        assert await repairs.fix_invalid_tclk_partner_ieee(ezsp_tclk_f) is True
+
+    assert "Fixing invalid TCLK" in caplog.text
+    assert "NV3 interface not available in this firmware" not in caplog.text
+
+    assert ezsp_tclk_f.setTokenData.mock_calls == [
+        call(
+            t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
+            0,
+            t.NV3StackTrustCenterToken(
+                mode=228,
+                eui64=t.EmberEUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA"),
+                key=t.EmberKeyData.convert(
+                    "21:8e:df:b8:50:a0:4a:b6:8b:c6:10:25:bc:4e:93:6a"
+                ),
+            ).serialize(),
+        )
+    ]


### PR DESCRIPTION
This PR is a little experimental and relies on functionality present only in the latest build of EmberZNet (7.3.1.0). I haven't yet figured out which firmwares are affected or what conditions are needed to trigger this problem.

---

There seem to be circumstances where the Trust Center Link Key's partner IEEE address does not match the coordinator's. This causes new Zigbee 3.0 devices which request APS link keys to leave the network, since the coordinator will never respond :

<img width="1243" alt="image" src="https://github.com/zigpy/bellows/assets/32534428/51ac73ea-7a54-471f-9143-debf4a001384">

It looks like the device's current EUI64 is not being correctly read by the firmware when we do not pass an EUI64 when creating the initial security state:

```python
2023-08-25 14:12:55.930 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame received getEui64: [79:50:12:76:46:fb:10:f4]
2023-08-25 14:12:55.974 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame received getCurrentSecurityState: [<EmberStatus.SUCCESS: 0>, EmberCurrentSecurityState(bitmask=<EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY|HAVE_TRUST_CENTER_LINK_KEY|TRUST_CENTER_USES_HASHED_LINK_KEY|96: 244>, trustCenterLongAddress=00:12:4b:00:1c:a1:b8:46)]
2023-08-25 14:12:55.966 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame received getKey: [<EmberStatus.SUCCESS: 0>, EmberKeyStruct(bitmask=<EmberKeyStructBitmask.KEY_HAS_OUTGOING_FRAME_COUNTER|KEY_HAS_PARTNER_EUI64|KEY_IS_AUTHORIZED: 26>, type=<EmberKeyType.TRUST_CENTER_LINK_KEY: 1>, key=b5:97:1c:d9:a8:e5:4c:8d:96:28:41:9d:83:1b:f7:6b, outgoingFrameCounter=0, incomingFrameCounter=0, sequenceNumber=0, partnerEUI64=00:12:4b:00:1c:a1:b8:46)]
2023-08-25 14:12:56.047 DEBUG (MainThread) [bellows.ezsp] NV3 restored EUI64: NV3KeyId.NVM3KEY_STACK_RESTORED_EUI64=79:50:12:76:46:fb:10:f4
```

The device's IEEE address is `79:50:12:76:46:fb:10:f4` but there seems to be a key table entry for `00:12:4b:00:1c:a1:b8:46`, its original IEEE address (burned into `USERDATA`). Upon applying this fix, the device now joins as expected:

<img width="1103" alt="image" src="https://github.com/zigpy/bellows/assets/32534428/cd7e1052-efba-4087-90aa-585bca8b4888">

Related: https://github.com/home-assistant/core/issues/97601