### PR TITLE
Always send `version(4)` when resetting

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -580,13 +580,6 @@ class EZSP:
                 ],
             }
 
-            # Growing the buffer without being joined to network crashes v8 and earlier
-            (state,) = await self.networkState()
-
-            if state != self.types.EmberNetworkStatus.JOINED_NETWORK:
-                LOGGER.debug("Skipping growing packet buffer, not on a network")
-                del config[self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name]
-
         # First, set the values
         for cfg in values.values():
             # XXX: A read failure does not mean the value is not writeable!

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -569,15 +569,12 @@ class EZSP:
                 ],
             }
 
-            # If we are not joined to a network, old FWs crash if we grow the buffer
-            if self._ezsp_version < 7:
-                (state,) = await self.networkState()
+            # Growing the buffer without being joined to network crashes v8 and earlier
+            (state,) = await self.networkState()
 
-                if state != self.types.EmberNetworkStatus.JOINED_NETWORK:
-                    LOGGER.debug("Skipping growing packet buffer, not on a network")
-                    del ezsp_config[
-                        self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name
-                    ]
+            if state != self.types.EmberNetworkStatus.JOINED_NETWORK:
+                LOGGER.debug("Skipping growing packet buffer, not on a network")
+                del ezsp_config[self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name]
 
         # First, set the values
         for cfg in ezsp_values.values():

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -539,7 +539,8 @@ class EZSP:
         """Return EZSP types for this specific version."""
         return self._protocol.types
 
-    def _merge_config(self, config: dict) -> tuple[dict, dict]:
+    async def write_config(self, config: dict) -> None:
+        """Initialize EmberZNet Stack."""
         config = self._protocol.SCHEMAS[conf.CONF_EZSP_CONFIG](config)
 
         # Not all config will be present in every EZSP version so only use valid keys
@@ -567,21 +568,17 @@ class EZSP:
                 value=value,
             )
 
-        return ezsp_config, ezsp_values
-
-    async def write_config(self, config: dict, values: dict) -> None:
-        """Initialize EmberZNet Stack."""
         # Make sure CONFIG_PACKET_BUFFER_COUNT is always set last
