### PR TITLE
Remove watchdog failure counter and fail on the first try

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -22,7 +22,6 @@ CONF_DEVICE_BAUDRATE = "baudrate"
 CONF_USE_THREAD = "use_thread"
 CONF_EZSP_CONFIG = "ezsp_config"
 CONF_EZSP_POLICIES = "ezsp_policies"
-CONF_PARAM_MAX_WATCHDOG_FAILURES = "max_watchdog_failures"
 CONF_FLOW_CONTROL = "flow_control"
 CONF_FLOW_CONTROL_DEFAULT = "software"
 
@@ -38,7 +37,6 @@ SCHEMA_DEVICE = SCHEMA_DEVICE.extend(
 CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
         vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
-        vol.Optional(CONF_PARAM_MAX_WATCHDOG_FAILURES, default=4): int,
         vol.Optional(CONF_EZSP_CONFIG, default={}): dict,
         vol.Optional(CONF_EZSP_POLICIES, default={}): vol.Schema(
             {vol.Optional(str): int}

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1134,31 +1134,22 @@ async def test_watchdog(app, monkeypatch, ezsp_version):
 
     monkeypatch.setattr(application, "WATCHDOG_WAKE_PERIOD", 0.01)
     monkeypatch.setattr(application, "EZSP_COUNTERS_CLEAR_IN_WATCHDOG_PERIODS", 2)
-    nop_success = 7
     app._ezsp.ezsp_version = ezsp_version
 
-    async def nop_mock():
-        nonlocal nop_success
-        if nop_success:
-            nop_success -= 1
-            if nop_success % 3:
-                raise EzspError
-            else:
-                return ([0] * 10,)
-        raise asyncio.TimeoutError
-
-    app._ezsp.nop = AsyncMock(side_effect=nop_mock)
-    app._ezsp.readCounters = AsyncMock(side_effect=nop_mock)
-    app._ezsp.readAndClearCounters = AsyncMock(side_effect=nop_mock)
+    app._ezsp.nop = AsyncMock(side_effect=EzspError())
+    app._ezsp.readCounters = AsyncMock(side_effect=EzspError())
+    app._ezsp.readAndClearCounters = AsyncMock(side_effect=EzspError())
     app._handle_reset_request = MagicMock()
     app._ctrl_event.set()
 
     await app._watchdog()
 
     if ezsp_version == 4:
-        assert app._ezsp.nop.await_count > 4
+        assert app._ezsp.nop.await_count == 1
+        assert app._ezsp.readCounters.await_count == 0
     else:
-        assert app._ezsp.readCounters.await_count >= 4
+        assert app._ezsp.nop.await_count == 0
+        assert app._ezsp.readCounters.await_count == 1
 
     assert app._handle_reset_request.call_count == 1
 


### PR DESCRIPTION
Watchdog failures should immediately cause the application controller to fail.