### PR TITLE
Correct gpepIncomingMessageHandler data signature

### DIFF
--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -628,19 +628,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -628,22 +628,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v4/commands.py
+++ b/bellows/ezsp/v4/commands.py
@@ -608,22 +608,25 @@ COMMANDS = {
     ),
     "dGpSentHandler": (0xC7, (), (t.EmberStatus, t.uint8_t)),
     "gpepIncomingMessageHandler": (
-        0xC5,
+        0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
 }

--- a/bellows/ezsp/v4/commands.py
+++ b/bellows/ezsp/v4/commands.py
@@ -611,22 +611,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
 }

--- a/bellows/ezsp/v5/commands.py
+++ b/bellows/ezsp/v5/commands.py
@@ -618,22 +618,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "setSecurityKey": (

--- a/bellows/ezsp/v5/commands.py
+++ b/bellows/ezsp/v5/commands.py
@@ -615,22 +615,25 @@ COMMANDS = {
     ),
     "dGpSentHandler": (0xC7, (), (t.EmberStatus, t.uint8_t)),
     "gpepIncomingMessageHandler": (
-        0xC5,
+        0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "setSecurityKey": (

--- a/bellows/ezsp/v6/commands.py
+++ b/bellows/ezsp/v6/commands.py
@@ -564,22 +564,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v6/commands.py
+++ b/bellows/ezsp/v6/commands.py
@@ -561,22 +561,25 @@ COMMANDS = {
     ),
     "dGpSentHandler": (0xC7, (), (t.EmberStatus, t.uint8_t)),
     "gpepIncomingMessageHandler": (
-        0xC5,
+        0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v7/commands.py
+++ b/bellows/ezsp/v7/commands.py
@@ -605,22 +605,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v7/commands.py
+++ b/bellows/ezsp/v7/commands.py
@@ -602,22 +602,25 @@ COMMANDS = {
     ),
     "dGpSentHandler": (0xC7, (), (t.EmberStatus, t.uint8_t)),
     "gpepIncomingMessageHandler": (
-        0xC5,
+        0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -628,19 +628,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -628,22 +628,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -624,19 +624,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberGpAddress,
+            t.EmberStatus,           # status
+            t.uint8_t,               # gpd link
+            t.uint8_t,               # sequence number
+            t.uint8_t,               # addrType
+            t.uint32_t,              # address
+            t.uint32_t,              # src ID
+            t.uint8_t,               # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,
-            t.Bool,
-            t.uint32_t,
-            t.uint8_t,
-            t.uint32_t,
-            t.EmberGpSinkListEntry,
-            t.LVBytes,
+            t.Bool,                  # auto commissioning
+            t.Bool,                  # rx capable?
+            t.uint32_t,              # security frame counter
+            t.uint8_t,               # gpd command id
+            t.uint32_t,              # MIC
+            t.uint8_t,               # proxy table index
+            t.LVBytes,               # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -624,22 +624,22 @@ COMMANDS = {
         0x00C5,
         (),
         (
-            t.EmberStatus,           # status
-            t.uint8_t,               # gpd link
-            t.uint8_t,               # sequence number
-            t.uint8_t,               # addrType
-            t.uint32_t,              # address
-            t.uint32_t,              # src ID
-            t.uint8_t,               # endpoint
+            t.EmberStatus,  # status
+            t.uint8_t,  # gpd link
+            t.uint8_t,  # sequence number
+            t.uint8_t,  # addrType
+            t.uint32_t,  # address
+            t.uint32_t,  # src ID
+            t.uint8_t,  # endpoint
             t.EmberGpSecurityLevel,
             t.EmberGpKeyType,
-            t.Bool,                  # auto commissioning
-            t.Bool,                  # rx capable?
-            t.uint32_t,              # security frame counter
-            t.uint8_t,               # gpd command id
-            t.uint32_t,              # MIC
-            t.uint8_t,               # proxy table index
-            t.LVBytes,               # optional payload
+            t.Bool,  # auto commissioning
+            t.Bool,  # rx capable?
+            t.uint32_t,  # security frame counter
+            t.uint8_t,  # gpd command id
+            t.uint32_t,  # MIC
+            t.uint8_t,  # proxy table index
+            t.LVBytes,  # optional payload
         ),
     ),
     "gpProxyTableGetEntry": (


### PR DESCRIPTION
This assumes that it's the same across all versions. Of course, that's very difficult to validate given the state of EZSP documentation. However, on v8 this is absolutely correct, and I don't see a reason why it might be only v8 as opposed to everywhere else. Will close #593.