### PR TITLE
Revert "Remove UART thread (#598)"

### DIFF
--- a/bellows/config/__init__.py
+++ b/bellows/config/__init__.py
@@ -30,6 +30,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
         vol.Optional(CONF_EZSP_POLICIES, default={}): vol.Schema(
             {vol.Optional(str): int}
         ),
+        vol.Optional(CONF_USE_THREAD, default=True): cv_boolean,
     }
 )
 

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -129,7 +129,7 @@ class EZSP:
     async def initialize(cls, zigpy_config: dict) -> EZSP:
         """Return initialized EZSP instance."""
         ezsp = cls(zigpy_config[conf.CONF_DEVICE])
-        await ezsp.connect()
+        await ezsp.connect(use_thread=zigpy_config[conf.CONF_USE_THREAD])
 
         try:
             await ezsp.startup_reset()
@@ -139,9 +139,9 @@ class EZSP:
 
         return ezsp
 
-    async def connect(self) -> None:
+    async def connect(self, *, use_thread: bool = True) -> None:
         assert self._gw is None
-        self._gw = await bellows.uart.connect(self._config, self)
+        self._gw = await bellows.uart.connect(self._config, self, use_thread=use_thread)
         self._protocol = v4.EZSPv4(self.handle_callback, self._gw)
 
     async def reset(self):

--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -1,0 +1,122 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import functools
+import logging
+import sys
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EventLoopThread:
+    """Run a parallel event loop in a separate thread."""
+
+    def __init__(self):
+        self.loop = None
+        self.thread_complete = None
+
+    def run_coroutine_threadsafe(self, coroutine):
+        current_loop = asyncio.get_event_loop()
+        future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
+        return asyncio.wrap_future(future, loop=current_loop)
+
+    def _thread_main(self, init_task):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+        try:
+            self.loop.run_until_complete(init_task)
+            self.loop.run_forever()
+        finally:
+            self.loop.close()
+            self.loop = None
+
+    async def start(self):
+        current_loop = asyncio.get_event_loop()
+        if self.loop is not None and not self.loop.is_closed():
+            return
+
+        executor_opts = {"max_workers": 1}
+        if sys.version_info[:2] >= (3, 6):
+            executor_opts["thread_name_prefix"] = __name__
+        executor = ThreadPoolExecutor(**executor_opts)
+
+        thread_started_future = current_loop.create_future()
+
+        async def init_task():
+            current_loop.call_soon_threadsafe(thread_started_future.set_result, None)
+
+        # Use current loop so current loop has a reference to the long-running thread
+        # as one of its tasks
+        thread_complete = current_loop.run_in_executor(
+            executor, self._thread_main, init_task()
+        )
+        self.thread_complete = thread_complete
+        current_loop.call_soon(executor.shutdown, False)
+        await thread_started_future
+        return thread_complete
+
+    def force_stop(self):
+        if self.loop is None:
+            return
+
+        def cancel_tasks_and_stop_loop():
+            tasks = asyncio.all_tasks(loop=self.loop)
+
+            for task in tasks:
+                self.loop.call_soon_threadsafe(task.cancel)
+
+            gather = asyncio.gather(*tasks, return_exceptions=True)
+            gather.add_done_callback(
+                lambda _: self.loop.call_soon_threadsafe(self.loop.stop)
+            )
+
+        self.loop.call_soon_threadsafe(cancel_tasks_and_stop_loop)
+
+
+class ThreadsafeProxy:
+    """Proxy class which enforces threadsafe non-blocking calls
+    This class can be used to wrap an object to ensure any calls
+    using that object's methods are done on a particular event loop
+    """
+
+    def __init__(self, obj, obj_loop):
+        self._obj = obj
+        self._obj_loop = obj_loop
+
+    def __getattr__(self, name):
+        func = getattr(self._obj, name)
+        if not callable(func):
+            raise TypeError(
+                "Can only use ThreadsafeProxy with callable attributes: {}.{}".format(
+                    self._obj.__class__.__name__, name
+                )
+            )
+
+        def func_wrapper(*args, **kwargs):
+            loop = self._obj_loop
+            curr_loop = asyncio.get_running_loop()
+            call = functools.partial(func, *args, **kwargs)
+            if loop == curr_loop:
+                return call()
+            if loop.is_closed():
+                # Disconnected
+                LOGGER.warning("Attempted to use a closed event loop")
+                return
+            if asyncio.iscoroutinefunction(func):
+                future = asyncio.run_coroutine_threadsafe(call(), loop)
+                return asyncio.wrap_future(future, loop=curr_loop)
+            else:
+
+                def check_result_wrapper():
+                    result = call()
+                    if result is not None:
+                        raise TypeError(
+                            (
+                                "ThreadsafeProxy can only wrap functions with no return"
+                                "value \nUse an async method to return values: {}.{}"
+                            ).format(self._obj.__class__.__name__, name)
+                        )
+
+                loop.call_soon_threadsafe(check_result_wrapper)
+
+        return func_wrapper

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -11,6 +11,7 @@ else:
 import zigpy.config
 import zigpy.serial
 
