### PR TITLE
Re-expose `bellows.config.CONF_DEVICE_BAUDRATE`

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import voluptuous as vol
 from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
     CONF_DEVICE,
+    CONF_DEVICE_BAUDRATE,
     CONF_DEVICE_PATH,
     CONF_NWK,
     CONF_NWK_CHANNEL,


### PR DESCRIPTION
All device configuration options are now a part of `zigpy.config`. This PR is a stopgap until dependent packages can be fixed.

See https://github.com/NabuCasa/universal-silabs-flasher/issues/46