### PR TITLE
fixed missing length of array in EZSP setSourceRoute from V8 onward

### DIFF
--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -315,7 +315,7 @@ COMMANDS = {
     ),
     "setSourceRoute": (
         0x00AE,
-        (t.EmberNodeId, t.LVList(t.EmberNodeId)),
+        (t.EmberNodeId, t.uint8_t, t.LVList(t.EmberNodeId)),
         (t.EmberStatus,),
     ),
     "setSourceRouteDiscoveryMode": (0x005A, (t.uint8_t,), (t.uint32_t,)),

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -314,7 +314,7 @@ COMMANDS = {
     "changeSourceRouteHandler": (0x00C4, (), (t.EmberNodeId, t.EmberNodeId, t.Bool)),
     "setSourceRoute": (
         0x00AE,
-        (t.EmberNodeId, t.LVList(t.EmberNodeId)),
+        (t.EmberNodeId, t.uint8_t, t.LVList(t.EmberNodeId)),
         (t.EmberStatus,),
     ),
     "setSourceRouteDiscoveryMode": (0x005A, (t.uint8_t,), (t.uint32_t,)),

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -311,7 +311,7 @@ COMMANDS = {
     "changeSourceRouteHandler": (0x00C4, (), (t.EmberNodeId, t.EmberNodeId, t.Bool)),
     "setSourceRoute": (
         0x00AE,
-        (t.EmberNodeId, t.LVList(t.EmberNodeId)),
+        (t.EmberNodeId, t.uint8_t, t.LVList(t.EmberNodeId)),
         (t.EmberStatus,),
     ),
     "setSourceRouteDiscoveryMode": (0x005A, (t.uint8_t,), (t.uint32_t,)),

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -775,8 +775,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def _set_source_route(
         self, nwk: zigpy.types.NWK, relays: list[zigpy.types.NWK]
     ) -> bool:
-        (res,) = await self._ezsp.setSourceRoute(nwk, relays)
-        return res == t.EmberStatus.SUCCESS
+        if self._ezsp.ezsp_version >= 8:
+            (res,) = await self._ezsp.setSourceRoute(nwk, len(relays), relays)
+            return res == t.EmberStatus.SUCCESS
+        else:
+            (res,) = await self._ezsp.setSourceRoute(nwk, relays)
+            return res == t.EmberStatus.SUCCESS
 
     async def energy_scan(
         self, channels: t.Channels, duration_exp: int, count: int


### PR DESCRIPTION
Happy new year, guys!

I might be mistaken, or might have missed an internal mechanism that sends array lengths, but I am somewhat confident that there is a bug in the setSourceRoute function from EZSP version 8 onward.

This is the code from Gecko SDI:
https://github.com/SiliconLabs/gecko_sdk/blame/gsdk_4.3/protocol/zigbee/app/util/ezsp/command-functions.h#L1718-L1734

This is the method signature:
```
EmberStatus ezspSetSourceRoute(
  EmberNodeId destination,
  uint8_t relayCount,
  uint16_t *relayList)
```

I believe the length of the array is missing. This PR would fix that.