### PR TITLE
fixed cli issues

### DIFF
--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -110,7 +110,7 @@ async def setup(dev, baudrate, cbh=None, configure=True):
         s.add_callback(cbh)
     try:
         await s.connect()
-        await s._startup_reset()
+        await s.startup_reset()
     except Exception as e:
         LOGGER.error(e)
         s.close()


### PR DESCRIPTION
I was having issues running bellows command in cli
e.g.
```
$ bellows -d /dev/XXX -b 115200 -v INFO --flow-control hardware scan
error: _startup_reset not found in COMMANDS
```

looks like the function _startup_reset() does not exist but is called startup_reset() without a leading _.

I am not aware of any implications this might have, but it works now - for me.