### PR TITLE
Ensure repairs work when `getTokenData` is present but NV3 is not

### DIFF
--- a/bellows/zigbee/repairs.py
+++ b/bellows/zigbee/repairs.py
@@ -33,7 +33,7 @@ async def fix_invalid_tclk_partner_ieee(ezsp: EZSP) -> bool:
             t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER, 0
         )
         assert status == t.EmberStatus.SUCCESS
-    except (InvalidCommandError, AttributeError):
+    except (InvalidCommandError, AttributeError, AssertionError):
         LOGGER.warning("NV3 interface not available in this firmware, please upgrade!")
         return False
 


### PR DESCRIPTION
Older 7.x builds contain `getTokenData` and `setTokenData` but the commands always return `EmberStatus.LIBRARY_NOT_PRESENT` when called.

https://github.com/home-assistant/core/issues/99774