+from bellows.thread import EventLoopThread, ThreadsafeProxy
 import bellows.types as t
 
 LOGGER = logging.getLogger(__name__)
@@ -363,7 +364,7 @@ class Gateway(asyncio.Protocol):
         return out
 
 
-async def connect(config, application):
+async def _connect(config, application):
     loop = asyncio.get_event_loop()
 
     connection_future = loop.create_future()
@@ -386,4 +387,23 @@ async def connect(config, application):
 
     await connection_future
 
+    thread_safe_protocol = ThreadsafeProxy(protocol, loop)
+    return thread_safe_protocol, connection_done_future
+
+
+async def connect(config, application, use_thread=True):
+    if use_thread:
+        application = ThreadsafeProxy(application, asyncio.get_event_loop())
+        thread = EventLoopThread()
+        await thread.start()
+        try:
+            protocol, connection_done = await thread.run_coroutine_threadsafe(
+                _connect(config, application)
+            )
+        except Exception:
+            thread.force_stop()
+            raise
+        connection_done.add_done_callback(lambda _: thread.force_stop())
+    else:
+        protocol, _ = await _connect(config, application)
     return protocol

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -24,7 +24,12 @@ import zigpy.util
 import zigpy.zdo.types as zdo_t
 
 import bellows
-from bellows.config import CONF_EZSP_CONFIG, CONF_EZSP_POLICIES, CONFIG_SCHEMA
+from bellows.config import (
+    CONF_EZSP_CONFIG,
+    CONF_EZSP_POLICIES,
+    CONF_USE_THREAD,
+    CONFIG_SCHEMA,
+)
 from bellows.exception import ControllerError, EzspError, StackAlreadyRunning
 import bellows.ezsp
 from bellows.ezsp.v8.types.named import EmberDeviceUpdate
@@ -133,7 +138,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def connect(self) -> None:
         ezsp = bellows.ezsp.EZSP(self.config[zigpy.config.CONF_DEVICE])