-        if self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name in config:
-            config = {
-                **config,
-                self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name: config[
+        if self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name in ezsp_config:
+            ezsp_config = {
+                **ezsp_config,
+                self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name: ezsp_config[
                     self.types.EzspConfigId.CONFIG_PACKET_BUFFER_COUNT.name
                 ],
             }
 
         # First, set the values
-        for cfg in values.values():
+        for cfg in ezsp_values.values():
             # XXX: A read failure does not mean the value is not writeable!
             status, current_value = await self.getValue(cfg.value_id)
 
@@ -609,7 +606,7 @@ class EZSP:
                 continue
 
         # Finally, set the config
-        for cfg in config.values():
+        for cfg in ezsp_config.values():
             (status, current_value) = await self.getConfigurationValue(cfg.config_id)
 
             # Only grow some config entries, all others should be set

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -142,7 +142,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await ezsp.startup_reset()
 
             # Writing config is required here because network info can't be loaded
-            await ezsp.write_config(*ezsp._merge_config(self.config[CONF_EZSP_CONFIG]))
+            await ezsp.write_config(self.config[CONF_EZSP_CONFIG])
         except Exception:
             ezsp.close()
             raise
@@ -486,10 +486,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def _reset(self):
         self._ezsp.stop_ezsp()
         await self._ezsp.startup_reset()
-        await self._ezsp.write_config(
-            *self._ezsp._merge_config(self.config[CONF_EZSP_CONFIG])
-        )
-        await self.register_endpoints()
+        await self._ezsp.write_config(self.config[CONF_EZSP_CONFIG])
 
     async def disconnect(self):
         # TODO: how do you shut down the stack?

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -154,17 +154,16 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Ensures the network is currently running and returns whether or not the network
         was started.
         """
-        ezsp = self._ezsp
-        (state,) = await ezsp.networkState()
+        (state,) = await self._ezsp.networkState()
 
-        if state == ezsp.types.EmberNetworkStatus.JOINED_NETWORK:
+        if state == self._ezsp.types.EmberNetworkStatus.JOINED_NETWORK:
             return False
 
-        with ezsp.wait_for_stack_status(t.EmberStatus.NETWORK_UP) as stack_status:
-            if ezsp.ezsp_version >= 6:
-                (init_status,) = await ezsp.networkInit(0x0000)
+        with self._ezsp.wait_for_stack_status(t.EmberStatus.NETWORK_UP) as stack_status:
+            if self._ezsp.ezsp_version >= 6:
+                (init_status,) = await self._ezsp.networkInit(0x0000)
             else:
-                (init_status,) = await ezsp.networkInitExtended(0x0000)
+                (init_status,) = await self._ezsp.networkInitExtended(0x0000)
 
             if init_status == t.EmberStatus.NOT_JOINED:
                 raise NetworkNotFormed("Node is not part of a network")

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -142,7 +142,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await ezsp.startup_reset()
 
             # Writing config is required here because network info can't be loaded
-            await ezsp.write_config(self.config[CONF_EZSP_CONFIG])
+            await ezsp.write_config(*ezsp._merge_config(self.config[CONF_EZSP_CONFIG]))
         except Exception:
             ezsp.close()
             raise
@@ -492,7 +492,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def _reset(self):
         self._ezsp.stop_ezsp()
         await self._ezsp.startup_reset()
-        await self._ezsp.write_config(self.config[CONF_EZSP_CONFIG])
+        await self._ezsp.write_config(
+            *self._ezsp._merge_config(self.config[CONF_EZSP_CONFIG])
+        )
 
     async def disconnect(self):
         # TODO: how do you shut down the stack?

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1854,28 +1854,3 @@ async def test_repair_tclk_partner_ieee(app: ControllerApplication) -> None:
         await app.start_network()
 
     assert len(app._reset.mock_calls) == 1
-
-
-async def test_startup_endpoint_register_already_running(
-    app: ControllerApplication, ieee: t.EmberEUI64
-) -> None:
-    """Test that the host is reset before endpoint registration if it is running."""
-
-    app._ezsp = _create_app_for_startup(app, t.EmberNodeType.COORDINATOR, ieee)
-    app._ezsp.addEndpoint = AsyncMock(
-        side_effect=[
-            [t.EmberStatus.INVALID_CALL],  # Fail the first time
-            [t.EmberStatus.SUCCESS],
-            [t.EmberStatus.SUCCESS],
-            [t.EmberStatus.SUCCESS],
-        ]
-    )
-
-    app._reset = AsyncMock()
-
-    with patch.object(bellows.multicast.Multicast, "startup"):
-        await app.start_network()
-
-    assert len(app._reset.mock_calls) == 1
-
-    assert app._ezsp.addEndpoint.call_count >= 3

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -790,12 +790,6 @@ async def test_config_initialize_husbzb1(ezsp_f):
     await ezsp_f.write_config({})
     assert ezsp_f.setConfigurationValue.mock_calls == expected_calls
 
-    # If there is no network, `CONFIG_PACKET_BUFFER_COUNT` won't be set
-    ezsp_f.setConfigurationValue.reset_mock()
-    ezsp_f.networkState = AsyncMock(return_value=(t.EmberNetworkStatus.NO_NETWORK,))
-    await ezsp_f.write_config({})
-    assert ezsp_f.setConfigurationValue.mock_calls == expected_calls[:-1]
-
 
 @pytest.mark.parametrize("version", ezsp.EZSP._BY_VERSION)
 async def test_config_initialize(version: int, ezsp_f, caplog):


### PR DESCRIPTION
This is the root cause of https://github.com/home-assistant/core/issues/102503.

Firmware crashes were seen on EZSPv6 but not on the v8 stick I was testing when I initially added this special case. A HUSBZB-1 running EZSPv8, however, still crashes. This PR removes the protocol version limitation for removing this config.