### PR TITLE
Register endpoints before stack startup

### DIFF
--- a/bellows/exception.py
+++ b/bellows/exception.py
@@ -11,3 +11,7 @@ class InvalidCommandError(EzspError):
 
 class ControllerError(ControllerException):
     pass
+
+
+class StackAlreadyRunning(EzspError):
+    pass

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -177,9 +177,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def start_network(self):
         ezsp = self._ezsp
 
-        if await repairs.fix_invalid_tclk_partner_ieee(ezsp):
-            await self._reset()
-
         try:
             await self.register_endpoints()
         except StackAlreadyRunning:
@@ -188,6 +185,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await self.register_endpoints()
 
         await self._ensure_network_running()
+
+        if await repairs.fix_invalid_tclk_partner_ieee(ezsp):
+            await self._reset()
+            await self.register_endpoints()
+            await self._ensure_network_running()
 
         if self.config[zigpy.config.CONF_SOURCE_ROUTING]:
             await ezsp.set_source_routing()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -593,9 +593,9 @@ def test_sequence(app):
         assert seq < 256
 
 
-def test_permit_ncp(app):
+async def test_permit_ncp(app):
     app._ezsp.permitJoining = AsyncMock()
-    app.permit_ncp(60)
+    await app.permit_ncp(60)
     assert app._ezsp.permitJoining.call_count == 1
 
 


### PR DESCRIPTION
#579 moved endpoint registration after network startup, causing it to actually fail on real devices.