-        await ezsp.connect()
+        await ezsp.connect(use_thread=self.config[CONF_USE_THREAD])
 
         try:
             await ezsp.startup_reset()

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,0 +1,188 @@
+import asyncio
+import sys
+import threading
+from unittest import mock
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
+else:
+    from asyncio import timeout as asyncio_timeout  # pragma: no cover
+
+import pytest
+
+from bellows.thread import EventLoopThread, ThreadsafeProxy
+
+
+async def test_thread_start(monkeypatch):
+    current_loop = asyncio.get_event_loop()
+    loopmock = mock.MagicMock()
+
+    monkeypatch.setattr(asyncio, "new_event_loop", lambda: loopmock)
+    monkeypatch.setattr(asyncio, "set_event_loop", lambda loop: None)
+
+    def mockrun(task):
+        future = asyncio.run_coroutine_threadsafe(task, loop=current_loop)
+        return future.result(1)
+
+    loopmock.run_until_complete.side_effect = mockrun
+    thread = EventLoopThread()
+    thread_complete = await thread.start()
+    await thread_complete
+
+    assert loopmock.run_until_complete.call_count == 1
+    assert loopmock.run_forever.call_count == 1
+    assert loopmock.close.call_count == 1
+
+
+class ExceptionCollector:
+    def __init__(self):
+        self.exceptions = []
+
+    def __call__(self, thread_loop, context):
+        exc = context.get("exception") or Exception(context["message"])
+        self.exceptions.append(exc)
+
+
+@pytest.fixture
+async def thread():
+    thread = EventLoopThread()
+    await thread.start()
+    thread.loop.call_soon_threadsafe(
+        thread.loop.set_exception_handler, ExceptionCollector()
+    )
+    yield thread
+    thread.force_stop()
+    if thread.thread_complete is not None:
+        async with asyncio_timeout(1):
+            await thread.thread_complete
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
+
+
+async def yield_other_thread(thread):
+    await thread.run_coroutine_threadsafe(asyncio.sleep(0))
+
+    exception_collector = thread.loop.get_exception_handler()
+    if exception_collector.exceptions:
+        raise exception_collector.exceptions[0]
+
+
+async def test_thread_loop(thread):
+    async def test_coroutine():
+        return mock.sentinel.result
+
+    future = asyncio.run_coroutine_threadsafe(test_coroutine(), loop=thread.loop)
+    result = await asyncio.wrap_future(future, loop=asyncio.get_event_loop())
+    assert result is mock.sentinel.result
+
+
+async def test_thread_double_start(thread):
+    previous_loop = thread.loop
+    await thread.start()
+    if sys.version_info[:2] >= (3, 6):
+        threads = [t for t in threading.enumerate() if "bellows" in t.name]
+        assert len(threads) == 1
+    assert thread.loop is previous_loop
+
+
+async def test_thread_already_stopped(thread):
+    thread.force_stop()
+    thread.force_stop()
+
+
+async def test_thread_run_coroutine_threadsafe(thread):
+    inner_loop = None
+
+    async def test_coroutine():
+        nonlocal inner_loop
+        inner_loop = asyncio.get_event_loop()
+        return mock.sentinel.result
+
+    result = await thread.run_coroutine_threadsafe(test_coroutine())
+    assert result is mock.sentinel.result
+    assert inner_loop is thread.loop
+
+
+async def test_proxy_callback(thread):
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, thread.loop)
+    obj.test.return_value = None
+    proxy.test()
+    await yield_other_thread(thread)
+    assert obj.test.call_count == 1
+
+
+async def test_proxy_async(thread):
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, thread.loop)
+    call_count = 0
+
+    async def magic():
+        nonlocal thread, call_count
+        assert asyncio.get_event_loop() == thread.loop
+        call_count += 1
+        return mock.sentinel.result
+
+    obj.test = magic
+    result = await proxy.test()
+
+    assert call_count == 1
+    assert result == mock.sentinel.result
+
+
+async def test_proxy_bad_function(thread):
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, thread.loop)
+    obj.test.return_value = mock.sentinel.value
+
+    with pytest.raises(TypeError):
+        proxy.test()
+        await yield_other_thread(thread)
+
+
+async def test_proxy_not_function():
+    loop = asyncio.get_event_loop()
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, loop)
+    obj.test = mock.sentinel.value
+    with pytest.raises(TypeError):
+        proxy.test
+
+
+async def test_proxy_no_thread():
+    loop = asyncio.get_event_loop()
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, loop)
+    proxy.test()
+    assert obj.test.call_count == 1
+
+
+async def test_proxy_loop_closed():
+    loop = asyncio.new_event_loop()
+    obj = mock.MagicMock()
+    proxy = ThreadsafeProxy(obj, loop)
+    loop.close()
+    proxy.test()
+    assert obj.test.call_count == 0
+
+
+async def test_thread_task_cancellation_after_stop(thread):
+    loop = asyncio.get_event_loop()
+    obj = mock.MagicMock()
+
+    async def wait_forever():
+        return await thread.loop.create_future()
+
+    obj.wait_forever = wait_forever
+
+    # Stop the thread while we're waiting
+    loop.call_later(0.1, thread.force_stop)
+
+    proxy = ThreadsafeProxy(obj, thread.loop)
+
+    # The cancellation should propagate to the outer event loop
+    with pytest.raises(asyncio.CancelledError):
+        # This will stall forever without the patch
+        async with asyncio_timeout(1):
+            await proxy.wait_forever()

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 
 import pytest
 import serial_asyncio
