### PR TITLE
Write board info to zigpy `NodeInfo`

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -344,10 +344,10 @@ class EZSP:
 
         self._protocol(data)
 
-    async def get_board_info(self) -> tuple[str, str, str]:
+    async def get_board_info(self) -> tuple[str, str, str | None]:
         """Return board info."""
 
-        tokens = []
+        tokens = {}
 
         for token in (t.EzspMfgTokenId.MFG_STRING, t.EzspMfgTokenId.MFG_BOARD_NAME):
             (value,) = await self.getMfgToken(token)
@@ -361,11 +361,12 @@ class EZSP:
             except UnicodeDecodeError:
                 result = "0x" + result.hex().upper()
 
-            tokens.append(result)
+            tokens[token] = result
 
         (status, ver_info_bytes) = await self.getValue(
             self.types.EzspValueId.VALUE_VERSION_INFO
         )
+        version = None
 
         if status == t.EmberStatus.SUCCESS:
             build, ver_info_bytes = t.uint16_t.deserialize(ver_info_bytes)
@@ -374,9 +375,12 @@ class EZSP:
             patch, ver_info_bytes = t.uint8_t.deserialize(ver_info_bytes)
             special, ver_info_bytes = t.uint8_t.deserialize(ver_info_bytes)
             version = f"{major}.{minor}.{patch}.{special} build {build}"
-        else:
-            version = "unknown stack version"
-        return tokens[0], tokens[1], version
+
+        return (
+            tokens[t.EzspMfgTokenId.MFG_STRING],
+            tokens[t.EzspMfgTokenId.MFG_BOARD_NAME],
+            version,
+        )
 
     async def _get_nv3_restored_eui64_key(self) -> t.NV3KeyId | None:
         """Get the NV3 key for the device's restored EUI64, if one exists."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "click-log>=0.2.1",
     "pure_pcapy3==1.0.1",
     "voluptuous",
-    "zigpy>=0.54.1",
+    "zigpy>=0.60.0",
     'async-timeout; python_version<"3.11"',
 ]
 

--- a/tests/test_application_network_state.py
+++ b/tests/test_application_network_state.py
@@ -18,6 +18,9 @@ def node_info():
         nwk=zigpy_t.NWK(0x0000),
         ieee=zigpy_t.EUI64.convert("00:12:4b:00:1c:a1:b8:46"),
         logical_type=zdo_t.LogicalType.Coordinator,
+        model="Mock board",
+        manufacturer="Mock Manufacturer",
+        version="Mock version",
     )
 
 

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -423,7 +423,7 @@ async def test_board_info(ezsp_f):
 
     assert mfg == "Manufacturer"
     assert brd == "0xFE"
-    assert ver == "unknown stack version"
+    assert ver is None
 
     with patch.object(
         ezsp_f,


### PR DESCRIPTION
Implements https://github.com/zigpy/zigpy/pull/1274 and adds the following to a generated backup:

```diff
      "node_info": {
          "nwk": "0000",
          "ieee": "04:cd:15:ff:fe:31:0e:ff",
          "logical_type": "coordinator",
+         "model": "Series1 Pro V2",
+         "manufacturer": "tubesZB",
+         "version": "7.2.1.0 build 144"
      }
```