### PR TITLE
Ensure EZSP repairs work with older firmware

### DIFF
--- a/bellows/zigbee/repairs.py
+++ b/bellows/zigbee/repairs.py
@@ -33,7 +33,7 @@ async def fix_invalid_tclk_partner_ieee(ezsp: EZSP) -> bool:
             t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER, 0
         )
         assert status == t.EmberStatus.SUCCESS
-    except InvalidCommandError:
+    except (InvalidCommandError, AttributeError):
         LOGGER.warning("NV3 interface not available in this firmware, please upgrade!")
         return False
 

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -32,6 +32,23 @@ async def ezsp_f():
         yield api
 
 
+async def make_ezsp(version=4) -> ezsp.EZSP:
+    api = ezsp.EZSP(DEVICE_CONFIG)
+    gw = MagicMock(spec_set=uart.Gateway)
+
+    with patch("bellows.uart.connect", new=AsyncMock(return_value=gw)):
+        await api.connect()
+
+    assert api._ezsp_version == 4
+
+    with patch.object(api, "_command", new=AsyncMock(return_value=[version, 0, 0])):
+        await api.version()
+
+    assert api._ezsp_version == version
+
+    return api
+
+
 async def test_connect(ezsp_f, monkeypatch):
     connected = False
 


### PR DESCRIPTION
Older firmwares can be affected by this issue yet not have the token interface, so they cannot be repaired.