### PR TITLE
Drop empty frames

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -302,6 +302,10 @@ class EZSP:
             LOGGER.debug("Ignoring frame, protocol is not configured: %r", data)
             return
 
+        if not data:
+            LOGGER.debug("Ignoring empty frame")
+            return
+
         self._protocol(data)
 
     async def get_board_info(

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -863,3 +863,12 @@ async def test_reset_custom_eui64(ezsp_f):
     assert ezsp_f.setTokenData.mock_calls == [
         call(t.NV3KeyId.CREATOR_STACK_RESTORED_EUI64, 0, t.LVBytes32(b"\xFF" * 8))
     ]
+
+
+def test_empty_frame_received(ezsp_f):
+    """Test dropping of invalid, empty frames."""
+    ezsp_f._protocol = MagicMock(spec_set=ezsp_f._protocol)
+    ezsp_f._protocol.__call__ = MagicMock()
+    ezsp_f.frame_received(b"")
+
+    assert ezsp_f._protocol.__call__.mock_calls == []


### PR DESCRIPTION
It seems like zigbeed (or our TCP-enabling patchset for it) can sometimes send completely empty frames:

```
2023-12-11 14:47:18.882 DEBUG (MainThread) [zigpy.serial] Opening a serial connection to 'socket://core-silabs-multiprotocol:9999' (57600 baudrate)
2023-12-11 14:47:18.902 DEBUG (MainThread) [bellows.uart] Data frame: b'592a2c7e'
2023-12-11 14:47:18.902 DEBUG (MainThread) [bellows.uart] Sending: b'8610be7e'
2023-12-11 14:47:18.905 ERROR (MainThread) [homeassistant] Error doing job: Fatal error: protocol.data_received() call failed.
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/asyncio/selector_events.py", line 1003, in _read_ready__data_received
    self._protocol.data_received(data)
  File "/usr/local/lib/python3.11/site-packages/bellows/uart.py", line 76, in data_received
    self.frame_received(frame)
  File "/usr/local/lib/python3.11/site-packages/bellows/uart.py", line 103, in frame_received
    self.data_frame_received(data)
  File "/usr/local/lib/python3.11/site-packages/bellows/uart.py", line 124, in data_frame_received
    self._application.frame_received(self._randomize(data[1:-3]))
  File "/usr/local/lib/python3.11/site-packages/bellows/ezsp/__init__.py", line 305, in frame_received
    self._protocol(data)
  File "/usr/local/lib/python3.11/site-packages/bellows/ezsp/protocol.py", line 83, in __call__
    sequence, frame_id, data = self._ezsp_frame_rx(data)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/bellows/ezsp/v4/__init__.py", line 33, in _ezsp_frame_rx
    return data[0], data[2], data[3:]
           ~~~~^^^
IndexError: index out of range
2023-12-11 14:47:18.932 DEBUG (MainThread) [bellows.uart] Connection lost: IndexError('index out of range')
```