### PR TITLE
Remove counter not used in EZSP v7

### DIFF
--- a/bellows/ezsp/v7/types/named.py
+++ b/bellows/ezsp/v7/types/named.py
@@ -565,9 +565,6 @@ class EmberCounterType(basic.enum8):
     COUNTER_PTA_LO_PRI_TX_ABORTED = 38
     # The number of aborted high priority packet traffic arbitration transmissions.
     COUNTER_PTA_HI_PRI_TX_ABORTED = 39
-    # The number of times an address conflict has caused node_id change, and an address
-    # conflict error is sent
-    COUNTER_ADDRESS_CONFLICT_SENT = 40
 
 
 class EmberJoinMethod(basic.enum8):


### PR DESCRIPTION
This counter is present only in EZSP v8.

Related: https://github.com/home-assistant/core/issues/116575, https://github.com/zigpy/zigpy/issues/1394