@@ -29,8 +30,112 @@ async def test_connect(flow_control, monkeypatch):
             }
         ),
         appmock,
+        use_thread=False,
     )
+
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
     gw.close()
+
+
+async def test_connect_threaded(monkeypatch):
+    appmock = MagicMock()
+    transport = MagicMock()
+
+    async def mockconnect(loop, protocol_factory, **kwargs):
+        protocol = protocol_factory()
+        loop.call_soon(protocol.connection_made, transport)
+        return None, protocol
+
+    monkeypatch.setattr(serial_asyncio, "create_serial_connection", mockconnect)
+
+    def on_transport_close():
+        gw.connection_lost(None)
+
+    transport.close.side_effect = on_transport_close
+    gw = await uart.connect(
+        conf.SCHEMA_DEVICE(
+            {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
+        ),
+        appmock,
+    )
+
+    # Need to close to release thread
+    gw.close()
+
+    # Ensure all threads are cleaned up
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
+
+
+async def test_connect_threaded_failure(monkeypatch):
+    appmock = MagicMock()
+    transport = MagicMock()
+
+    mockconnect = AsyncMock()
+    mockconnect.side_effect = OSError
+
+    monkeypatch.setattr(serial_asyncio, "create_serial_connection", mockconnect)
+
+    def on_transport_close():
+        gw.connection_lost(None)
+
+    transport.close.side_effect = on_transport_close
+    with pytest.raises(OSError):
+        gw = await uart.connect(
+            conf.SCHEMA_DEVICE(
+                {
+                    conf.CONF_DEVICE_PATH: "/dev/serial",
+                    conf.CONF_DEVICE_BAUDRATE: 115200,
+                }
+            ),
+            appmock,
+        )
+
+    # Ensure all threads are cleaned up
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
+
+
+async def test_connect_threaded_failure_cancellation_propagation(monkeypatch):
+    appmock = MagicMock()
+
+    async def mock_connect(loop, protocol_factory, *args, **kwargs):
+        protocol = protocol_factory()
+        transport = AsyncMock()
+
+        protocol.connection_made(transport)
+
+        return transport, protocol
+
+    with patch("bellows.uart.zigpy.serial.create_serial_connection", mock_connect):
+        gw = await uart.connect(
+            conf.SCHEMA_DEVICE(
+                {
+                    conf.CONF_DEVICE_PATH: "/dev/serial",
+                    conf.CONF_DEVICE_BAUDRATE: 115200,
+                }
+            ),
+            appmock,
+            use_thread=True,
+        )
+
+    # Begin waiting for the startup reset
+    wait_for_reset = gw.wait_for_startup_reset()
+
+    # But lose connection halfway through
+    asyncio.get_running_loop().call_later(0.1, gw.connection_lost, RuntimeError())
+
+    # Cancellation should propagate to the outer loop
+    with pytest.raises(RuntimeError):
+        await wait_for_reset
+
+    # Ensure all threads are cleaned up
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
 
 
 @pytest.fixture
@@ -278,6 +383,7 @@ async def test_connection_lost_reset_error_propagation(monkeypatch):
             {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
         ),
         app,
+        use_thread=False,  # required until #484 is merged
     )
 
     asyncio.get_running_loop().call_later(0.1, gw.connection_lost, ValueError())
