### PR TITLE
Reset after NVRAM changes

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -565,6 +565,16 @@ class EZSP:
                 ],
             }
 
+            # If we are not joined to a network, old FWs crash if we grow the buffer
+            if self._ezsp_version < 7:
+                (state,) = await self.networkState()
+
+                if state != self.types.EmberNetworkStatus.JOINED_NETWORK:
+                    LOGGER.debug("Skipping growing packet buffer, not on a network")
+                    del ezsp_config[
+                        self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name
+                    ]
+
         # First, set the values
         for cfg in ezsp_values.values():
             # XXX: A read failure does not mean the value is not writeable!

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -157,7 +157,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             return False
 
         with self._ezsp.wait_for_stack_status(t.EmberStatus.NETWORK_UP) as stack_status:
-            (init_status,) = await self._ezsp.networkInit()
+            if self._ezsp.ezsp_version >= 6:
+                (init_status,) = await self._ezsp.networkInit(0x0000)
+            else:
+                (init_status,) = await self._ezsp.networkInitExtended(0x0000)
 
             if init_status == t.EmberStatus.NOT_JOINED:
                 raise NetworkNotFormed("Node is not part of a network")

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -176,9 +176,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._ensure_network_running()
 
         if await repairs.fix_invalid_tclk_partner_ieee(ezsp):
-            # Reboot the stack after modifying NV3
-            ezsp.stop_ezsp()
-            await ezsp.startup_reset()
+            await self._reset()
             await self._ensure_network_running()
 
         if self.config[zigpy.config.CONF_SOURCE_ROUTING]:
@@ -396,9 +394,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 await ezsp.write_custom_eui64(node_info.ieee, burn_into_userdata=True)
                 wrote_eui64 = True
 
-        # If we cannot write the new EUI64, don't mess up key entries with the unwritten
-        # EUI64 address
-        if not wrote_eui64:
+        if wrote_eui64:
+            # Reset after writing the EUI64, as it touches NVRAM
+            await self._reset()
+        else:
+            # If we cannot write the new EUI64, don't mess up key entries with the
+            # unwritten EUI64 address
             node_info.ieee = current_eui64
             network_info.tc_link_key.partner_ieee = current_eui64
 
@@ -455,6 +456,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         parameters.channels = t.Channels(network_info.channel_mask)
 
         await ezsp.formNetwork(parameters)
+        await self._ensure_network_running()
 
     async def reset_network_info(self):
         # The network must be running before we can leave it
@@ -471,6 +473,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         # Reset the custom EUI64
         await self._ezsp.reset_custom_eui64()
+
+        # We must reset when NV3 has changed
+        await self._reset()
+
+    async def _reset(self):
+        self._ezsp.stop_ezsp()
+        await self._ezsp.startup_reset()
+        await self._ezsp.write_config(self.config[CONF_EZSP_CONFIG])
 
     async def disconnect(self):
         # TODO: how do you shut down the stack?

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -172,12 +172,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def start_network(self):
         ezsp = self._ezsp
 
-        await self.register_endpoints()
         await self._ensure_network_running()
 
         if await repairs.fix_invalid_tclk_partner_ieee(ezsp):
             await self._reset()
             await self._ensure_network_running()
+
+        await self.register_endpoints()
 
         if self.config[zigpy.config.CONF_SOURCE_ROUTING]:
             await ezsp.set_source_routing()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -153,6 +153,7 @@ async def _test_startup(
     ezsp_mock.addEndpoint = AsyncMock(return_value=t.EmberStatus.SUCCESS)
     ezsp_mock.setConfigurationValue = AsyncMock(return_value=t.EmberStatus.SUCCESS)
     ezsp_mock.networkInit = AsyncMock(return_value=[init])
+    ezsp_mock.networkInitExtended = AsyncMock(return_value=[init])
     ezsp_mock.getNetworkParameters = AsyncMock(return_value=[0, nwk_type, nwk_params])
     ezsp_mock.can_burn_userdata_custom_eui64 = AsyncMock(return_value=True)
     ezsp_mock.can_rewrite_custom_eui64 = AsyncMock(return_value=True)
@@ -221,6 +222,11 @@ async def _test_startup(
 
     with p1, p2 as multicast_mock:
         await app.startup(auto_form=auto_form)
+
+    if ezsp_version > 6:
+        assert ezsp_mock.networkInitExtended.call_count == 0
+    else:
+        assert ezsp_mock.networkInit.call_count == 0
 
     assert ezsp_mock.write_config.call_count == 1
     assert ezsp_mock.addEndpoint.call_count >= 2


### PR DESCRIPTION
Bellows can sometimes have issues forming new networks: settings are successfully written, the network starts up, a backup afterwards works, but upon reset the settings are lost/revert.

It seems that we need to write our EmberZNet config after reset, in addition to resetting after every NVRAM change.