### PR TITLE
Fix startup broken by #577

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -25,6 +25,7 @@ import zigpy.zdo.types as zdo_t
 
 import bellows
 from bellows.config import (
+    CONF_EZSP_CONFIG,
     CONF_EZSP_POLICIES,
     CONF_PARAM_MAX_WATCHDOG_FAILURES,
     CONF_USE_THREAD,
@@ -142,6 +143,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             ezsp.close()
             raise
 
+        # Writing config is required here because network info can't be loaded otherwise
+        await ezsp.write_config(self.config[CONF_EZSP_CONFIG])
         self._ezsp = ezsp
 
     async def _ensure_network_running(self) -> bool:
@@ -169,6 +172,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def start_network(self):
         ezsp = self._ezsp
 
+        await self.register_endpoints()
         await self._ensure_network_running()
 
         if await repairs.fix_invalid_tclk_partner_ieee(ezsp):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -64,6 +64,7 @@ def ezsp_mock(ieee):
     mock_ezsp.readCounters = AsyncMock(return_value=[[0] * 10])
     mock_ezsp.readAndClearCounters = AsyncMock(return_value=[[0] * 10])
     mock_ezsp.setPolicy = AsyncMock(return_value=[0])
+    mock_ezsp.addEndpoint = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
     mock_ezsp.get_board_info = AsyncMock(
         return_value=("Mock Manufacturer", "Mock board", "Mock version")
     )
@@ -220,6 +221,9 @@ async def _test_startup(
 
     with p1, p2 as multicast_mock:
         await app.startup(auto_form=auto_form)
+
+    assert ezsp_mock.write_config.call_count == 1
+    assert ezsp_mock.addEndpoint.call_count >= 2
     assert multicast_mock.await_count == 1
 
 


### PR DESCRIPTION
#577 reorganized startup to allow for a simpler runtime reset (required for rebooting after writing config) but unfortunately omitted calls to `register_endpoints` and `write_config`, severely breaking it. This PR should address this.

CC @TheJulianJES