@@ -285,7 +391,13 @@ async def test_connection_lost_reset_error_propagation(monkeypatch):
     with pytest.raises(ValueError):
         await gw.reset()
 
+    # Need to close to release thread
     gw.close()
+
+    # Ensure all threads are cleaned up
+    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
+    threads = [t for t in threading.enumerate() if "bellows" in t.name]
+    assert len(threads) == 0
 
 
 async def test_wait_for_startup_reset(gw):


### PR DESCRIPTION
This reverts commit 1ac01edef70d49dec21694909ddd9e56d5fc07eb.

The UART thread unfortunately is still necessary: even though writes are done outside of the event loop, notifications to read the serial port's file descriptor are *not* and any event loop slowdown will cause traffic from the radio to the library to effectively be halted.

Example:

```python
2023-12-28 14:05:17.843 DEBUG (MainThread) [serialpy.descriptor_transport] Event loop woke up reader
2023-12-28 14:05:17.843 DEBUG (MainThread) [serialpy.descriptor_transport] Received b"\x07t\xb1\xedT.\x14\xb6R\x95K%\xabU\x920b\xe07t\x121o\x93=\xccf\x8c\xdd\xec;{\x1f~\x17t\xb1\xedT.\x14\xb6R\x95K%\xabU\x923`\xe37t\x121o\x93<\xcck\x8c\xdd]?\xc4}3~'t\xb1\xedT.\x14\xb6R\x95K%\xabU\x922k\xe17t\x121o\x93?\xcch\x8c\xd5w?\x8c\xe1~7t\xb1\xedT.\x14\xb0^\x95K%\xabU\x925c\xe37t\x121k\x93>\xccc\x89\xd9\xd2\x8b\xfe\xe6\xcd\xdex\x8f~Gt\xb1\xedT.\x14\xb6R\x95K%\xabU\x924{\xe37t\x121o\x939\xcck\x8c\xdd]?\xa2}8~\x0ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x920b\xe07t\x121o\x93=\xccf\x8c\xdd\xec;J\xd3~\x1ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x923`\xe37t\x121o\x93<\xcck\x8c\xdd]?\xf5\xdf~/t\xb1\xedT.\x14\xb6R\x95K%\xabU\x922k\xe17t\x121o\x93?\xcch\x8c\xd5w?\xbd-~?t\xb1\xedT.\x14\xb0^\x95K%\xabU\x925c\xe37t\x121k\x93>\xccc\x89\xd9\xd2\x8b\xfe\xe6\xcd\xdeqD~Ot\xb1\xedT.\x14\xb6R\x95K%\xabU\x924{\xe37t\x121o\x939\xcck\x8c\xdd]?\x93\xd4~\x0ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x920b\xe07t\x121o\x93=\xccf\x8c\xdd\xec;J\xd3~\x1ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x923`\xe37t\x121o\x93<\xcck\x8c\xdd]?\xf5\xdf~/t\xb1\xedT.\x14\xb6R\x95K%\xabU\x922k\xe17t\x121o\x93?\xcch\x8c\xd5w?\xbd-~?t\xb1\xedT.\x14\xb0^\x95K%\xabU\x925c\xe37t\x121k\x93>\xccc\x89\xd9\xd2\x8b\xfe\xe6\xcd\xdeqD~Ot\xb1\xedT.\x14\xb6R\x95K%\xabU\x924{\xe37t\x121o\x939\xcck\x8c\xdd]?\x93\xd4~\x0ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x920b\xe07t\x121o\x93=\xccf\x8c\xdd\xec;J\xd3~\x1ft\xb1\xedT.\x14\xb6R\x95K%\xabU\x923`\xe37t\x121o\x93<\xcck\x8c\xdd]?\xf5\xdf~/t\xb1\xedT.\x14\xb6R\x95K%\xabU\x922k\xe17t\x121o\x93?\xcch\x8c\xd5w?\xbd-~?t\xb1\xedT.\x14\xb0^\x95K%\xabU\x925c\xe37t\x121k\x93>\xccc\x89\xd9\xd2\x8b\xfe\xe6\xcd\xdeqD~Ot\xb1\xedT.\x14\xb6R\x95K%\xabU\x924{\xe37t\x121o\x939\xcck\x8c\xdd]?\x93\xd4~\xc2\x02Q\xa8\xbd~"
2023-12-28 14:05:17.843 DEBUG (MainThread) [serialpy.descriptor_transport] Immediately writing b'\x81`Y~'
2023-12-28 14:05:17.844 DEBUG (MainThread) [serialpy.descriptor_transport] Sent 4 of 4 bytes
2023-12-28 14:05:17.844 DEBUG (MainThread) [bellows.ezsp.protocol] Application frame received incomingMessageHandler: [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=2820, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=121), 254, -82, 0xdf10, 255, 255, b'\x18\xc0\n\x05\x05!\x92\x04']
2023-12-28 14:05:17.845 DEBUG (MainThread) [bellows.zigbee.application] Received incomingMessageHandler frame with [<EmberIncomingMessageType.INCOMING_UNICAST: 0>, EmberApsFrame(profileId=260, clusterId=2820, sourceEndpoint=1, destinationEndpoint=1, options=<EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY: 256>, groupId=0, sequence=121), 254, -82, 0xdf10, 255, 255, b'\x18\xc0\n\x05\x05!\x92\x04']
2023-12-28 14:05:17.845 DEBUG (MainThread) [zigpy.application] Received a packet: ZigbeePacket(timestamp=datetime.datetime(2023, 12, 28, 20, 5, 17, 845700, tzinfo=datetime.timezone.utc), src=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0xDF10), src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.NWK: 2>, address=0x0000), dst_ep=1, source_route=None, extended_timeout=False, tsn=121, profile_id=260, cluster_id=2820, data=Serialized[b'\x18\xc0\n\x05\x05!\x92\x04'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=0, lqi=254, rssi=-82)
2023-12-28 14:05:17.847 DEBUG (MainThread) [zigpy.zcl] [0xDF10:1:0x0b04] Received ZCL frame: b'\x18\xc0\n\x05\x05!\x92\x04'
2023-12-28 14:05:17.847 DEBUG (MainThread) [zigpy.zcl] [0xDF10:1:0x0b04] Decoded ZCL frame header: ZCLHeader(frame_control=FrameControl(frame_type=<FrameType.GLOBAL_COMMAND: 0>, is_manufacturer_specific=0, direction=<Direction.Client_to_Server: 1>, disable_default_response=1, reserved=0, *is_cluster=False, *is_general=True), tsn=192, command_id=10, *direction=<Direction.Client_to_Server: 1>)
2023-12-28 14:05:17.849 DEBUG (MainThread) [zigpy.zcl] [0xDF10:1:0x0b04] Decoded ZCL frame: ElectricalMeasurement:Report_Attributes(attribute_reports=[Attribute(attrid=0x0505, value=TypeValue(type=uint16_t, value=1170))])
2023-12-28 14:05:17.849 DEBUG (MainThread) [zigpy.zcl] [0xDF10:1:0x0b04] Received command 0x0A (TSN 192): Report_Attributes(attribute_reports=[Attribute(attrid=0x0505, value=TypeValue(type=uint16_t, value=1170))])
2023-12-28 14:05:17.850 DEBUG (MainThread) [zigpy.zcl] [0xDF10:1:0x0b04] Attribute report received: rms_voltage=1170
2023-12-28 14:05:17.852 DEBUG (MainThread) [serialpy.descriptor_transport] Immediately writing b'\x82P:~'
2023-12-28 14:05:17.853 DEBUG (MainThread) [serialpy.descriptor_transport] Sent 4 of 4 bytes
...
```