### PR TITLE
EZSP startup reset corner cases

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -138,12 +138,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         try:
             await ezsp.startup_reset()
+
+            # Writing config is required here because network info can't be loaded
+            await ezsp.write_config(self.config[CONF_EZSP_CONFIG])
         except Exception:
             ezsp.close()
             raise
 
-        # Writing config is required here because network info can't be loaded otherwise
-        await ezsp.write_config(self.config[CONF_EZSP_CONFIG])
         self._ezsp = ezsp
 
     async def _ensure_network_running(self) -> bool:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1793,7 +1793,7 @@ async def test_connect_failure(
     app: ControllerApplication, ezsp_mock: ezsp.EZSP
 ) -> None:
     """Test that a failure to connect propagates."""
-    ezsp_mock.startup_reset = AsyncMock(side_effect=OSError())
+    ezsp_mock.write_config = AsyncMock(side_effect=OSError())
     ezsp_mock.connect = AsyncMock()
     app._ezsp = None
 

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -388,7 +388,7 @@ async def test_connection_lost_reset_error_propagation(monkeypatch):
 
     asyncio.get_running_loop().call_later(0.1, gw.connection_lost, ValueError())
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(ValueError):
         await gw.reset()
 
     # Need to close to release thread


### PR DESCRIPTION
There are a few corner cases left with EZSP startup:

1. EZSP remaining open if config writing fails (e.g. disconnect)
2. Disconnect during non-startup reset