### PR TITLE
Convert command types to dictionaries

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -205,15 +205,18 @@ class EZSP:
             "getValue": 999,
         }.get(name, 0)
 
-    async def _command(self, name: str, *args: tuple[Any, ...]) -> Any:
+    async def _command(self, name: str, *args: Any, **kwargs: Any) -> Any:
         if not self.is_ezsp_running:
             LOGGER.debug(
-                "Couldn't send command %s(%s). EZSP is not running", name, args
+                "Couldn't send command %s(%s, %s). EZSP is not running",
+                name,
+                args,
+                kwargs,
             )
             raise EzspError("EZSP is not running")
 
         async with self._send_sem(priority=self._get_command_priority(name)):
-            return await self._protocol.command(name, *args)
+            return await self._protocol.command(name, *args, **kwargs)
 
     async def _list_command(self, name, item_frames, completion_frame, spos, *args):
         """Run a command, returning result callbacks as a list"""

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -172,11 +172,11 @@ class EZSP:
 
     async def version(self):
         ver, stack_type, stack_version = await self._command(
-            "version", self.ezsp_version
+            "version", desiredProtocolVersion=self.ezsp_version
         )
         if ver != self.ezsp_version:
             self._switch_protocol_version(ver)
-            await self._command("version", ver)
+            await self._command("version", desiredProtocolVersion=ver)
         LOGGER.debug(
             "EZSP Stack Type: %s, Stack Version: %04x, Protocol version: %s",
             stack_type,
@@ -218,7 +218,9 @@ class EZSP:
         async with self._send_sem(priority=self._get_command_priority(name)):
             return await self._protocol.command(name, *args, **kwargs)
 
-    async def _list_command(self, name, item_frames, completion_frame, spos, *args):
+    async def _list_command(
+        self, name, item_frames, completion_frame, spos, *args, **kwargs
+    ):
         """Run a command, returning result callbacks as a list"""
         fut = asyncio.Future()
         results = []
@@ -231,7 +233,7 @@ class EZSP:
 
         cbid = self.add_callback(cb)
         try:
-            v = await self._command(name, *args)
+            v = await self._command(name, *args, **kwargs)
             if t.sl_Status.from_ember_status(v[0]) != t.sl_Status.OK:
                 raise Exception(v)
             v = await fut
@@ -307,7 +309,7 @@ class EZSP:
 
     async def formNetwork(self, parameters: t.EmberNetworkParameters) -> None:
         with self.wait_for_stack_status(t.sl_Status.NETWORK_UP) as stack_status:
-            v = await self._command("formNetwork", parameters)
+            v = await self._command("formNetwork", parameters=parameters)
 
             if t.sl_Status.from_ember_status(v[0]) != t.sl_Status.OK:
                 raise zigpy.exceptions.FormationFailure(f"Failure forming network: {v}")
@@ -344,7 +346,7 @@ class EZSP:
         tokens = {}
 
         for token in (t.EzspMfgTokenId.MFG_STRING, t.EzspMfgTokenId.MFG_BOARD_NAME):
-            (value,) = await self.getMfgToken(token)
+            (value,) = await self.getMfgToken(tokenId=token)
             LOGGER.debug("Read %s token: %s", token.name, value)
 
             # Tokens are fixed-length and initially filled with \xFF
@@ -360,7 +362,9 @@ class EZSP:
 
             tokens[token] = result
 
-        (status, ver_info_bytes) = await self.getValue(t.EzspValueId.VALUE_VERSION_INFO)
+        (status, ver_info_bytes) = await self.getValue(
+            valueId=t.EzspValueId.VALUE_VERSION_INFO
+        )
         version = None
 
         if t.sl_Status.from_ember_status(status) == t.sl_Status.OK:
@@ -384,7 +388,7 @@ class EZSP:
             t.NV3KeyId.NVM3KEY_STACK_RESTORED_EUI64,  # RCP firmware
         ):
             try:
-                rsp = await self.getTokenData(key, 0)
+                rsp = await self.getTokenData(token=key, index=0)
             except (InvalidCommandError, AttributeError):
                 # Either the command doesn't exist in the EZSP version, or the command
                 # is not implemented in the firmware
@@ -400,7 +404,7 @@ class EZSP:
 
     async def _get_mfg_custom_eui_64(self) -> t.EUI64 | None:
         """Get the custom EUI 64 manufacturing token, if it has a valid value."""
-        (data,) = await self.getMfgToken(t.EzspMfgTokenId.MFG_CUSTOM_EUI_64)
+        (data,) = await self.getMfgToken(tokenId=t.EzspMfgTokenId.MFG_CUSTOM_EUI_64)
 
         # Manufacturing tokens do not exist in RCP firmware: all reads are empty
         if not data:
@@ -458,14 +462,15 @@ class EZSP:
         if nv3_eui64_key is not None:
             # Prefer NV3 storage over MFG_CUSTOM_EUI_64, as it can be rewritten
             (status,) = await self.setTokenData(
-                nv3_eui64_key,
-                0,
-                t.LVBytes32(ieee.serialize()),
+                token=nv3_eui64_key,
+                index=0,
+                token_data=t.LVBytes32(ieee.serialize()),
             )
             assert t.sl_Status.from_ember_status(status) == t.sl_Status.OK
         elif mfg_custom_eui64 is None and burn_into_userdata:
             (status,) = await self.setMfgToken(
-                t.EzspMfgTokenId.MFG_CUSTOM_EUI_64, ieee.serialize()
+                tokenId=t.EzspMfgTokenId.MFG_CUSTOM_EUI_64,
+                tokenData=ieee.serialize(),
             )
             assert t.sl_Status.from_ember_status(status) == t.sl_Status.OK
         elif mfg_custom_eui64 is None and not burn_into_userdata:
@@ -500,20 +505,20 @@ class EZSP:
     async def set_source_routing(self) -> None:
         """Enable source routing on NCP."""
         res = await self.setConcentrator(
-            True,
-            t.EmberConcentratorType.HIGH_RAM_CONCENTRATOR,
-            MTOR_MIN_INTERVAL,
-            MTOR_MAX_INTERVAL,
-            MTOR_ROUTE_ERROR_THRESHOLD,
-            MTOR_DELIVERY_FAIL_THRESHOLD,
-            0,
+            on=True,
+            concentratorType=t.EmberConcentratorType.HIGH_RAM_CONCENTRATOR,
+            minTime=MTOR_MIN_INTERVAL,
+            maxTime=MTOR_MAX_INTERVAL,
+            routeErrorThreshold=MTOR_ROUTE_ERROR_THRESHOLD,
+            deliveryFailureThreshold=MTOR_DELIVERY_FAIL_THRESHOLD,
+            maxHops=0,
         )
         LOGGER.debug("Set concentrator type: %s", res)
         if t.sl_Status.from_ember_status(res[0]) != t.sl_Status.OK:
             LOGGER.warning("Couldn't set concentrator type %s: %s", True, res)
 
         if self._ezsp_version >= 8:
-            await self.setSourceRouteDiscoveryMode(1)
+            await self.setSourceRouteDiscoveryMode(mode=1)
 
     def start_ezsp(self):
         """Mark EZSP as running."""
@@ -579,7 +584,7 @@ class EZSP:
         # First, set the values
         for cfg in ezsp_values.values():
             # XXX: A read failure does not mean the value is not writeable!
-            status, current_value = await self.getValue(cfg.value_id)
+            status, current_value = await self.getValue(valueId=cfg.value_id)
 
             if t.sl_Status.from_ember_status(status) == t.sl_Status.OK:
                 current_value, _ = type(cfg.value).deserialize(current_value)
@@ -593,7 +598,9 @@ class EZSP:
                 current_value,
             )
 
-            (status,) = await self.setValue(cfg.value_id, cfg.value.serialize())
+            (status,) = await self.setValue(
+                valueId=cfg.value_id, value=cfg.value.serialize()
+            )
 
             if t.sl_Status.from_ember_status(status) != t.sl_Status.OK:
                 LOGGER.debug(
@@ -606,7 +613,9 @@ class EZSP:
 
         # Finally, set the config
         for cfg in ezsp_config.values():
-            (status, current_value) = await self.getConfigurationValue(cfg.config_id)
+            (status, current_value) = await self.getConfigurationValue(
+                configId=cfg.config_id
+            )
 
             # Only grow some config entries, all others should be set
             if (
@@ -629,7 +638,9 @@ class EZSP:
                 current_value,
             )
 
-            (status,) = await self.setConfigurationValue(cfg.config_id, cfg.value)
+            (status,) = await self.setConfigurationValue(
+                configId=cfg.config_id, value=cfg.value
+            )
             if t.sl_Status.from_ember_status(status) != t.sl_Status.OK:
                 LOGGER.debug(
                     "Could not set config %s = %s: %s",

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -64,7 +64,7 @@ class ProtocolHandler(abc.ABC):
 
     async def command(self, name, *args, **kwargs) -> Any:
         """Serialize command and send it."""
-        LOGGER.debug("Sending command  %s: %s", name, args)
+        LOGGER.debug("Sending command  %s: %s %s", name, args, kwargs)
         data = self._ezsp_frame(name, *args, **kwargs)
         cmd_id, _, rx_schema = self.COMMANDS[name]
         future = asyncio.get_running_loop().create_future()

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -49,8 +49,7 @@ class ProtocolHandler(abc.ABC):
         frame = self._ezsp_frame_tx(name)
 
         if isinstance(tx_schema, dict):
-            assert not kwargs
-            data = t.serialize_dict(args, tx_schema)
+            data = t.serialize_dict(args, kwargs, tx_schema)
         else:
             data = tx_schema(*args, **kwargs).serialize()
         return frame + data

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -51,7 +51,7 @@ class ProtocolHandler(abc.ABC):
         if isinstance(tx_schema, dict):
             assert not kwargs
             data = t.serialize_dict(args, tx_schema)
-        elif isinstance(tx_schema, tuple):
+        elif isinstance(tx_schema, (tuple, list)):
             assert not kwargs
             data = t.serialize(args, tx_schema)
         else:
@@ -108,7 +108,7 @@ class ProtocolHandler(abc.ABC):
             return
 
         try:
-            if isinstance(rx_schema, tuple):
+            if isinstance(rx_schema, (tuple, list)):
                 result, data = t.deserialize(data, rx_schema)
                 LOGGER.debug("Received command %s: %s", frame_name, result)
             elif isinstance(rx_schema, dict):

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -51,9 +51,6 @@ class ProtocolHandler(abc.ABC):
         if isinstance(tx_schema, dict):
             assert not kwargs
             data = t.serialize_dict(args, tx_schema)
-        elif isinstance(tx_schema, (tuple, list)):
-            assert not kwargs
-            data = t.serialize(args, tx_schema)
         else:
             data = tx_schema(*args, **kwargs).serialize()
         return frame + data
@@ -108,13 +105,10 @@ class ProtocolHandler(abc.ABC):
             return
 
         try:
-            if isinstance(rx_schema, (tuple, list)):
-                result, data = t.deserialize(data, rx_schema)
-                LOGGER.debug("Received command %s: %s", frame_name, result)
-            elif isinstance(rx_schema, dict):
+            if isinstance(rx_schema, dict):
                 result, data = t.deserialize_dict(data, rx_schema)
                 LOGGER.debug("Received command %s: %s", frame_name, result)
-                result = tuple(result.values())
+                result = list(result.values())
             else:
                 result, data = rx_schema.deserialize(data)
                 LOGGER.debug("Received command %s: %s", frame_name, result)

--- a/bellows/ezsp/v10/__init__.py
+++ b/bellows/ezsp/v10/__init__.py
@@ -27,8 +27,8 @@ class EZSPv10(EZSPv9):
     async def write_child_data(self, children: dict[t.EUI64, t.NWK]) -> None:
         for index, (eui64, nwk) in enumerate(children.items()):
             await self.setChildData(
-                index,
-                t.EmberChildDataV10(
+                index=index,
+                child_data=t.EmberChildDataV10(
                     eui64=eui64,
                     type=t.EmberNodeType.SLEEPY_END_DEVICE,
                     id=nwk,

--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -7,30 +7,22 @@ COMMANDS = {
     # Use the correct `EmberChildData` object with the extra field
     "getChildData": (
         0x004A,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "child_data": t.EmberChildDataV10,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "child_data": t.EmberChildDataV10,
+        },
     ),
     "setChildData": (
         0x00AC,
-        tuple(
-            {
-                "index": t.uint8_t,
-                "child_data": t.EmberChildDataV10,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+            "child_data": t.EmberChildDataV10,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
 }

--- a/bellows/ezsp/v10/commands.py
+++ b/bellows/ezsp/v10/commands.py
@@ -7,12 +7,30 @@ COMMANDS = {
     # Use the correct `EmberChildData` object with the extra field
     "getChildData": (
         0x004A,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberChildDataV10),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "child_data": t.EmberChildDataV10,
+            }.values()
+        ),
     ),
     "setChildData": (
         0x00AC,
-        (t.uint8_t, t.EmberChildDataV10),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "index": t.uint8_t,
+                "child_data": t.EmberChildDataV10,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
 }

--- a/bellows/ezsp/v11/commands.py
+++ b/bellows/ezsp/v11/commands.py
@@ -6,12 +6,10 @@ COMMANDS = {
     **COMMANDS_v10,
     "pollHandler": (
         0x0044,
-        tuple({}.values()),
-        tuple(
-            {
-                "childId": t.EmberNodeId,
-                "transmitExpected": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "childId": t.EmberNodeId,
+            "transmitExpected": t.Bool,
+        },
     ),
 }

--- a/bellows/ezsp/v11/commands.py
+++ b/bellows/ezsp/v11/commands.py
@@ -6,7 +6,12 @@ COMMANDS = {
     **COMMANDS_v10,
     "pollHandler": (
         0x0044,
-        (),
-        tuple({"childId": t.EmberNodeId, "transmitExpected": t.Bool}.values()),
+        tuple({}.values()),
+        tuple(
+            {
+                "childId": t.EmberNodeId,
+                "transmitExpected": t.Bool,
+            }.values()
+        ),
     ),
 }

--- a/bellows/ezsp/v12/commands.py
+++ b/bellows/ezsp/v12/commands.py
@@ -7,193 +7,145 @@ COMMANDS = {
     **COMMANDS_v11,
     "readAttribute": (
         0x0108,
-        tuple(
-            {
-                "endpoint": t.uint8_t,
-                "cluster": t.uint16_t,
-                "attributeId": t.uint16_t,
-                "mask": t.uint8_t,
-                "manufacturerCode": t.uint16_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "dataType": t.uint8_t,
-                "data": t.LVBytes,
-            }.values()
-        ),
+        {
+            "endpoint": t.uint8_t,
+            "cluster": t.uint16_t,
+            "attributeId": t.uint16_t,
+            "mask": t.uint8_t,
+            "manufacturerCode": t.uint16_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "dataType": t.uint8_t,
+            "data": t.LVBytes,
+        },
     ),
     "writeAttribute": (
         0x0109,
-        tuple(
-            {
-                "endpoint": t.uint8_t,
-                "cluster": t.uint16_t,
-                "attributeId": t.uint16_t,
-                "mask": t.uint8_t,
-                "manufacturerCode": t.uint16_t,
-                "overrideReadOnlyAndDataType": t.Bool,
-                "justTest": t.Bool,
-                "dataType": t.uint8_t,
-                "data": t.LVBytes,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "endpoint": t.uint8_t,
+            "cluster": t.uint16_t,
+            "attributeId": t.uint16_t,
+            "mask": t.uint8_t,
+            "manufacturerCode": t.uint16_t,
+            "overrideReadOnlyAndDataType": t.Bool,
+            "justTest": t.Bool,
+            "dataType": t.uint8_t,
+            "data": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setPassiveAckConfig": (
         0x0105,
-        tuple(
-            {
-                "config": t.uint8_t,
-                "minAcksNeeded": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "config": t.uint8_t,
+            "minAcksNeeded": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "checkKeyContext": (
         0x0110,
-        tuple(
-            {
-                "config": t.uint8_t,
-                "minAcksNeeded": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "config": t.uint8_t,
+            "minAcksNeeded": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "childId": (
         0x0106,
-        tuple(
-            {
-                "childIndex": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "childId": t.EmberNodeId,
-            }.values()
-        ),
+        {
+            "childIndex": t.uint8_t,
+        },
+        {
+            "childId": t.EmberNodeId,
+        },
     ),
     "exportKey": (
         0x0114,
-        tuple(
-            {
-                "context": t.SecurityManagerContextV12,
-            }.values()
-        ),
-        tuple(
-            {
-                "key": KeyData,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context": t.SecurityManagerContextV12,
+        },
+        {
+            "key": KeyData,
+            "status": t.sl_Status,
+        },
     ),
     "exportLinkKeyByEui": (
         0x010D,
-        tuple(
-            {
-                "eui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "plaintext_key": KeyData,
-                "index": t.uint8_t,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "plaintext_key": KeyData,
+            "index": t.uint8_t,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "exportLinkKeyByIndex": (
         0x010F,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "eui64": t.EUI64,
-                "plaintext_key": KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "eui64": t.EUI64,
+            "plaintext_key": KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "exportTransientKeyByEui": (
         0x0113,
-        tuple(
-            {
-                "eui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "context": t.SecurityManagerContextV12,
-                "plaintext_key": KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "context": t.SecurityManagerContextV12,
+            "plaintext_key": KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "exportTransientKeyByIndex": (
         0x0112,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "context": t.SecurityManagerContextV12,
-                "plaintext_key": KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "context": t.SecurityManagerContextV12,
+            "plaintext_key": KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "getApsKeyInfo": (
         0x010C,
-        tuple(
-            {
-                "context_in": t.SecurityManagerContextV12,
-            }.values()
-        ),
-        tuple(
-            {
-                "eui": t.EUI64,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context_in": t.SecurityManagerContextV12,
+        },
+        {
+            "eui": t.EUI64,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "gpSinkCommission": (
         0x010A,
-        tuple(
-            {
-                "options": t.uint8_t,
-                "gpmAddrForSecurity": t.uint16_t,
-                "gpmAddrForPairing": t.uint16_t,
-                "sinkEndpoint": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "options": t.uint8_t,
+            "gpmAddrForSecurity": t.uint16_t,
+            "gpmAddrForPairing": t.uint16_t,
+            "sinkEndpoint": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "gpTranslationTableClear": (
         0x010B,
@@ -202,46 +154,34 @@ COMMANDS = {
     ),
     "importKey": (
         0x0115,
-        tuple(
-            {
-                "context": t.SecurityManagerContextV12,
-                "key": KeyData,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context": t.SecurityManagerContextV12,
+            "key": KeyData,
+        },
+        {
+            "status": t.sl_Status,
+        },
     ),
     "importLinkKey": (
         0x010E,
-        tuple(
-            {
-                "index": t.uint8_t,
-                "address": t.EUI64,
-                "key": KeyData,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+            "address": t.EUI64,
+            "key": KeyData,
+        },
+        {
+            "status": t.sl_Status,
+        },
     ),
     "importTransientKey": (
         0x0111,
-        tuple(
-            {
-                "eui64": t.EUI64,
-                "plaintext_key": KeyData,
-                "flags": t.SecurityManagerContextFlags,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+            "plaintext_key": KeyData,
+            "flags": t.SecurityManagerContextFlags,
+        },
+        {
+            "status": t.sl_Status,
+        },
     ),
 }

--- a/bellows/ezsp/v13/commands.py
+++ b/bellows/ezsp/v13/commands.py
@@ -7,111 +7,85 @@ COMMANDS = {
     "getNetworkKeyInfo": (
         0x0116,
         (),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "network_key_info": t.SecurityManagerNetworkKeyInfo,
-            }.values()
-        ),
+        {
+            "status": t.sl_Status,
+            "network_key_info": t.SecurityManagerNetworkKeyInfo,
+        },
     ),
     "gpSecurityTestVectors": (
         0x0117,
         (),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "tokenFactoryReset": (
         0x0077,
-        tuple({"excludeOutgoingFC": t.Bool, "excludeBootCounter": t.Bool}.values()),
+        ({"excludeOutgoingFC": t.Bool, "excludeBootCounter": t.Bool}),
         (),
     ),
     "gpSinkTableGetNumberOfActiveEntries": (
         0x0118,
         (),
-        tuple(
-            {
-                "number_of_entries": t.uint8_t,
-            }.values()
-        ),
+        {
+            "number_of_entries": t.uint8_t,
+        },
     ),
     # The following commands are redefined because `SecurityManagerContext` changed
     "exportKey": (
         0x0114,
-        tuple(
-            {
-                "context": t.SecurityManagerContextV13,
-            }.values()
-        ),
-        tuple(
-            {
-                "key": t.KeyData,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context": t.SecurityManagerContextV13,
+        },
+        {
+            "key": t.KeyData,
+            "status": t.sl_Status,
+        },
     ),
     "exportTransientKeyByEui": (
         0x0113,
-        tuple(
-            {
-                "eui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "context": t.SecurityManagerContextV13,
-                "plaintext_key": t.KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "context": t.SecurityManagerContextV13,
+            "plaintext_key": t.KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "exportTransientKeyByIndex": (
         0x0112,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "context": t.SecurityManagerContextV13,
-                "plaintext_key": t.KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "context": t.SecurityManagerContextV13,
+            "plaintext_key": t.KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "getApsKeyInfo": (
         0x010C,
-        tuple(
-            {
-                "context_in": t.SecurityManagerContextV13,
-            }.values()
-        ),
-        tuple(
-            {
-                "eui": t.EUI64,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context_in": t.SecurityManagerContextV13,
+        },
+        {
+            "eui": t.EUI64,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+            "status": t.sl_Status,
+        },
     ),
     "importKey": (
         0x0115,
-        tuple(
-            {
-                "context": t.SecurityManagerContextV13,
-                "key": t.KeyData,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "context": t.SecurityManagerContextV13,
+            "key": t.KeyData,
+        },
+        {
+            "status": t.sl_Status,
+        },
     ),
 }
 

--- a/bellows/ezsp/v13/commands.py
+++ b/bellows/ezsp/v13/commands.py
@@ -6,7 +6,7 @@ COMMANDS = {
     **COMMANDS_v12,
     "getNetworkKeyInfo": (
         0x0116,
-        (),
+        {},
         {
             "status": t.sl_Status,
             "network_key_info": t.SecurityManagerNetworkKeyInfo,
@@ -14,19 +14,22 @@ COMMANDS = {
     ),
     "gpSecurityTestVectors": (
         0x0117,
-        (),
+        {},
         {
             "status": t.EmberStatus,
         },
     ),
     "tokenFactoryReset": (
         0x0077,
-        ({"excludeOutgoingFC": t.Bool, "excludeBootCounter": t.Bool}),
-        (),
+        {
+            "excludeOutgoingFC": t.Bool,
+            "excludeBootCounter": t.Bool,
+        },
+        {},
     ),
     "gpSinkTableGetNumberOfActiveEntries": (
         0x0118,
-        (),
+        {},
         {
             "number_of_entries": t.uint8_t,
         },

--- a/bellows/ezsp/v14/__init__.py
+++ b/bellows/ezsp/v14/__init__.py
@@ -26,11 +26,11 @@ class EZSPv14(EZSPv13):
 
     async def read_address_table(self) -> AsyncGenerator[tuple[t.NWK, t.EUI64], None]:
         (status, addr_table_size) = await self.getConfigurationValue(
-            t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE
+            configId=t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE
         )
 
         for idx in range(addr_table_size + 100):
-            (status, nwk, eui64) = await self.getAddressTableInfo(idx)
+            (status, nwk, eui64) = await self.getAddressTableInfo(index=idx)
 
             if status != t.sl_Status.OK:
                 continue
@@ -45,7 +45,7 @@ class EZSPv14(EZSPv13):
 
     async def get_network_key(self) -> zigpy.state.Key:
         status, network_key_data, _ = await self.exportKey(
-            t.SecurityManagerContextV13(
+            context=t.SecurityManagerContextV13(
                 core_key_type=t.SecurityManagerKeyType.NETWORK,
                 key_index=0,
                 derived_type=t.SecurityManagerDerivedKeyTypeV13.NONE,
@@ -72,7 +72,7 @@ class EZSPv14(EZSPv13):
 
     async def get_tc_link_key(self) -> zigpy.state.Key:
         status, tc_link_key_data, _ = await self.exportKey(
-            t.SecurityManagerContextV13(
+            context=t.SecurityManagerContextV13(
                 core_key_type=t.SecurityManagerKeyType.TC_LINK,
                 key_index=0,
                 derived_type=t.SecurityManagerDerivedKeyTypeV13.NONE,
@@ -97,13 +97,13 @@ class EZSPv14(EZSPv13):
         data: bytes,
     ) -> tuple[t.sl_Status, t.uint8_t]:
         status, sequence = await self.sendBroadcast(
-            0x0000,
-            address,
-            aps_sequence,
-            aps_frame,
-            radius,
-            message_tag,
-            data,
+            alias=0x0000,
+            destination=address,
+            sequence=aps_sequence,
+            aps_frame=aps_frame,
+            radius=radius,
+            message_tag=message_tag,
+            message=data,
         )
 
         return status, sequence

--- a/bellows/ezsp/v14/commands.py
+++ b/bellows/ezsp/v14/commands.py
@@ -30,7 +30,10 @@ COMMANDS = {
     ),
     "getTokenData": (
         0x0102,
-        ({"token": t.uint32_t, "index": t.uint32_t}),
+        {
+            "token": t.uint32_t,
+            "index": t.uint32_t,
+        },
         GetTokenDataRsp,
     ),
     "exportLinkKeyByIndex": (

--- a/bellows/ezsp/v14/commands.py
+++ b/bellows/ezsp/v14/commands.py
@@ -20,152 +20,120 @@ _REPLACEMENTS = {
 COMMANDS = {
     "setExtendedTimeout": (
         0x007E,
-        tuple(
-            {
-                "remoteEui64": t.EUI64,
-                "extendedTimeout": t.Bool,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-            }.values()
-        ),
+        {
+            "remoteEui64": t.EUI64,
+            "extendedTimeout": t.Bool,
+        },
+        {
+            "status": t.sl_Status,
+        },
     ),
     "getTokenData": (
         0x0102,
-        tuple({"token": t.uint32_t, "index": t.uint32_t}.values()),
+        ({"token": t.uint32_t, "index": t.uint32_t}),
         GetTokenDataRsp,
     ),
     "exportLinkKeyByIndex": (
         0x010F,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "context": t.SecurityManagerContextV13,
-                "plaintext_key": t.KeyData,
-                "key_data": t.SecurityManagerAPSKeyMetadata,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.sl_Status,
+            "context": t.SecurityManagerContextV13,
+            "plaintext_key": t.KeyData,
+            "key_data": t.SecurityManagerAPSKeyMetadata,
+        },
     ),
     "exportKey": (
         0x0114,
-        tuple(
-            {
-                "context": t.SecurityManagerContextV13,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "key": t.KeyData,
-                "context": t.SecurityManagerContextV13,
-            }.values()
-        ),
+        {
+            "context": t.SecurityManagerContextV13,
+        },
+        {
+            "status": t.sl_Status,
+            "key": t.KeyData,
+            "context": t.SecurityManagerContextV13,
+        },
     ),
     "getAddressTableInfo": (
         0x005E,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "nwk": NWK,
-                "eui64": EUI64,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.sl_Status,
+            "nwk": NWK,
+            "eui64": EUI64,
+        },
     ),
     "incomingMessageHandler": (
         0x0045,
-        tuple({}.values()),
-        tuple(
-            {
-                "message_type": t.EmberIncomingMessageType,
-                "aps_frame": t.EmberApsFrame,
-                "nwk": NWK,
-                "eui64": EUI64,
-                "binding_index": t.uint8_t,
-                "address_index": t.uint8_t,
-                "lqi": t.uint8_t,
-                "rssi": t.int8s,
-                "timestamp": t.uint32_t,
-                "message": t.LVBytes,
-            }.values()
-        ),
+        {},
+        {
+            "message_type": t.EmberIncomingMessageType,
+            "aps_frame": t.EmberApsFrame,
+            "nwk": NWK,
+            "eui64": EUI64,
+            "binding_index": t.uint8_t,
+            "address_index": t.uint8_t,
+            "lqi": t.uint8_t,
+            "rssi": t.int8s,
+            "timestamp": t.uint32_t,
+            "message": t.LVBytes,
+        },
     ),
     "messageSentHandler": (
         0x003F,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "message_type": t.EmberOutgoingMessageType,
-                "nwk": NWK,
-                "aps_frame": t.EmberApsFrame,
-                "message_tag": t.uint16_t,
-                "message": t.LVBytes,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.sl_Status,
+            "message_type": t.EmberOutgoingMessageType,
+            "nwk": NWK,
+            "aps_frame": t.EmberApsFrame,
+            "message_tag": t.uint16_t,
+            "message": t.LVBytes,
+        },
     ),
     "sendUnicast": (
         0x0034,
-        tuple(
-            {
-                "message_type": t.EmberOutgoingMessageType,
-                "nwk": NWK,
-                "aps_frame": t.EmberApsFrame,
-                "message_tag": t.uint16_t,
-                "message": t.LVBytes,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "sequence": t.uint8_t,
-            }.values()
-        ),
+        {
+            "message_type": t.EmberOutgoingMessageType,
+            "nwk": NWK,
+            "aps_frame": t.EmberApsFrame,
+            "message_tag": t.uint16_t,
+            "message": t.LVBytes,
+        },
+        {
+            "status": t.sl_Status,
+            "sequence": t.uint8_t,
+        },
     ),
     "sendBroadcast": (
         0x0034,
-        tuple(
-            {
-                "alias": t.uint16_t,
-                "destination": BroadcastAddress,
-                "sequence": t.uint8_t,
-                "aps_frame": t.EmberApsFrame,
-                "radius": t.uint8_t,
-                "message_tag": t.uint16_t,
-                "message": t.LVBytes,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.sl_Status,
-                "sequence": t.uint8_t,
-            }.values()
-        ),
+        {
+            "alias": t.uint16_t,
+            "destination": BroadcastAddress,
+            "sequence": t.uint8_t,
+            "aps_frame": t.EmberApsFrame,
+            "radius": t.uint8_t,
+            "message_tag": t.uint16_t,
+            "message": t.LVBytes,
+        },
+        {
+            "status": t.sl_Status,
+            "sequence": t.uint8_t,
+        },
     ),
     "launchStandaloneBootloader": (
         0x008F,
-        tuple(
-            {
-                "mode": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                # XXX: One of the few commands that does *not* migrate to `sl_Status`!
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "mode": t.uint8_t,
+        },
+        {
+            # XXX: One of the few commands that does *not* migrate to `sl_Status`!
+            "status": t.EmberStatus,
+        },
     ),
 }
 
@@ -175,10 +143,16 @@ for name, (command_id, tx_schema, rx_schema) in COMMANDS_v13.items():
         continue
 
     if not isinstance(tx_schema, Struct):
-        tx_schema = tuple([_REPLACEMENTS.get(s, s) for s in tx_schema])
+        if isinstance(tx_schema, dict):
+            tx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in tx_schema.items()}
+        else:
+            tx_schema = [_REPLACEMENTS.get(v, v) for v in tx_schema]
 
     if not isinstance(tx_schema, Struct):
-        rx_schema = tuple([_REPLACEMENTS.get(s, s) for s in rx_schema])
+        if isinstance(tx_schema, dict):
+            rx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in rx_schema.items()}
+        else:
+            rx_schema = [_REPLACEMENTS.get(v, v) for v in rx_schema]
 
     COMMANDS[name] = (command_id, tx_schema, rx_schema)
 

--- a/bellows/ezsp/v14/commands.py
+++ b/bellows/ezsp/v14/commands.py
@@ -148,8 +148,8 @@ for name, (command_id, tx_schema, rx_schema) in COMMANDS_v13.items():
         else:
             tx_schema = [_REPLACEMENTS.get(v, v) for v in tx_schema]
 
-    if not isinstance(tx_schema, Struct):
-        if isinstance(tx_schema, dict):
+    if not isinstance(rx_schema, Struct):
+        if isinstance(rx_schema, dict):
             rx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in rx_schema.items()}
         else:
             rx_schema = [_REPLACEMENTS.get(v, v) for v in rx_schema]

--- a/bellows/ezsp/v14/commands.py
+++ b/bellows/ezsp/v14/commands.py
@@ -142,17 +142,11 @@ for name, (command_id, tx_schema, rx_schema) in COMMANDS_v13.items():
     if name in COMMANDS:
         continue
 
-    if not isinstance(tx_schema, Struct):
-        if isinstance(tx_schema, dict):
-            tx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in tx_schema.items()}
-        else:
-            tx_schema = [_REPLACEMENTS.get(v, v) for v in tx_schema]
+    if isinstance(tx_schema, dict):
+        tx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in tx_schema.items()}
 
-    if not isinstance(rx_schema, Struct):
-        if isinstance(rx_schema, dict):
-            rx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in rx_schema.items()}
-        else:
-            rx_schema = [_REPLACEMENTS.get(v, v) for v in rx_schema]
+    if isinstance(rx_schema, dict):
+        rx_schema = {k: _REPLACEMENTS.get(v, v) for k, v in rx_schema.items()}
 
     COMMANDS[name] = (command_id, tx_schema, rx_schema)
 

--- a/bellows/ezsp/v4/commands.py
+++ b/bellows/ezsp/v4/commands.py
@@ -15,7 +15,7 @@ COMMANDS = {
     "setConfigurationValue": (
         0x53,
         (t.EzspConfigId, t.uint16_t),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "addEndpoint": (
         0x02,
@@ -29,12 +29,12 @@ COMMANDS = {
             t.List[t.uint16_t],
             t.List[t.uint16_t],
         ),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "setPolicy": (
         0x55,
         (t.EzspPolicyId, t.EzspDecisionId),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "getPolicy": (
         0x56,
@@ -54,38 +54,38 @@ COMMANDS = {
     "setValue": (
         0xAB,
         (t.EzspValueId, t.LVBytes),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "setGpioCurrentConfiguration": (
         0xAC,
         (t.uint8_t, t.uint8_t, t.uint8_t),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "setGpioPowerUpDownConfiguration": (
         0xAD,
         (t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
-        (t.EzspStatus,),
+        {"status": t.EzspStatus},
     ),
     "setGpioRadioPowerMask": (
         0xAE,
         (t.uint32_t,),
-        (),
+        {},
     ),
     "setCtune": (
         0xF5,
         (t.uint16_t,),
-        (),
+        {},
     ),
     "getCtune": (
         0xF6,
-        (),
+        {},
         (t.uint16_t,),
     ),
     # 5. Utilities Frames
     "nop": (
         0x05,
-        (),
-        (),
+        {},
+        {},
     ),
     "echo": (
         0x81,
@@ -94,18 +94,18 @@ COMMANDS = {
     ),
     "invalidCommand": (
         0x58,
-        (),
-        (t.EzspStatus,),
+        {},
+        {"status": t.EzspStatus},
     ),
     "callback": (
         0x06,
-        (),
-        (),
+        {},
+        {},
     ),
     "noCallbacks": (
         0x07,
-        (),
-        (),
+        {},
+        {},
     ),
     "setToken": (
         0x09,
@@ -129,12 +129,12 @@ COMMANDS = {
     ),
     "stackTokenChangedHandler": (
         0x0D,
-        (),
+        {},
         (t.uint16_t,),
     ),
     "getRandomNumber": (
         0x49,
-        (),
+        {},
         (t.EmberStatus, t.uint16_t),
     ),
     "setTimer": (
@@ -149,7 +149,7 @@ COMMANDS = {
     ),
     "timerHandler": (
         0x0F,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "debugWrite": (
@@ -159,23 +159,23 @@ COMMANDS = {
     ),
     "readAndClearCounters": (
         0x65,
-        (),
+        {},
         (t.FixedList[t.uint16_t, len(t.EmberCounterType)],),
     ),
     "readCounters": (
         0xF1,
-        (),
+        {},
         (t.FixedList[t.uint16_t, len(t.EmberCounterType)],),
     ),
     "counterRolloverHandler": (
         0xF2,
-        (),
+        {},
         (t.EmberCounterType,),
     ),
     "delayTest": (
         0x9D,
         (t.uint16_t,),
-        (),
+        {},
     ),
     "getLibraryStatus": (
         0x01,
@@ -184,7 +184,7 @@ COMMANDS = {
     ),
     "getXncpInfo": (
         0x13,
-        (),
+        {},
         (t.EmberStatus, t.uint16_t, t.uint16_t),
     ),
     "customFrame": (
@@ -194,34 +194,34 @@ COMMANDS = {
     ),
     "customFrameHandler": (
         0x54,
-        (),
+        {},
         (t.LVBytes,),
     ),
     "getEui64": (
         0x26,
-        (),
+        {},
         (t.EUI64,),
     ),
     "getNodeId": (
         0x27,
-        (),
+        {},
         (t.EmberNodeId,),
     ),
     "networkInit": (
         0x17,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     # 6. Networking Frames
     "setManufacturerCode": (
         0x15,
         (t.uint16_t,),
-        (),
+        {},
     ),
     "setPowerDescriptor": (
         0x16,
         (t.uint16_t,),
-        (),
+        {},
     ),
     "networkInitExtended": (
         0x70,
@@ -230,12 +230,12 @@ COMMANDS = {
     ),
     "networkState": (
         0x18,
-        (),
+        {},
         (t.EmberNetworkStatus,),
     ),
     "stackStatusHandler": (
         0x19,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "startScan": (
@@ -245,22 +245,22 @@ COMMANDS = {
     ),
     "energyScanResultHandler": (
         0x48,
-        (),
+        {},
         (t.uint8_t, t.int8s),
     ),
     "networkFoundHandler": (
         0x1B,
-        (),
+        {},
         (t.EmberZigbeeNetwork, t.uint8_t, t.int8s),
     ),
     "scanCompleteHandler": (
         0x1C,
-        (),
+        {},
         (t.uint8_t, t.EmberStatus),
     ),
     "stopScan": (
         0x1D,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "formNetwork": (
@@ -275,7 +275,7 @@ COMMANDS = {
     ),
     "leaveNetwork": (
         0x20,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "findAndRejoinNetwork": (
@@ -290,7 +290,7 @@ COMMANDS = {
     ),
     "childJoinHandler": (
         0x23,
-        (),
+        {},
         (t.uint8_t, t.Bool, t.EmberNodeId, t.EUI64, t.EmberNodeType),
     ),
     "energyScanRequest": (
@@ -300,12 +300,12 @@ COMMANDS = {
     ),
     "getNetworkParameters": (
         0x28,
-        (),
+        {},
         (t.EmberStatus, t.EmberNodeType, t.EmberNetworkParameters),
     ),
     "getParentChildParameters": (
         0x29,
-        (),
+        {},
         (t.uint8_t, t.EUI64, t.EmberNodeId),
     ),
     "getChildData": (
@@ -320,7 +320,7 @@ COMMANDS = {
     ),
     "neighborCount": (
         0x7A,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "getRouteTableEntry": (
@@ -346,7 +346,7 @@ COMMANDS = {
     # 7. Binding Frames
     "clearBindingTable": (
         0x2A,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "setBinding": (
@@ -377,22 +377,22 @@ COMMANDS = {
     "setBindingRemoteNodeId": (
         0x30,
         (t.uint8_t, t.EmberNodeId),
-        (),
+        {},
     ),
     "remoteSetBindingHandler": (
         0x31,
-        (),
+        {},
         (t.EmberBindingTableEntry, t.uint8_t, t.EmberStatus),
     ),
     "remoteDeleteBindingHandler": (
         0x32,
-        (),
+        {},
         (t.uint8_t, t.EmberStatus),
     ),
     # 8. Messaging Frames
     "maximumPayloadLength": (
         0x33,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "sendUnicast": (
@@ -436,7 +436,7 @@ COMMANDS = {
     ),
     "messageSentHandler": (
         0x3F,
-        (),
+        {},
         (
             t.EmberOutgoingMessageType,
             t.uint16_t,
@@ -458,22 +458,22 @@ COMMANDS = {
     ),
     "pollCompleteHandler": (
         0x43,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "pollHandler": (
         0x44,
-        (),
+        {},
         (t.EmberNodeId,),
     ),
     "incomingSenderEui64Handler": (
         0x62,
-        (),
+        {},
         (t.EUI64,),
     ),
     "incomingMessageHandler": (
         0x45,
-        (),
+        {},
         (
             t.EmberIncomingMessageType,
             t.EmberApsFrame,
@@ -487,7 +487,7 @@ COMMANDS = {
     ),
     "incomingRouteRecordHandler": (
         0x59,
-        (),
+        {},
         (t.EmberNodeId, t.EUI64, t.uint8_t, t.int8s, t.LVList[t.EmberNodeId]),
     ),
     "setSourceRoute": (
@@ -497,12 +497,12 @@ COMMANDS = {
     ),
     "incomingManyToOneRouteRequestHandler": (
         0x7D,
-        (),
+        {},
         (t.EmberNodeId, t.EUI64, t.uint8_t),
     ),
     "incomingRouteErrorHandler": (
         0x80,
-        (),
+        {},
         (t.EmberStatus, t.EmberNodeId),
     ),
     "addressTableEntryIsActive": (
@@ -518,7 +518,7 @@ COMMANDS = {
     "setAddressTableRemoteNodeId": (
         0x5D,
         (t.uint8_t, t.EmberNodeId),
-        (),
+        {},
     ),
     "getAddressTableRemoteEui64": (
         0x5E,
@@ -533,7 +533,7 @@ COMMANDS = {
     "setExtendedTimeout": (
         0x7E,
         (t.EUI64, t.Bool),
-        (),
+        {},
     ),
     "getExtendedTimeout": (
         0x7F,
@@ -567,7 +567,7 @@ COMMANDS = {
     ),
     "idConflictHandler": (
         0x7C,
-        (),
+        {},
         (t.EmberNodeId,),
     ),
     "sendRawMessage": (
@@ -577,17 +577,17 @@ COMMANDS = {
     ),
     "macPassthroughMessageHandler": (
         0x97,
-        (),
+        {},
         (t.EmberMacPassthroughType, t.uint8_t, t.int8s, t.LVBytes),
     ),
     "macFilterMatchMessageHandler": (
         0x46,
-        (),
+        {},
         (t.uint8_t, t.EmberMacPassthroughType, t.uint8_t, t.int8s, t.LVBytes),
     ),
     "rawTransmitCompleteHandler": (
         0x98,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     # 9. Security Frames
@@ -598,7 +598,7 @@ COMMANDS = {
     ),
     "getCurrentSecurityState": (
         0x69,
-        (),
+        {},
         (t.EmberStatus, t.EmberCurrentSecurityState),
     ),
     "getKey": (
@@ -608,7 +608,7 @@ COMMANDS = {
     ),
     "switchNetworkKeyHandler": (
         0x6E,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "getKeyTableEntry": (
@@ -638,7 +638,7 @@ COMMANDS = {
     ),
     "clearKeyTable": (
         0xB1,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "requestLinkKey": (
@@ -648,7 +648,7 @@ COMMANDS = {
     ),
     "zigbeeKeyEstablishmentHandler": (
         0x9B,
-        (),
+        {},
         (t.EUI64, t.EmberKeyStatus),
     ),
     "addTransientLinkKey": (
@@ -658,13 +658,13 @@ COMMANDS = {
     ),
     "clearTransientLinkKeys": (
         0x6B,
-        (),
-        (),
+        {},
+        {},
     ),
     # 10. Trust Center Frames
     "trustCenterJoinHandler": (
         0x24,
-        (),
+        {},
         (
             t.EmberNodeId,
             t.EUI64,
@@ -680,7 +680,7 @@ COMMANDS = {
     ),
     "broadcastNetworkKeySwitch": (
         0x74,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "becomeTrustCenter": (
@@ -706,12 +706,12 @@ COMMANDS = {
     # 11. Certificate Based Key Exchange (CBKE) Frames
     "generateCbkeKeys": (
         0xA4,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "generateCbkeKeysHandler": (
         0x9E,
-        (),
+        {},
         (t.EmberStatus, t.EmberPublicKeyData),
     ),
     "calculateSmacs": (
@@ -721,17 +721,17 @@ COMMANDS = {
     ),
     "calculateSmacsHandler": (
         0xA0,
-        (),
+        {},
         (t.EmberStatus, t.EmberSmacData, t.EmberSmacData),
     ),
     "generateCbkeKeys283k1": (
         0xE8,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "generateCbkeKeysHandler283k1": (
         0xE9,
-        (),
+        {},
         (t.EmberStatus, t.EmberPublicKey283k1Data),
     ),
     "calculateSmacs283k1": (
@@ -741,7 +741,7 @@ COMMANDS = {
     ),
     "calculateSmacsHandler283k1": (
         0xEB,
-        (),
+        {},
         (t.EmberStatus, t.EmberSmacData, t.EmberSmacData),
     ),
     "clearTemporaryDataMaybeStoreLinkKey": (
@@ -756,12 +756,12 @@ COMMANDS = {
     ),
     "getCertificate": (
         0xA5,
-        (),
+        {},
         (t.EmberStatus, t.EmberCertificateData),
     ),
     "getCertificate283k1": (
         0xEC,
-        (),
+        {},
         (t.EmberStatus, t.EmberCertificate283k1Data),
     ),
     "dsaSign": (
@@ -771,7 +771,7 @@ COMMANDS = {
     ),  # Deprecated
     "dsaSignHandler": (
         0xA7,
-        (),
+        {},
         (t.EmberStatus, t.LVBytes),
     ),  # Deprecated
     "dsaVerify": (
@@ -781,7 +781,7 @@ COMMANDS = {
     ),
     "dsaVerifyHandler": (
         0x78,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "dsaVerify283k1": (
@@ -811,27 +811,27 @@ COMMANDS = {
     ),
     "mfglibEnd": (
         0x84,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "mfglibStartTone": (
         0x85,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "mfglibStopTone": (
         0x86,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "mfglibStartStream": (
         0x87,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "mfglibStopStream": (
         0x88,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "mfglibSendPacket": (
@@ -846,7 +846,7 @@ COMMANDS = {
     ),
     "mfglibGetChannel": (
         0x8B,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "mfglibSetPower": (
@@ -856,12 +856,12 @@ COMMANDS = {
     ),
     "mfglibGetPower": (
         0x8D,
-        (),
+        {},
         (t.int8s,),
     ),
     "mfglibRxHandler": (
         0x8E,
-        (),
+        {},
         (t.uint8_t, t.int8s, t.LVBytes),
     ),
     # 13. Bootloader Frames
@@ -877,17 +877,17 @@ COMMANDS = {
     ),
     "getStandaloneBootloaderVersionPlatMicroPhy": (
         0x91,
-        (),
+        {},
         (t.uint16_t, t.uint8_t, t.uint8_t, t.uint8_t),
     ),
     "incomingBootloadMessageHandler": (
         0x92,
-        (),
+        {},
         (t.EUI64, t.uint8_t, t.int8s, t.LVBytes),
     ),
     "bootloadTransmitCompleteHandler": (
         0x93,
-        (),
+        {},
         (t.EmberStatus, t.LVBytes),
     ),
     "aesEncrypt": (
@@ -923,17 +923,17 @@ COMMANDS = {
     ),
     "zllNetworkFoundHandler": (
         0xB6,
-        (),
+        {},
         (t.EmberZllNetwork, t.Bool, t.EmberZllDeviceInfoRecord, t.uint8_t, t.int8s),
     ),
     "zllScanCompleteHandler": (
         0xB7,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "zllAddressAssignmentHandler": (
         0xB8,
-        (),
+        {},
         (t.EmberZllAddressAssignment, t.uint8_t, t.int8s),
     ),
     "setLogicalAndRadioChannel": (
@@ -943,32 +943,32 @@ COMMANDS = {
     ),
     "getLogicalChannel": (
         0xBA,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "zllTouchLinkTargetHandler": (
         0xBB,
-        (),
+        {},
         (t.EmberZllNetwork,),
     ),
     "zllGetTokens": (
         0xBC,
-        (),
+        {},
         (t.EmberTokTypeStackZllData, t.EmberTokTypeStackZllSecurity),
     ),
     "zllSetDataToken": (
         0xBD,
         (t.EmberTokTypeStackZllData,),
-        (),
+        {},
     ),
     "zllSetNonZllNetwork": (
         0xBF,
-        (),
-        (),
+        {},
+        {},
     ),
     "isZllNetwork": (
         0xBE,
-        (),
+        {},
         (t.Bool,),
     ),
     # 15 RF4CE Frames
@@ -999,12 +999,12 @@ COMMANDS = {
     ),
     "rf4ceIncomingMessageHandler": (
         0xD5,
-        (),
+        {},
         (t.uint8_t, t.uint8_t, t.uint16_t, t.EmberRf4ceTxOption, t.LVBytes),
     ),
     "rf4ceMessageSentHandler": (
         0xD6,
-        (),
+        {},
         (
             t.EmberStatus,
             t.uint8_t,
@@ -1022,7 +1022,7 @@ COMMANDS = {
     ),
     "rf4ceStop": (
         0xD8,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "rf4ceDiscovery": (
@@ -1039,12 +1039,12 @@ COMMANDS = {
     ),
     "rf4ceDiscoveryCompleteHandler": (
         0xDA,
-        (),
+        {},
         (t.EmberStatus,),
     ),
     "rf4ceDiscoveryRequestHandler": (
         0xDB,
-        (),
+        {},
         (
             t.EUI64,
             t.uint8_t,
@@ -1056,7 +1056,7 @@ COMMANDS = {
     ),
     "rf4ceDiscoveryResponseHandler": (
         0xDC,
-        (),
+        {},
         (
             t.Bool,
             t.uint8_t,
@@ -1076,7 +1076,7 @@ COMMANDS = {
     ),
     "rf4ceAutoDiscoveryResponseCompleteHandler": (
         0xDE,
-        (),
+        {},
         (
             t.EmberStatus,
             t.EUI64,
@@ -1093,12 +1093,12 @@ COMMANDS = {
     ),
     "rf4cePairCompleteHandler": (
         0xE0,
-        (),
+        {},
         (t.EmberStatus, t.uint8_t, t.EmberRf4ceVendorInfo, t.EmberRf4ceApplicationInfo),
     ),
     "rf4cePairRequestHandler": (
         0xE1,
-        (),
+        {},
         (
             t.EmberStatus,
             t.uint8_t,
@@ -1116,12 +1116,12 @@ COMMANDS = {
     ),
     "rf4ceUnpairHandler": (
         0xE3,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "rf4ceUnpairCompleteHandler": (
         0xE4,
-        (),
+        {},
         (t.uint8_t,),
     ),
     "rf4ceSetPowerSavingParameters": (
@@ -1141,7 +1141,7 @@ COMMANDS = {
     ),
     "rf4ceGetApplicationInfo": (
         0xEF,
-        (),
+        {},
         (t.EmberStatus, t.EmberRf4ceApplicationInfo),
     ),
     "rf4ceGetMaxPayload": (
@@ -1151,7 +1151,7 @@ COMMANDS = {
     ),
     "rf4ceGetNetworkParameters": (
         0xF4,
-        (),
+        {},
         (t.EmberStatus, t.EmberNodeType, t.EmberNetworkParameters),
     ),
     # 16 Green Power Frames
@@ -1167,7 +1167,7 @@ COMMANDS = {
             t.EUI64,
             t.KeyData,
         ),
-        (),
+        {},
     ),
     "dGpSend": (
         0xC6,
@@ -1176,12 +1176,12 @@ COMMANDS = {
     ),
     "dGpSentHandler": (
         0xC7,
-        (),
+        {},
         (t.EmberStatus, t.uint8_t),
     ),
     "gpepIncomingMessageHandler": (
         0x00C5,
-        (),
+        {},
         (
             t.EmberStatus,  # status
             t.uint8_t,  # gpd link

--- a/bellows/ezsp/v4/commands.py
+++ b/bellows/ezsp/v4/commands.py
@@ -4,82 +4,146 @@ COMMANDS = {
     # 4. Configuration frames
     "version": (
         0x00,
-        (t.uint8_t,),
-        (t.uint8_t, t.uint8_t, t.uint16_t),
+        {
+            "desiredProtocolVersion": t.uint8_t,
+        },
+        {
+            "protocolVersion": t.uint8_t,
+            "stackType": t.uint8_t,
+            "stackVersion": t.uint16_t,
+        },
     ),
     "getConfigurationValue": (
         0x52,
-        (t.EzspConfigId,),
-        (t.EzspStatus, t.uint16_t),
+        {
+            "configId": t.EzspConfigId,
+        },
+        {
+            "status": t.EzspStatus,
+            "value": t.uint16_t,
+        },
     ),
     "setConfigurationValue": (
         0x53,
-        (t.EzspConfigId, t.uint16_t),
-        {"status": t.EzspStatus},
+        {
+            "configId": t.EzspConfigId,
+            "value": t.uint16_t,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "addEndpoint": (
         0x02,
-        (
-            t.uint8_t,
-            t.uint16_t,
-            t.uint16_t,
-            t.uint8_t,
-            t.uint8_t,
-            t.uint8_t,
-            t.List[t.uint16_t],
-            t.List[t.uint16_t],
-        ),
-        {"status": t.EzspStatus},
+        {
+            "endpoint": t.uint8_t,
+            "profileId": t.uint16_t,
+            "deviceId": t.uint16_t,
+            "deviceVersion": t.uint8_t,
+            "inputClusterCount": t.uint8_t,
+            "outputClusterCount": t.uint8_t,
+            "inputClusterList": t.List[t.uint16_t],
+            "outputClusterList": t.List[t.uint16_t],
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "setPolicy": (
         0x55,
-        (t.EzspPolicyId, t.EzspDecisionId),
-        {"status": t.EzspStatus},
+        {
+            "policyId": t.EzspPolicyId,
+            "decisionId": t.EzspDecisionId,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "getPolicy": (
         0x56,
-        (t.EzspPolicyId,),
-        (t.EzspStatus, t.EzspDecisionId),
+        {
+            "policyId": t.EzspPolicyId,
+        },
+        {
+            "status": t.EzspStatus,
+            "decisionId": t.EzspDecisionId,
+        },
     ),
     "getValue": (
         0xAA,
-        (t.EzspValueId,),
-        (t.EzspStatus, t.LVBytes),
+        {
+            "valueId": t.EzspValueId,
+        },
+        {
+            "status": t.EzspStatus,
+            "value": t.LVBytes,
+        },
     ),
     "getExtendedValue": (
         0x03,
-        (t.EzspExtendedValueId, t.uint32_t),
-        (t.EzspStatus, t.LVBytes),
+        {
+            "valueId": t.EzspExtendedValueId,
+            "characteristics": t.uint32_t,
+        },
+        {
+            "status": t.EzspStatus,
+            "value": t.LVBytes,
+        },
     ),
     "setValue": (
         0xAB,
-        (t.EzspValueId, t.LVBytes),
-        {"status": t.EzspStatus},
+        {
+            "valueId": t.EzspValueId,
+            "value": t.LVBytes,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "setGpioCurrentConfiguration": (
         0xAC,
-        (t.uint8_t, t.uint8_t, t.uint8_t),
-        {"status": t.EzspStatus},
+        {
+            "portPin": t.uint8_t,
+            "cfg": t.uint8_t,
+            "out": t.uint8_t,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "setGpioPowerUpDownConfiguration": (
         0xAD,
-        (t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t, t.uint8_t),
-        {"status": t.EzspStatus},
+        {
+            "portPin": t.uint8_t,
+            "puCfg": t.uint8_t,
+            "puOut": t.uint8_t,
+            "pdCfg": t.uint8_t,
+            "pdOut": t.uint8_t,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "setGpioRadioPowerMask": (
         0xAE,
-        (t.uint32_t,),
+        {
+            "mask": t.uint32_t,
+        },
         {},
     ),
     "setCtune": (
         0xF5,
-        (t.uint16_t,),
+        {
+            "ctune": t.uint16_t,
+        },
         {},
     ),
     "getCtune": (
         0xF6,
         {},
-        (t.uint16_t,),
+        {
+            "ctune": t.uint16_t,
+        },
     ),
     # 5. Utilities Frames
     "nop": (
@@ -89,13 +153,19 @@ COMMANDS = {
     ),
     "echo": (
         0x81,
-        (t.LVBytes,),
-        (t.LVBytes,),
+        {
+            "data": t.LVBytes,
+        },
+        {
+            "echo": t.LVBytes,
+        },
     ),
     "invalidCommand": (
         0x58,
         {},
-        {"status": t.EzspStatus},
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "callback": (
         0x06,
@@ -109,552 +179,964 @@ COMMANDS = {
     ),
     "setToken": (
         0x09,
-        (t.uint8_t, t.FixedList[t.uint8_t, 8]),
-        (t.EmberStatus,),
+        {
+            "tokenId": t.uint8_t,
+            "tokenData": t.FixedList[t.uint8_t, 8],
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getToken": (
         0x0A,
-        (t.uint8_t,),
-        (t.EmberStatus, t.FixedList[t.uint8_t, 8]),
+        {
+            "tokenId": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "tokenData": t.FixedList[t.uint8_t, 8],
+        },
     ),
     "getMfgToken": (
         0x0B,
-        (t.EzspMfgTokenId,),
-        (t.LVBytes,),
+        {
+            "tokenId": t.EzspMfgTokenId,
+        },
+        {
+            "tokenData": t.LVBytes,
+        },
     ),
     "setMfgToken": (
         0x0C,
-        (t.EzspMfgTokenId, t.LVBytes),
-        (t.EmberStatus,),
+        {
+            "tokenId": t.EzspMfgTokenId,
+            "tokenData": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "stackTokenChangedHandler": (
         0x0D,
         {},
-        (t.uint16_t,),
+        {
+            "tokenAddress": t.uint16_t,
+        },
     ),
     "getRandomNumber": (
         0x49,
         {},
-        (t.EmberStatus, t.uint16_t),
+        {
+            "status": t.EmberStatus,
+            "value": t.uint16_t,
+        },
     ),
     "setTimer": (
         0x0E,
-        (t.uint8_t, t.uint16_t, t.EmberEventUnits, t.Bool),
-        (t.EmberStatus,),
+        {
+            "timerId": t.uint8_t,
+            "time": t.uint16_t,
+            "units": t.EmberEventUnits,
+            "repeat": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getTimer": (
         0x4E,
-        (t.uint8_t,),
-        (t.uint16_t, t.EmberEventUnits, t.Bool),
+        {
+            "timerId": t.uint8_t,
+        },
+        {
+            "time": t.uint16_t,
+            "units": t.EmberEventUnits,
+            "repeat": t.Bool,
+        },
     ),
     "timerHandler": (
         0x0F,
         {},
-        (t.uint8_t,),
+        {
+            "timerId": t.uint8_t,
+        },
     ),
     "debugWrite": (
         0x12,
-        (t.Bool, t.LVBytes),
-        (t.EmberStatus,),
+        {
+            "binaryMessage": t.Bool,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "readAndClearCounters": (
         0x65,
         {},
-        (t.FixedList[t.uint16_t, len(t.EmberCounterType)],),
+        {
+            "values": t.FixedList[t.uint16_t, len(t.EmberCounterType)],
+        },
     ),
     "readCounters": (
         0xF1,
         {},
-        (t.FixedList[t.uint16_t, len(t.EmberCounterType)],),
+        {
+            "values": t.FixedList[t.uint16_t, len(t.EmberCounterType)],
+        },
     ),
     "counterRolloverHandler": (
         0xF2,
         {},
-        (t.EmberCounterType,),
+        {
+            "type": t.EmberCounterType,
+        },
     ),
     "delayTest": (
         0x9D,
-        (t.uint16_t,),
+        {
+            "delay": t.uint16_t,
+        },
         {},
     ),
     "getLibraryStatus": (
         0x01,
-        (t.uint8_t,),
-        (t.uint8_t,),
+        {
+            "libraryId": t.uint8_t,
+        },
+        {
+            "status": t.uint8_t,
+        },
     ),
     "getXncpInfo": (
         0x13,
         {},
-        (t.EmberStatus, t.uint16_t, t.uint16_t),
+        {
+            "status": t.EmberStatus,
+            "manufacturerId": t.uint16_t,
+            "versionNumber": t.uint16_t,
+        },
     ),
     "customFrame": (
         0x47,
-        (t.LVBytes,),
-        (t.EmberStatus, t.LVBytes),
+        {
+            "payload": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "reply": t.LVBytes,
+        },
     ),
     "customFrameHandler": (
         0x54,
         {},
-        (t.LVBytes,),
+        {
+            "payload": t.LVBytes,
+        },
     ),
     "getEui64": (
         0x26,
         {},
-        (t.EUI64,),
+        {
+            "eui64": t.EUI64,
+        },
     ),
     "getNodeId": (
         0x27,
         {},
-        (t.EmberNodeId,),
+        {
+            "nodeId": t.EmberNodeId,
+        },
     ),
     "networkInit": (
         0x17,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 6. Networking Frames
     "setManufacturerCode": (
         0x15,
-        (t.uint16_t,),
+        {
+            "code": t.uint16_t,
+        },
         {},
     ),
     "setPowerDescriptor": (
         0x16,
-        (t.uint16_t,),
+        {
+            "descriptor": t.uint16_t,
+        },
         {},
     ),
     "networkInitExtended": (
         0x70,
-        (t.EmberNetworkInitBitmask,),
-        (t.EmberStatus,),
+        {
+            "networkInitStruct": t.EmberNetworkInitBitmask,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "networkState": (
         0x18,
         {},
-        (t.EmberNetworkStatus,),
+        {
+            "status": t.EmberNetworkStatus,
+        },
     ),
     "stackStatusHandler": (
         0x19,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "startScan": (
         0x1A,
-        (t.EzspNetworkScanType, t.uint32_t, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "scanType": t.EzspNetworkScanType,
+            "channelMask": t.Channels,
+            "duration": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "energyScanResultHandler": (
         0x48,
         {},
-        (t.uint8_t, t.int8s),
+        {
+            "channel": t.uint8_t,
+            "maxRssiValue": t.int8s,
+        },
     ),
     "networkFoundHandler": (
         0x1B,
         {},
-        (t.EmberZigbeeNetwork, t.uint8_t, t.int8s),
+        {
+            "networkFound": t.EmberZigbeeNetwork,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+        },
     ),
     "scanCompleteHandler": (
         0x1C,
         {},
-        (t.uint8_t, t.EmberStatus),
+        {
+            "channel": t.uint8_t,
+            "status": t.EmberStatus,
+        },
     ),
     "stopScan": (
         0x1D,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "formNetwork": (
         0x1E,
-        (t.EmberNetworkParameters,),
-        (t.EmberStatus,),
+        {
+            "parameters": t.EmberNetworkParameters,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "joinNetwork": (
         0x1F,
-        (t.EmberNodeType, t.EmberNetworkParameters),
-        (t.EmberStatus,),
+        {
+            "nodeType": t.EmberNodeType,
+            "parameters": t.EmberNetworkParameters,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "leaveNetwork": (
         0x20,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "findAndRejoinNetwork": (
         0x21,
-        (t.Bool, t.uint32_t),
-        (t.EmberStatus,),
+        {
+            "haveCurrentNetworkKey": t.Bool,
+            "channelMask": t.uint32_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "permitJoining": (
         0x22,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "duration": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "childJoinHandler": (
         0x23,
         {},
-        (t.uint8_t, t.Bool, t.EmberNodeId, t.EUI64, t.EmberNodeType),
+        {
+            "index": t.uint8_t,
+            "joining": t.Bool,
+            "childId": t.EmberNodeId,
+            "childEui64": t.EUI64,
+            "childType": t.EmberNodeType,
+        },
     ),
     "energyScanRequest": (
         0x9C,
-        (t.EmberNodeId, t.Channels, t.uint8_t, t.uint16_t),
-        (t.EmberStatus,),
+        {
+            "target": t.EmberNodeId,
+            "scanChannels": t.Channels,
+            "scanDuration": t.uint8_t,
+            "scanCount": t.uint16_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getNetworkParameters": (
         0x28,
         {},
-        (t.EmberStatus, t.EmberNodeType, t.EmberNetworkParameters),
+        {
+            "status": t.EmberStatus,
+            "nodeType": t.EmberNodeType,
+            "parameters": t.EmberNetworkParameters,
+        },
     ),
     "getParentChildParameters": (
         0x29,
         {},
-        (t.uint8_t, t.EUI64, t.EmberNodeId),
+        {
+            "childCount": t.uint8_t,
+            "parentEui64": t.EUI64,
+            "parentNodeId": t.EmberNodeId,
+        },
     ),
     "getChildData": (
         0x4A,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberNodeId, t.EUI64, t.EmberNodeType),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "childId": t.EmberNodeId,
+            "childEui64": t.EUI64,
+            "childType": t.EmberNodeType,
+        },
     ),
     "getNeighbor": (
         0x79,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberNeighborTableEntry),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "value": t.EmberNeighborTableEntry,
+        },
     ),
     "neighborCount": (
         0x7A,
         {},
-        (t.uint8_t,),
+        {
+            "value": t.uint8_t,
+        },
     ),
     "getRouteTableEntry": (
         0x7B,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberRouteTableEntry),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "value": t.EmberRouteTableEntry,
+        },
     ),
     "setRadioPower": (
         0x99,
-        (t.int8s,),
-        (t.EmberStatus,),
+        {
+            "power": t.int8s,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setRadioChannel": (
         0x9A,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "channel": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setConcentrator": (
         0x10,
-        (t.Bool, t.uint16_t, t.uint16_t, t.uint16_t, t.uint8_t, t.uint8_t, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "on": t.Bool,
+            "concentratorType": t.uint16_t,
+            "minTime": t.uint16_t,
+            "maxTime": t.uint16_t,
+            "routeErrorThreshold": t.uint8_t,
+            "deliveryFailureThreshold": t.uint8_t,
+            "maxHops": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 7. Binding Frames
     "clearBindingTable": (
         0x2A,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setBinding": (
         0x2B,
-        (t.uint8_t, t.EmberBindingTableEntry),
-        (t.EmberStatus,),
+        {
+            "index": t.uint8_t,
+            "value": t.EmberBindingTableEntry,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getBinding": (
         0x2C,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberBindingTableEntry),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "value": t.EmberBindingTableEntry,
+        },
     ),
     "deleteBinding": (
         0x2D,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "bindingIsActive": (
         0x2E,
-        (t.uint8_t,),
-        (t.Bool,),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "active": t.Bool,
+        },
     ),
     "getBindingRemoteNodeId": (
         0x2F,
-        (t.uint8_t,),
-        (t.EmberNodeId,),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "nodeId": t.EmberNodeId,
+        },
     ),
     "setBindingRemoteNodeId": (
         0x30,
-        (t.uint8_t, t.EmberNodeId),
+        {
+            "index": t.uint8_t,
+            "nodeId": t.EmberNodeId,
+        },
         {},
     ),
     "remoteSetBindingHandler": (
         0x31,
         {},
-        (t.EmberBindingTableEntry, t.uint8_t, t.EmberStatus),
+        {
+            "entry": t.EmberBindingTableEntry,
+            "index": t.uint8_t,
+            "policyDecision": t.EmberStatus,
+        },
     ),
     "remoteDeleteBindingHandler": (
         0x32,
         {},
-        (t.uint8_t, t.EmberStatus),
+        {
+            "index": t.uint8_t,
+            "policyDecision": t.EmberStatus,
+        },
     ),
     # 8. Messaging Frames
     "maximumPayloadLength": (
         0x33,
         {},
-        (t.uint8_t,),
+        {
+            "apsLength": t.uint8_t,
+        },
     ),
     "sendUnicast": (
         0x34,
-        (
-            t.EmberOutgoingMessageType,
-            t.EmberNodeId,
-            t.EmberApsFrame,
-            t.uint8_t,
-            t.LVBytes,
-        ),
-        (t.EmberStatus, t.uint8_t),
+        {
+            "type": t.EmberOutgoingMessageType,
+            "indexOrDestination": t.EmberNodeId,
+            "apsFrame": t.EmberApsFrame,
+            "messageTag": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "sequence": t.uint8_t,
+        },
     ),
     "sendBroadcast": (
         0x36,
-        (t.EmberNodeId, t.EmberApsFrame, t.uint8_t, t.uint8_t, t.LVBytes),
-        (t.EmberStatus, t.uint8_t),
+        {
+            "destination": t.EmberNodeId,
+            "apsFrame": t.EmberApsFrame,
+            "radius": t.uint8_t,
+            "messageTag": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "sequence": t.uint8_t,
+        },
     ),
     "proxyBroadcast": (
         0x37,
-        (
-            t.EmberNodeId,
-            t.EmberNodeId,
-            t.uint8_t,
-            t.EmberApsFrame,
-            t.uint8_t,
-            t.uint8_t,
-            t.LVBytes,
-        ),
-        (t.EmberStatus, t.uint8_t),
+        {
+            "source": t.EmberNodeId,
+            "destination": t.EmberNodeId,
+            "nwkSequence": t.uint8_t,
+            "apsFrame": t.EmberApsFrame,
+            "radius": t.uint8_t,
+            "messageTag": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "apsSequence": t.uint8_t,
+        },
     ),
     "sendMulticast": (
         0x38,
-        (t.EmberApsFrame, t.uint8_t, t.uint8_t, t.uint8_t, t.LVBytes),
-        (t.EmberStatus, t.uint8_t),
+        {
+            "apsFrame": t.EmberApsFrame,
+            "hops": t.uint8_t,
+            "nonmemberRadius": t.uint8_t,
+            "messageTag": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "sequence": t.uint8_t,
+        },
     ),
     "sendReply": (
         0x39,
-        (t.EmberNodeId, t.EmberApsFrame, t.LVBytes),
-        (t.EmberStatus,),
+        {
+            "sender": t.EmberNodeId,
+            "apsFrame": t.EmberApsFrame,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "messageSentHandler": (
         0x3F,
         {},
-        (
-            t.EmberOutgoingMessageType,
-            t.uint16_t,
-            t.EmberApsFrame,
-            t.uint8_t,
-            t.EmberStatus,
-            t.LVBytes,
-        ),
+        {
+            "type": t.EmberOutgoingMessageType,
+            "indexOrDestination": t.uint16_t,
+            "apsFrame": t.EmberApsFrame,
+            "messageTag": t.uint8_t,
+            "status": t.EmberStatus,
+            "messageContents": t.LVBytes,
+        },
     ),
     "sendManyToOneRouteRequest": (
         0x41,
-        (t.uint16_t, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "concentratorType": t.uint16_t,
+            "radius": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "pollForData": (
         0x42,
-        (t.uint16_t, t.EmberEventUnits, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "interval": t.uint16_t,
+            "units": t.EmberEventUnits,
+            "failureLimit": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "pollCompleteHandler": (
         0x43,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "pollHandler": (
         0x44,
         {},
-        (t.EmberNodeId,),
+        {
+            "childId": t.EmberNodeId,
+        },
     ),
     "incomingSenderEui64Handler": (
         0x62,
         {},
-        (t.EUI64,),
+        {
+            "senderEui64": t.EUI64,
+        },
     ),
     "incomingMessageHandler": (
         0x45,
         {},
-        (
-            t.EmberIncomingMessageType,
-            t.EmberApsFrame,
-            t.uint8_t,
-            t.int8s,
-            t.EmberNodeId,
-            t.uint8_t,
-            t.uint8_t,
-            t.LVBytes,
-        ),
+        {
+            "type": t.EmberIncomingMessageType,
+            "apsFrame": t.EmberApsFrame,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+            "sender": t.EmberNodeId,
+            "bindingIndex": t.uint8_t,
+            "addressIndex": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
     ),
     "incomingRouteRecordHandler": (
         0x59,
         {},
-        (t.EmberNodeId, t.EUI64, t.uint8_t, t.int8s, t.LVList[t.EmberNodeId]),
+        {
+            "source": t.EmberNodeId,
+            "sourceEui": t.EUI64,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+            "relayList": t.LVList[t.EmberNodeId],
+        },
     ),
     "setSourceRoute": (
         0x5A,
-        (t.EmberNodeId, t.LVList[t.EmberNodeId]),
-        (t.EmberStatus,),
+        {
+            "destination": t.EmberNodeId,
+            "relayList": t.LVList[t.EmberNodeId],
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "incomingManyToOneRouteRequestHandler": (
         0x7D,
         {},
-        (t.EmberNodeId, t.EUI64, t.uint8_t),
+        {
+            "source": t.EmberNodeId,
+            "longId": t.EUI64,
+            "cost": t.uint8_t,
+        },
     ),
     "incomingRouteErrorHandler": (
         0x80,
         {},
-        (t.EmberStatus, t.EmberNodeId),
+        {
+            "status": t.EmberStatus,
+            "target": t.EmberNodeId,
+        },
     ),
     "addressTableEntryIsActive": (
         0x5B,
-        (t.uint8_t,),
-        (t.Bool,),
+        {
+            "addressTableIndex": t.uint8_t,
+        },
+        {
+            "active": t.Bool,
+        },
     ),
     "setAddressTableRemoteEui64": (
         0x5C,
-        (t.uint8_t, t.EUI64),
-        (t.EmberStatus,),
+        {
+            "addressTableIndex": t.uint8_t,
+            "eui64": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setAddressTableRemoteNodeId": (
         0x5D,
-        (t.uint8_t, t.EmberNodeId),
+        {
+            "addressTableIndex": t.uint8_t,
+            "id": t.EmberNodeId,
+        },
         {},
     ),
     "getAddressTableRemoteEui64": (
         0x5E,
-        (t.uint8_t,),
-        (t.EUI64,),
+        {
+            "addressTableIndex": t.uint8_t,
+        },
+        {
+            "eui64": t.EUI64,
+        },
     ),
     "getAddressTableRemoteNodeId": (
         0x5F,
-        (t.uint8_t,),
-        (t.EmberNodeId,),
+        {
+            "addressTableIndex": t.uint8_t,
+        },
+        {
+            "nodeId": t.EmberNodeId,
+        },
     ),
     "setExtendedTimeout": (
         0x7E,
-        (t.EUI64, t.Bool),
+        {
+            "remoteEui64": t.EUI64,
+            "extendedTimeout": t.Bool,
+        },
         {},
     ),
     "getExtendedTimeout": (
         0x7F,
-        (t.EUI64,),
-        (t.Bool,),
+        {
+            "remoteEui64": t.EUI64,
+        },
+        {
+            "extendedTimeout": t.Bool,
+        },
     ),
     "replaceAddressTableEntry": (
         0x82,
-        (t.uint8_t, t.EUI64, t.EmberNodeId, t.Bool),
-        (t.EmberStatus, t.EUI64, t.EmberNodeId, t.Bool),
+        {
+            "addressTableIndex": t.uint8_t,
+            "newEui64": t.EUI64,
+            "newId": t.EmberNodeId,
+            "newExtendedTimeout": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+            "oldEui64": t.EUI64,
+            "oldId": t.EmberNodeId,
+            "oldExtendedTimeout": t.Bool,
+        },
     ),
     "lookupNodeIdByEui64": (
         0x60,
-        (t.EUI64,),
-        (t.EmberNodeId,),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "nodeId": t.EmberNodeId,
+        },
     ),
     "lookupEui64ByNodeId": (
         0x61,
-        (t.EmberNodeId,),
-        (t.EmberStatus, t.EUI64),
+        {
+            "nodeId": t.EmberNodeId,
+        },
+        {
+            "status": t.EmberStatus,
+            "eui64": t.EUI64,
+        },
     ),
     "getMulticastTableEntry": (
         0x63,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberMulticastTableEntry),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "value": t.EmberMulticastTableEntry,
+        },
     ),
     "setMulticastTableEntry": (
         0x64,
-        (t.uint8_t, t.EmberMulticastTableEntry),
-        (t.EmberStatus,),
+        {
+            "index": t.uint8_t,
+            "value": t.EmberMulticastTableEntry,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "idConflictHandler": (
         0x7C,
         {},
-        (t.EmberNodeId,),
+        {
+            "nodeId": t.EmberNodeId,
+        },
     ),
     "sendRawMessage": (
         0x96,
-        (t.LVBytes,),
-        (t.EmberStatus,),
+        {
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "macPassthroughMessageHandler": (
         0x97,
         {},
-        (t.EmberMacPassthroughType, t.uint8_t, t.int8s, t.LVBytes),
+        {
+            "messageType": t.EmberMacPassthroughType,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+            "messageContents": t.LVBytes,
+        },
     ),
     "macFilterMatchMessageHandler": (
         0x46,
         {},
-        (t.uint8_t, t.EmberMacPassthroughType, t.uint8_t, t.int8s, t.LVBytes),
+        {
+            "filterIndexMatch": t.uint8_t,
+            "legacyPassthroughType": t.EmberMacPassthroughType,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+            "messageContents": t.LVBytes,
+        },
     ),
     "rawTransmitCompleteHandler": (
         0x98,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 9. Security Frames
     "setInitialSecurityState": (
         0x68,
-        (t.EmberInitialSecurityState,),
-        (t.EmberStatus,),
+        {
+            "state": t.EmberInitialSecurityState,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getCurrentSecurityState": (
         0x69,
         {},
-        (t.EmberStatus, t.EmberCurrentSecurityState),
+        {
+            "status": t.EmberStatus,
+            "state": t.EmberCurrentSecurityState,
+        },
     ),
     "getKey": (
         0x6A,
-        (t.EmberKeyType,),
-        (t.EmberStatus, t.EmberKeyStruct),
+        {
+            "keyType": t.EmberKeyType,
+        },
+        {
+            "status": t.EmberStatus,
+            "keyStruct": t.EmberKeyStruct,
+        },
     ),
     "switchNetworkKeyHandler": (
         0x6E,
         {},
-        (t.uint8_t,),
+        {
+            "sequenceNumber": t.uint8_t,
+        },
     ),
     "getKeyTableEntry": (
         0x71,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberKeyStruct),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "keyStruct": t.EmberKeyStruct,
+        },
     ),
     "setKeyTableEntry": (
         0x72,
-        (t.uint8_t, t.EUI64, t.Bool, t.KeyData),
-        (t.EmberStatus,),
+        {
+            "index": t.uint8_t,
+            "address": t.EUI64,
+            "linkKey": t.Bool,
+            "keyData": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "findKeyTableEntry": (
         0x75,
-        (t.EUI64, t.Bool),
-        (t.uint8_t,),
+        {
+            "address": t.EUI64,
+            "linkKey": t.Bool,
+        },
+        {
+            "index": t.uint8_t,
+        },
     ),
     "addOrUpdateKeyTableEntry": (
         0x66,
-        (t.EUI64, t.Bool, t.KeyData),
-        (t.EmberStatus,),
+        {
+            "address": t.EUI64,
+            "linkKey": t.Bool,
+            "keyData": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "eraseKeyTableEntry": (
         0x76,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "clearKeyTable": (
         0xB1,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "requestLinkKey": (
         0x14,
-        (t.EUI64,),
-        (t.EmberStatus,),
+        {
+            "partner": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zigbeeKeyEstablishmentHandler": (
         0x9B,
         {},
-        (t.EUI64, t.EmberKeyStatus),
+        {
+            "partner": t.EUI64,
+            "status": t.EmberKeyStatus,
+        },
     ),
     "addTransientLinkKey": (
         0xAF,
-        (t.EUI64, t.KeyData),
-        (t.EmberStatus,),
+        {
+            "partner": t.EUI64,
+            "transientKey": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "clearTransientLinkKeys": (
         0x6B,
@@ -665,300 +1147,511 @@ COMMANDS = {
     "trustCenterJoinHandler": (
         0x24,
         {},
-        (
-            t.EmberNodeId,
-            t.EUI64,
-            t.EmberDeviceUpdate,
-            t.EmberJoinDecision,
-            t.EmberNodeId,
-        ),
+        {
+            "newNodeId": t.EmberNodeId,
+            "newNodeEui64": t.EUI64,
+            "status": t.EmberDeviceUpdate,
+            "policyDecision": t.EmberJoinDecision,
+            "parentOfNewNodeId": t.EmberNodeId,
+        },
     ),
     "broadcastNextNetworkKey": (
         0x73,
-        (t.KeyData,),
-        (t.EmberStatus,),
+        {
+            "key": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "broadcastNetworkKeySwitch": (
         0x74,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "becomeTrustCenter": (
         0x77,
-        (t.KeyData,),
-        (t.EmberStatus,),
+        {
+            "key": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "aesMmoHash": (
         0x6F,
-        (t.EmberAesMmoHashContext, t.Bool, t.LVBytes),
-        (t.EmberStatus, t.EmberAesMmoHashContext),
+        {
+            "context": t.EmberAesMmoHashContext,
+            "finalize": t.Bool,
+            "data": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "returnContext": t.EmberAesMmoHashContext,
+        },
     ),
     "removeDevice": (
         0xA8,
-        (t.EmberNodeId, t.EUI64, t.EUI64),
-        (t.EmberStatus,),
+        {
+            "destShort": t.EmberNodeId,
+            "destLong": t.EUI64,
+            "targetLong": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "unicastNwkKeyUpdate": (
         0xA9,
-        (t.EmberNodeId, t.EUI64, t.KeyData),
-        (t.EmberStatus,),
+        {
+            "destShort": t.EmberNodeId,
+            "destLong": t.EUI64,
+            "key": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 11. Certificate Based Key Exchange (CBKE) Frames
     "generateCbkeKeys": (
         0xA4,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "generateCbkeKeysHandler": (
         0x9E,
         {},
-        (t.EmberStatus, t.EmberPublicKeyData),
+        {
+            "status": t.EmberStatus,
+            "ephemeralPublicKey": t.EmberPublicKeyData,
+        },
     ),
     "calculateSmacs": (
         0x9F,
-        (t.Bool, t.EmberCertificateData, t.EmberPublicKeyData),
-        (t.EmberStatus,),
+        {
+            "amInitiator": t.Bool,
+            "partnerCertificate": t.EmberCertificateData,
+            "partnerEphemeralPublicKey": t.EmberPublicKeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "calculateSmacsHandler": (
         0xA0,
         {},
-        (t.EmberStatus, t.EmberSmacData, t.EmberSmacData),
+        {
+            "status": t.EmberStatus,
+            "initiatorSmac": t.EmberSmacData,
+            "responderSmac": t.EmberSmacData,
+        },
     ),
     "generateCbkeKeys283k1": (
         0xE8,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "generateCbkeKeysHandler283k1": (
         0xE9,
         {},
-        (t.EmberStatus, t.EmberPublicKey283k1Data),
+        {
+            "status": t.EmberStatus,
+            "ephemeralPublicKey": t.EmberPublicKey283k1Data,
+        },
     ),
     "calculateSmacs283k1": (
         0xEA,
-        (t.Bool, t.EmberCertificate283k1Data, t.EmberPublicKey283k1Data),
-        (t.EmberStatus,),
+        {
+            "amInitiator": t.Bool,
+            "partnerCertificate": t.EmberCertificate283k1Data,
+            "partnerEphemeralPublicKey": t.EmberPublicKey283k1Data,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "calculateSmacsHandler283k1": (
         0xEB,
         {},
-        (t.EmberStatus, t.EmberSmacData, t.EmberSmacData),
+        {
+            "status": t.EmberStatus,
+            "initiatorSmac": t.EmberSmacData,
+            "responderSmac": t.EmberSmacData,
+        },
     ),
     "clearTemporaryDataMaybeStoreLinkKey": (
         0xA1,
-        (t.Bool,),
-        (t.EmberStatus,),
+        {
+            "storeLinkKey": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "clearTemporaryDataMaybeStoreLinkKey283k1": (
         0xEE,
-        (t.Bool,),
-        (t.EmberStatus,),
+        {
+            "storeLinkKey": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getCertificate": (
         0xA5,
         {},
-        (t.EmberStatus, t.EmberCertificateData),
+        {
+            "status": t.EmberStatus,
+            "localCert": t.EmberCertificateData,
+        },
     ),
     "getCertificate283k1": (
         0xEC,
         {},
-        (t.EmberStatus, t.EmberCertificate283k1Data),
+        {
+            "status": t.EmberStatus,
+            "localCert": t.EmberCertificate283k1Data,
+        },
     ),
     "dsaSign": (
         0xA6,
-        (t.LVBytes,),
-        (t.EmberStatus,),
+        {
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),  # Deprecated
     "dsaSignHandler": (
         0xA7,
         {},
-        (t.EmberStatus, t.LVBytes),
+        {
+            "status": t.EmberStatus,
+            "messageContents": t.LVBytes,
+        },
     ),  # Deprecated
     "dsaVerify": (
         0xA3,
-        (t.EmberMessageDigest, t.EmberCertificateData, t.EmberSignatureData),
-        (t.EmberStatus,),
+        {
+            "digest": t.EmberMessageDigest,
+            "signerCertificate": t.EmberCertificateData,
+            "receivedSig": t.EmberSignatureData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "dsaVerifyHandler": (
         0x78,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "dsaVerify283k1": (
         0xB0,
-        (t.EmberMessageDigest, t.EmberCertificate283k1Data, t.EmberSignature283k1Data),
-        (t.EmberStatus,),
+        {
+            "digest": t.EmberMessageDigest,
+            "signerCertificate": t.EmberCertificate283k1Data,
+            "receivedSig": t.EmberSignature283k1Data,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setPreinstalledCbkeData": (
         0xA2,
-        (t.EmberPublicKeyData, t.EmberCertificateData, t.EmberPrivateKeyData),
-        (t.EmberStatus,),
+        {
+            "caPublic": t.EmberPublicKeyData,
+            "myCert": t.EmberCertificateData,
+            "myKey": t.EmberPrivateKeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
-    "setPreinstalledCbkeData283k1": (
+    "savePreinstalledCbkeData283k1": (
         0xED,
-        (
-            t.EmberPublicKey283k1Data,
-            t.EmberCertificate283k1Data,
-            t.EmberPrivateKey283k1Data,
-        ),
-        (t.EmberStatus,),
+        {},
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 12. Mfglib Frames
     "mfglibStart": (
         0x83,
-        (t.Bool,),
-        (t.EmberStatus,),
+        {
+            "rxCallback": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibEnd": (
         0x84,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibStartTone": (
         0x85,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibStopTone": (
         0x86,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibStartStream": (
         0x87,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibStopStream": (
         0x88,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibSendPacket": (
         0x89,
-        (t.LVBytes,),
-        (t.EmberStatus,),
+        {
+            "packetContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibSetChannel": (
         0x8A,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "channel": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibGetChannel": (
         0x8B,
         {},
-        (t.uint8_t,),
+        {
+            "channel": t.uint8_t,
+        },
     ),
     "mfglibSetPower": (
         0x8C,
-        (t.uint16_t, t.int8s),
-        (t.EmberStatus,),
+        {
+            "txPowerMode": t.uint16_t,
+            "power": t.int8s,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "mfglibGetPower": (
         0x8D,
         {},
-        (t.int8s,),
+        {
+            "power": t.int8s,
+        },
     ),
     "mfglibRxHandler": (
         0x8E,
         {},
-        (t.uint8_t, t.int8s, t.LVBytes),
+        {
+            "linkQuality": t.uint8_t,
+            "rssi": t.int8s,
+            "packetContents": t.LVBytes,
+        },
     ),
     # 13. Bootloader Frames
     "launchStandaloneBootloader": (
         0x8F,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "mode": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "sendBootloadMessage": (
         0x90,
-        (t.Bool, t.EUI64, t.LVBytes),
-        (t.EmberStatus,),
+        {
+            "broadcast": t.Bool,
+            "destEui64": t.EUI64,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getStandaloneBootloaderVersionPlatMicroPhy": (
         0x91,
         {},
-        (t.uint16_t, t.uint8_t, t.uint8_t, t.uint8_t),
+        {
+            "bootloader_version": t.uint16_t,
+            "nodePlat": t.uint8_t,
+            "nodeMicro": t.uint8_t,
+            "nodePhy": t.uint8_t,
+        },
     ),
     "incomingBootloadMessageHandler": (
         0x92,
         {},
-        (t.EUI64, t.uint8_t, t.int8s, t.LVBytes),
+        {
+            "longId": t.EUI64,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+            "messageContents": t.LVBytes,
+        },
     ),
     "bootloadTransmitCompleteHandler": (
         0x93,
         {},
-        (t.EmberStatus, t.LVBytes),
+        {
+            "status": t.EmberStatus,
+            "messageContents": t.LVBytes,
+        },
     ),
     "aesEncrypt": (
         0x94,
-        (t.FixedList[t.uint8_t, 16], t.FixedList[t.uint8_t, 16]),
-        (t.FixedList[t.uint8_t, 16],),
+        {
+            "plaintext": t.FixedList[t.uint8_t, 16],
+            "key": t.FixedList[t.uint8_t, 16],
+        },
+        {
+            "ciphertext": t.FixedList[t.uint8_t, 16],
+        },
     ),
     "overrideCurrentChannel": (
         0x95,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "channel": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 14. ZLL Frames
     "zllNetworkOps": (
         0xB2,
-        (t.EmberZllNetwork, t.EzspZllNetworkOperation, t.int8s),
-        (t.EmberStatus,),
+        {
+            "networkInfo": t.EmberZllNetwork,
+            "op": t.EzspZllNetworkOperation,
+            "radioTxPower": t.int8s,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllSetInitialSecurityState": (
         0xB3,
-        (t.KeyData, t.EmberZllInitialSecurityState),
-        (t.EmberStatus,),
+        {
+            "networkKey": t.KeyData,
+            "securityState": t.EmberZllInitialSecurityState,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllStartScan": (
         0xB4,
-        (t.Channels, t.int8s, t.EmberNodeType),
-        (t.EmberStatus,),
+        {
+            "channelMask": t.Channels,
+            "radioPowerForScan": t.int8s,
+            "nodeType": t.EmberNodeType,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllSetRxOnWhenIdle": (
         0xB5,
-        (t.uint16_t,),
-        (t.EmberStatus,),
+        {
+            "durationMs": t.uint32_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllNetworkFoundHandler": (
         0xB6,
         {},
-        (t.EmberZllNetwork, t.Bool, t.EmberZllDeviceInfoRecord, t.uint8_t, t.int8s),
+        {
+            "networkInfo": t.EmberZllNetwork,
+            "isDeviceInfoNull": t.Bool,
+            "deviceInfo": t.EmberZllDeviceInfoRecord,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+        },
     ),
     "zllScanCompleteHandler": (
         0xB7,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllAddressAssignmentHandler": (
         0xB8,
         {},
-        (t.EmberZllAddressAssignment, t.uint8_t, t.int8s),
+        {
+            "addressInfo": t.EmberZllAddressAssignment,
+            "lastHopLqi": t.uint8_t,
+            "lastHopRssi": t.int8s,
+        },
     ),
     "setLogicalAndRadioChannel": (
         0xB9,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getLogicalChannel": (
         0xBA,
         {},
-        (t.uint8_t,),
+        {
+            "radioChannel": t.uint8_t,
+        },
     ),
     "zllTouchLinkTargetHandler": (
         0xBB,
         {},
-        (t.EmberZllNetwork,),
+        {
+            "networkInfo": t.EmberZllNetwork,
+        },
     ),
     "zllGetTokens": (
         0xBC,
         {},
-        (t.EmberTokTypeStackZllData, t.EmberTokTypeStackZllSecurity),
+        {
+            "data": t.EmberTokTypeStackZllData,
+            "security": t.EmberTokTypeStackZllSecurity,
+        },
     ),
     "zllSetDataToken": (
         0xBD,
-        (t.EmberTokTypeStackZllData,),
+        {
+            "data": t.EmberTokTypeStackZllData,
+        },
         {},
     ),
     "zllSetNonZllNetwork": (
@@ -969,236 +1662,352 @@ COMMANDS = {
     "isZllNetwork": (
         0xBE,
         {},
-        (t.Bool,),
+        {
+            "isZllNetwork": t.Bool,
+        },
     ),
     # 15 RF4CE Frames
     "rf4ceSetPairingTableEntry": (
         0xD0,
-        (t.uint8_t, t.EmberRf4cePairingTableEntry),
-        (t.EmberStatus,),
+        {
+            "pairingIndex": t.uint8_t,
+            "entry": t.EmberRf4cePairingTableEntry,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceGetPairingTableEntry": (
         0xD1,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberRf4cePairingTableEntry),
+        {
+            "pairingIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "entry": t.EmberRf4cePairingTableEntry,
+        },
     ),
     "rf4ceDeletePairingTableEntry": (
         0xD2,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "pairingIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceKeyUpdate": (
         0xD3,
-        (t.uint8_t, t.KeyData),
-        (t.EmberStatus,),
+        {
+            "pairingIndex": t.uint8_t,
+            "key": t.KeyData,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceSend": (
         0xD4,
-        (t.uint8_t, t.uint8_t, t.uint16_t, t.EmberRf4ceTxOption, t.uint8_t, t.LVBytes),
-        (t.EmberStatus,),
+        {
+            "pairingIndex": t.uint8_t,
+            "profileId": t.uint8_t,
+            "vendorId": t.uint16_t,
+            "txOptions": t.EmberRf4ceTxOption,
+            "messageTag": t.uint8_t,
+            "message": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceIncomingMessageHandler": (
         0xD5,
         {},
-        (t.uint8_t, t.uint8_t, t.uint16_t, t.EmberRf4ceTxOption, t.LVBytes),
+        {
+            "pairingIndex": t.uint8_t,
+            "profileId": t.uint8_t,
+            "vendorId": t.uint16_t,
+            "txOptions": t.EmberRf4ceTxOption,
+            "message": t.LVBytes,
+        },
     ),
     "rf4ceMessageSentHandler": (
         0xD6,
         {},
-        (
-            t.EmberStatus,
-            t.uint8_t,
-            t.EmberRf4ceTxOption,
-            t.uint8_t,
-            t.uint16_t,
-            t.uint8_t,
-            t.LVBytes,
-        ),
+        {
+            "status": t.EmberStatus,
+            "pairingIndex": t.uint8_t,
+            "profileId": t.uint8_t,
+            "vendorId": t.uint16_t,
+            "txOptions": t.uint8_t,
+            "message": t.LVBytes,
+        },
     ),
     "rf4ceStart": (
         0xD7,
-        (t.EmberRf4ceNodeCapabilities, t.EmberRf4ceVendorInfo, t.int8s),
-        (t.EmberStatus,),
+        {
+            "capabilities": t.EmberRf4ceNodeCapabilities,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "power": t.int8s,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceStop": (
         0xD8,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceDiscovery": (
         0xD9,
-        (
-            t.EmberPanId,
-            t.EmberNodeId,
-            t.uint8_t,
-            t.uint16_t,
-            t.uint8_t,
-            t.LVList[t.uint8_t],
-        ),
-        (t.EmberStatus,),
+        {
+            "panId": t.EmberPanId,
+            "nodeId": t.EmberNodeId,
+            "searchDevType": t.uint8_t,
+            "discDuration": t.uint16_t,
+            "maxDiscRepetitions": t.uint8_t,
+            "discProfileIdList": t.LVList[t.uint8_t],
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceDiscoveryCompleteHandler": (
         0xDA,
         {},
-        (t.EmberStatus,),
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceDiscoveryRequestHandler": (
         0xDB,
         {},
-        (
-            t.EUI64,
-            t.uint8_t,
-            t.EmberRf4ceVendorInfo,
-            t.EmberRf4ceApplicationInfo,
-            t.uint8_t,
-            t.uint8_t,
-        ),
+        {
+            "ieeeAddr": t.EUI64,
+            "nodeCapabilities": t.uint8_t,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+            "searchDevType": t.uint8_t,
+            "rxLinkQuality": t.uint8_t,
+        },
     ),
     "rf4ceDiscoveryResponseHandler": (
         0xDC,
         {},
-        (
-            t.Bool,
-            t.uint8_t,
-            t.EmberPanId,
-            t.EUI64,
-            t.uint8_t,
-            t.EmberRf4ceVendorInfo,
-            t.EmberRf4ceApplicationInfo,
-            t.uint8_t,
-            t.uint8_t,
-        ),
+        {
+            "atCapacity": t.Bool,
+            "channel": t.uint8_t,
+            "panId": t.EmberPanId,
+            "ieeeAddr": t.EUI64,
+            "nodeCapabilities": t.uint8_t,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+            "rxLinkQuality": t.uint8_t,
+            "discRequestLqi": t.uint8_t,
+        },
     ),
     "rf4ceEnableAutoDiscoveryResponse": (
         0xDD,
-        (t.uint16_t,),
-        (t.EmberStatus,),
+        {
+            "duration": t.uint16_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceAutoDiscoveryResponseCompleteHandler": (
         0xDE,
         {},
-        (
-            t.EmberStatus,
-            t.EUI64,
-            t.uint8_t,
-            t.EmberRf4ceVendorInfo,
-            t.EmberRf4ceApplicationInfo,
-            t.uint8_t,
-        ),
+        {
+            "status": t.EmberStatus,
+            "srcIeeeAddr": t.EUI64,
+            "nodeCapabilities": t.uint8_t,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+            "searchDevType": t.uint8_t,
+        },
     ),
     "rf4cePair": (
         0xDF,
-        (t.uint8_t, t.EmberPanId, t.EUI64, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "channel": t.uint8_t,
+            "panId": t.EmberPanId,
+            "ieeeAddr": t.EUI64,
+            "keyExchangeTransferCount": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4cePairCompleteHandler": (
         0xE0,
         {},
-        (t.EmberStatus, t.uint8_t, t.EmberRf4ceVendorInfo, t.EmberRf4ceApplicationInfo),
+        {
+            "status": t.EmberStatus,
+            "pairingIndex": t.uint8_t,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+        },
     ),
     "rf4cePairRequestHandler": (
         0xE1,
         {},
-        (
-            t.EmberStatus,
-            t.uint8_t,
-            t.EUI64,
-            t.uint8_t,
-            t.EmberRf4ceVendorInfo,
-            t.EmberRf4ceApplicationInfo,
-            t.uint8_t,
-        ),
+        {
+            "status": t.EmberStatus,
+            "pairingIndex": t.uint8_t,
+            "srcIeeeAddr": t.EUI64,
+            "nodeCapabilities": t.uint8_t,
+            "vendorInfo": t.EmberRf4ceVendorInfo,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+            "keyExchangeTransferCount": t.uint8_t,
+        },
     ),
     "rf4ceUnpair": (
         0xE2,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        {
+            "pairingIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceUnpairHandler": (
         0xE3,
         {},
-        (t.uint8_t,),
+        {
+            "pairingIndex": t.uint8_t,
+        },
     ),
     "rf4ceUnpairCompleteHandler": (
         0xE4,
         {},
-        (t.uint8_t,),
+        {
+            "pairingIndex": t.uint8_t,
+        },
     ),
     "rf4ceSetPowerSavingParameters": (
         0xE5,
-        (t.uint32_t, t.uint32_t),
-        (t.EmberStatus,),
+        {
+            "dutyCycle": t.uint32_t,
+            "activePeriod": t.uint32_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceSetFrequencyAgilityParameters": (
         0xE6,
-        (t.uint8_t, t.uint8_t, t.int8s, t.uint16_t, t.uint8_t),
-        (t.EmberStatus,),
+        {
+            "rssiWindowSize": t.uint8_t,
+            "channelChangeReads": t.uint8_t,
+            "rssiThreshold": t.int8s,
+            "readInterval": t.uint16_t,
+            "readDuration": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceSetApplicationInfo": (
         0xE7,
-        (t.EmberRf4ceApplicationInfo,),
-        (t.EmberStatus,),
+        {
+            "appInfo": t.EmberRf4ceApplicationInfo,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "rf4ceGetApplicationInfo": (
         0xEF,
         {},
-        (t.EmberStatus, t.EmberRf4ceApplicationInfo),
+        {
+            "status": t.EmberStatus,
+            "appInfo": t.EmberRf4ceApplicationInfo,
+        },
     ),
     "rf4ceGetMaxPayload": (
         0xF3,
-        (t.uint8_t, t.EmberRf4ceTxOption),
-        (t.uint8_t,),
+        {
+            "pairingIndex": t.uint8_t,
+            "txOptions": t.EmberRf4ceTxOption,
+        },
+        {
+            "maxLength": t.uint8_t,
+        },
     ),
     "rf4ceGetNetworkParameters": (
         0xF4,
         {},
-        (t.EmberStatus, t.EmberNodeType, t.EmberNetworkParameters),
+        {
+            "status": t.EmberStatus,
+            "nodeType": t.EmberNodeType,
+            "parameters": t.EmberNetworkParameters,
+        },
     ),
     # 16 Green Power Frames
     "gpProxyTableProcessGpPairing": (
         0xC9,
-        (
-            t.uint32_t,
-            t.EmberGpAddress,
-            t.uint8_t,
-            t.uint16_t,
-            t.uint16_t,
-            t.uint16_t,
-            t.EUI64,
-            t.KeyData,
-        ),
-        {},
+        {
+            "options": t.uint32_t,
+            "addr": t.EmberGpAddress,
+            "commMode": t.uint8_t,
+            "sinkNetworkAddress": t.uint16_t,
+            "sinkGroupId": t.uint16_t,
+            "assignedAlias": t.uint16_t,
+            "sinkIeeeAddress": t.EUI64,
+            "gpdKey": t.KeyData,
+        },
+        {
+            "gpPairingAdded": t.Bool,
+        },
     ),
     "dGpSend": (
         0xC6,
-        (t.Bool, t.Bool, t.EmberGpAddress, t.uint8_t, t.LVBytes, t.uint8_t, t.uint16_t),
-        (t.EmberStatus,),
+        {
+            "action": t.Bool,
+            "useCca": t.Bool,
+            "addr": t.EmberGpAddress,
+            "gpdCommandId": t.uint8_t,
+            "gpdAsdu": t.LVBytes,
+            "gpepHandle": t.uint8_t,
+            "gpTxQueueEntryLifetimeMs": t.uint16_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "dGpSentHandler": (
         0xC7,
         {},
-        (t.EmberStatus, t.uint8_t),
+        {
+            "status": t.EmberStatus,
+            "gpepHandle": t.uint8_t,
+        },
     ),
     "gpepIncomingMessageHandler": (
         0x00C5,
         {},
-        (
-            t.EmberStatus,  # status
-            t.uint8_t,  # gpd link
-            t.uint8_t,  # sequence number
-            t.uint8_t,  # addrType
-            t.uint32_t,  # address
-            t.uint32_t,  # src ID
-            t.uint8_t,  # endpoint
-            t.EmberGpSecurityLevel,
-            t.EmberGpKeyType,
-            t.Bool,  # auto commissioning
-            t.Bool,  # rx capable?
-            t.uint32_t,  # security frame counter
-            t.uint8_t,  # gpd command id
-            t.uint32_t,  # MIC
-            t.uint8_t,  # proxy table index
-            t.LVBytes,  # optional payload
-        ),
+        {
+            "status": t.EmberStatus,
+            "gpdLink": t.uint8_t,
+            "sequenceNumber": t.uint8_t,
+            "addrType": t.uint8_t,
+            "addr": t.uint32_t,
+            "applicationId": t.uint8_t,
+            "address": t.EUI64,  # TODO: `sourceId` if appId == 0 else `gpdIeeeAddress`
+            "endpoint": t.uint8_t,
+            "gpdfSecurityLevel": t.EmberGpSecurityLevel,
+            "gpdfSecurityKeyType": t.EmberGpKeyType,
+            "autoCommissioning": t.Bool,
+            "bidirectionalInfo": t.Bool,
+            "gpdSecurityFrameCounter": t.uint32_t,
+            "gpdCommandId": t.uint8_t,
+            "mic": t.uint32_t,
+            "proxyTableIndex": t.uint8_t,
+            "gpdCommandPayload": t.LVBytes,
+        },
     ),
 }

--- a/bellows/ezsp/v5/__init__.py
+++ b/bellows/ezsp/v5/__init__.py
@@ -38,7 +38,7 @@ class EZSPv5(EZSPv4):
     async def add_transient_link_key(
         self, ieee: t.EUI64, key: t.KeyData
     ) -> t.sl_Status:
-        (status,) = await self.addTransientLinkKey(ieee, key)
+        (status,) = await self.addTransientLinkKey(partner=ieee, transientKey=key)
         return t.sl_Status.from_ember_status(status)
 
     async def pre_permit(self, time_s: int) -> None:
@@ -53,13 +53,13 @@ class EZSPv5(EZSPv4):
         )
 
         for idx in range(addr_table_size):
-            (nwk,) = await self.getAddressTableRemoteNodeId(idx)
+            (nwk,) = await self.getAddressTableRemoteNodeId(addressTableIndex=idx)
 
             # Ignore invalid NWK entries
             if nwk in t.EmberDistinguishedNodeId.__members__.values():
                 continue
 
-            (eui64,) = await self.getAddressTableRemoteEui64(idx)
+            (eui64,) = await self.getAddressTableRemoteEui64(addressTableIndex=idx)
 
             if eui64 in (
                 t.EUI64.convert("00:00:00:00:00:00:00:00"),
@@ -75,8 +75,8 @@ class EZSPv5(EZSPv4):
         assert state == t.EmberNetworkStatus.NO_NETWORK
 
         (status,) = await self.setValue(
-            t.EzspValueId.VALUE_NWK_FRAME_COUNTER,
-            t.uint32_t(frame_counter).serialize(),
+            valueId=t.EzspValueId.VALUE_NWK_FRAME_COUNTER,
+            value=t.uint32_t(frame_counter).serialize(),
         )
         assert t.sl_Status.from_ember_status(status) == t.sl_Status.OK
 
@@ -86,7 +86,7 @@ class EZSPv5(EZSPv4):
         assert state == t.EmberNetworkStatus.NO_NETWORK
 
         (status,) = await self.setValue(
-            t.EzspValueId.VALUE_APS_FRAME_COUNTER,
-            t.uint32_t(frame_counter).serialize(),
+            valueId=t.EzspValueId.VALUE_APS_FRAME_COUNTER,
+            value=t.uint32_t(frame_counter).serialize(),
         )
         assert t.sl_Status.from_ember_status(status) == t.sl_Status.OK

--- a/bellows/ezsp/v5/commands.py
+++ b/bellows/ezsp/v5/commands.py
@@ -5,37 +5,84 @@ COMMANDS = {
     **COMMANDS_v4,
     "changeSourceRouteHandler": (
         0xC4,
-        (),
-        (t.EmberNodeId, t.EmberNodeId, t.Bool),
+        tuple({}.values()),
+        tuple(
+            {
+                "newChildId": t.EmberNodeId,
+                "newParentId": t.EmberNodeId,
+                "ourChild": t.Bool,
+            }.values()
+        ),
     ),
     "setSecurityKey": (
         0xCA,
-        (t.KeyData, t.SecureEzspSecurityType),
-        (t.EzspStatus,),
+        tuple(
+            {
+                "securityKey": t.KeyData,
+                "securityType": t.SecureEzspSecurityType,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EzspStatus,
+            }.values()
+        ),
     ),
     "setSecurityParameters": (
         0xCB,
-        (t.SecureEzspSecurityLevel, t.uint128_t),
-        (t.EzspStatus, t.uint128_t),
+        tuple(
+            {
+                "securityLevel": t.SecureEzspSecurityLevel,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EzspStatus,
+                "randomNumber": t.uint128_t,
+            }.values()
+        ),
     ),
     "resetToFactoryDefaults": (
         0xCC,
-        (),
-        (t.EzspStatus,),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EzspStatus,
+            }.values()
+        ),
     ),
     "getSecurityKeyStatus": (
         0xCD,
-        (),
-        (t.EzspStatus, t.SecureEzspSecurityType),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EzspStatus,
+                "securityType": t.SecureEzspSecurityType,
+            }.values()
+        ),
     ),
     "getTransientLinkKey": (
         0xCE,
-        (t.EUI64,),
-        (t.EmberStatus, t.EmberTransientKeyDataV5),
+        tuple(
+            {
+                "eui": t.EUI64,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "transientKeyData": t.EmberTransientKeyDataV5,
+            }.values()
+        ),
     ),
     "setChannelMap": (
         0xF7,
-        (t.uint8_t, t.uint8_t),
-        (),
+        tuple(
+            {
+                "page": t.uint8_t,
+                "channel": t.uint8_t,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
 }

--- a/bellows/ezsp/v5/commands.py
+++ b/bellows/ezsp/v5/commands.py
@@ -5,84 +5,64 @@ COMMANDS = {
     **COMMANDS_v4,
     "changeSourceRouteHandler": (
         0xC4,
-        tuple({}.values()),
-        tuple(
-            {
-                "newChildId": t.EmberNodeId,
-                "newParentId": t.EmberNodeId,
-                "ourChild": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "newChildId": t.EmberNodeId,
+            "newParentId": t.EmberNodeId,
+            "ourChild": t.Bool,
+        },
     ),
     "setSecurityKey": (
         0xCA,
-        tuple(
-            {
-                "securityKey": t.KeyData,
-                "securityType": t.SecureEzspSecurityType,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EzspStatus,
-            }.values()
-        ),
+        {
+            "securityKey": t.KeyData,
+            "securityType": t.SecureEzspSecurityType,
+        },
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "setSecurityParameters": (
         0xCB,
-        tuple(
-            {
-                "securityLevel": t.SecureEzspSecurityLevel,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EzspStatus,
-                "randomNumber": t.uint128_t,
-            }.values()
-        ),
+        {
+            "securityLevel": t.SecureEzspSecurityLevel,
+        },
+        {
+            "status": t.EzspStatus,
+            "randomNumber": t.uint128_t,
+        },
     ),
     "resetToFactoryDefaults": (
         0xCC,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EzspStatus,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EzspStatus,
+        },
     ),
     "getSecurityKeyStatus": (
         0xCD,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EzspStatus,
-                "securityType": t.SecureEzspSecurityType,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EzspStatus,
+            "securityType": t.SecureEzspSecurityType,
+        },
     ),
     "getTransientLinkKey": (
         0xCE,
-        tuple(
-            {
-                "eui": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "transientKeyData": t.EmberTransientKeyDataV5,
-            }.values()
-        ),
+        {
+            "eui": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+            "transientKeyData": t.EmberTransientKeyDataV5,
+        },
     ),
     "setChannelMap": (
         0xF7,
-        tuple(
-            {
-                "page": t.uint8_t,
-                "channel": t.uint8_t,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "page": t.uint8_t,
+            "channel": t.uint8_t,
+        },
+        {},
     ),
 }

--- a/bellows/ezsp/v6/__init__.py
+++ b/bellows/ezsp/v6/__init__.py
@@ -24,6 +24,6 @@ class EZSPv6(EZSPv5):
 
     async def initialize_network(self) -> t.sl_Status:
         (init_status,) = await self.networkInit(
-            networkInitBitmask=t.NETWORK_INIT_NO_OPTIONS
+            networkInitBitmask=t.EmberNetworkInitBitmask.NETWORK_INIT_NO_OPTIONS
         )
         return t.sl_Status.from_ember_status(init_status)

--- a/bellows/ezsp/v6/__init__.py
+++ b/bellows/ezsp/v6/__init__.py
@@ -23,5 +23,7 @@ class EZSPv6(EZSPv5):
     }
 
     async def initialize_network(self) -> t.sl_Status:
-        (init_status,) = await self.networkInit(0x0000)
+        (init_status,) = await self.networkInit(
+            networkInitBitmask=t.NETWORK_INIT_NO_OPTIONS
+        )
         return t.sl_Status.from_ember_status(init_status)

--- a/bellows/ezsp/v6/commands.py
+++ b/bellows/ezsp/v6/commands.py
@@ -5,236 +5,507 @@ COMMANDS = {
     **COMMANDS_v5,
     "getPhyInterfaceCount": (
         0xFC,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "interfaceCount": t.uint8_t,
+            }.values()
+        ),
     ),
     "unusedPanIdFoundHandler": (
         0xD2,
-        (),
-        (t.uint8_t, t.EmberStatus),
+        tuple({}.values()),
+        tuple(
+            {
+                "panId": t.uint16_t,
+                "channel": t.uint8_t,
+            }.values()
+        ),
     ),
     "findUnusedPanId": (
         0xD3,
-        (t.Channels, t.uint8_t),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "channelMask": t.Channels,
+                "duration": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getRadioParameters": (
         0xFD,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberNodeType, t.EmberNetworkParameters),
+        tuple(
+            {
+                "phyIndex": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "parameters": t.EmberMultiPhyRadioParameters,
+            }.values()
+        ),
     ),
     "getSourceRouteTableTotalSize": (
         0xC3,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "sourceRouteTableTotalSize": t.uint8_t,
+            }.values()
+        ),
     ),
     "getSourceRouteTableFilledSize": (
         0xC2,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "sourceRouteTableFilledSize": t.uint8_t,
+            }.values()
+        ),
     ),
     "getSourceRouteTableEntry": (
         0xC1,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberNodeId, t.uint8_t),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "destination": t.EmberNodeId,
+                "closerIndex": t.uint8_t,
+            }.values()
+        ),
     ),
     "setRoutingShortcutThreshold": (
         0xD0,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getRoutingShortcutThreshold": (
         0xD1,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "routingShortcutThresh": t.uint8_t,
+            }.values()
+        ),
     ),
     "setBrokenRouteErrorCode": (
         0x11,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "errorCode": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "multiPhyStart": (
         0xF8,
-        (t.uint8_t, t.uint8_t, t.uint8_t, t.int8s, t.EmberMultiPhyNwkConfig),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "phyIndex": t.uint8_t,
+                "page": t.uint8_t,
+                "channel": t.uint8_t,
+                "power": t.int8s,
+                "bitmask": t.EmberMultiPhyNwkConfig,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "multiPhyStop": (
         0xF9,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "phyIndex": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "multiPhySetRadioPower": (
         0xFA,
-        (t.uint8_t, t.int8s),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "phyIndex": t.uint8_t,
+                "power": t.int8s,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "sendLinkPowerDeltaRequest": (
         0xF7,
-        (),
-        (t.EmberStatus,),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "multiPhySetRadioChannel": (
         0xFB,
-        (t.uint8_t, t.uint8_t, t.uint8_t),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "phyIndex": t.uint8_t,
+                "page": t.uint8_t,
+                "channel": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getDutyCycleState": (
         0x35,
-        (),
-        (t.EmberStatus, t.EmberDutyCycleState),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "returnedState": t.EmberDutyCycleState,
+            }.values()
+        ),
     ),
     "setDutyCycleLimitsInStack": (
         0x40,
-        (t.EmberDutyCycleLimits,),
-        (t.EmberStatus, t.EmberDutyCycleState),
+        tuple(
+            {
+                "limits": t.EmberDutyCycleLimits,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getDutyCycleLimits": (
         0x4B,
-        (),
-        (t.EmberStatus, t.EmberDutyCycleLimits),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "limits": t.EmberDutyCycleLimits,
+            }.values()
+        ),
     ),
     "getCurrentDutyCycle": (
         0x4C,
-        (t.uint8_t,),
-        (t.EmberStatus, t.FixedList[t.uint8_t, 134]),
+        tuple(
+            {
+                "maxDevices": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "arrayOfDeviceDutyCycles": t.FixedList[t.uint8_t, 134],
+            }.values()
+        ),
     ),
     "dutyCycleHandler": (
         0x4D,
-        (),
-        (
-            t.uint8_t,
-            t.uint8_t,
-            t.EmberDutyCycleState,
-            t.uint8_t,
-            t.EmberPerDeviceDutyCycle,
+        tuple({}.values()),
+        tuple(
+            {
+                "channelPage": t.uint8_t,
+                "channel": t.uint8_t,
+                "state": t.EmberDutyCycleState,
+                "arrayOfDeviceDutyCycles": t.LVList[t.EmberPerDeviceDutyCycle],
+            }.values()
         ),
     ),
     "sendMulticastWithAlias": (
         0x3A,
-        (
-            t.EmberApsFrame,
-            t.uint8_t,
-            t.uint8_t,
-            t.uint16_t,
-            t.uint8_t,
-            t.uint8_t,
-            t.LVBytes,
+        tuple(
+            {
+                "hops": t.EmberApsFrame,
+                "nonmemberRadius": t.uint8_t,
+                "alias": t.uint8_t,
+                "nwkSequence": t.uint16_t,
+                "messageTag": t.uint8_t,
+                "messageLength": t.uint8_t,
+                "messageContents": t.LVBytes,
+            }.values()
         ),
-        (
-            t.EmberStatus,
-            t.uint8_t,
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "sequence": t.uint8_t,
+            }.values()
         ),
     ),
     "writeNodeData": (
         0xFE,
-        (t.Bool,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "erase": t.Bool,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "sendTrustCenterLinkKey": (
         0x67,
-        (t.EmberNodeId, t.EUI64),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "destinationNodeId": t.EmberNodeId,
+                "destinationEui64": t.EUI64,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "zllSetSecurityStateWithoutKey": (
         0xCF,
-        (t.EmberZllInitialSecurityState,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "securityState": t.EmberZllInitialSecurityState,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "zllSetRadioIdleMode": (
         0xD4,
-        (t.EmberRadioPowerMode,),
-        (),
+        tuple(
+            {
+                "mode": t.EmberRadioPowerMode,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setZllNodeType": (
         0xD5,
-        (t.EmberNodeType,),
-        (),
+        tuple(
+            {
+                "nodeType": t.EmberNodeType,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setZllAdditionalState": (
         0xD6,
-        (t.uint16_t,),
-        (),
+        tuple(
+            {
+                "state": t.uint16_t,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "zllOperationInProgress": (
         0xD7,
-        (),
-        (t.Bool,),
+        tuple({}.values()),
+        tuple(
+            {
+                "zllOperationInProgress": t.Bool,
+            }.values()
+        ),
     ),
     "zllRxOnWhenIdleGetActive": (
         0xD8,
-        (),
-        (t.Bool,),
+        tuple({}.values()),
+        tuple(
+            {
+                "zllRxOnWhenIdleGetActive": t.Bool,
+            }.values()
+        ),
     ),
     "getZllPrimaryChannelMask": (
         0xD9,
-        (),
-        (t.Channels,),
+        tuple({}.values()),
+        tuple(
+            {
+                "zllPrimaryChannelMask": t.Channels,
+            }.values()
+        ),
     ),
     "getZllSecondaryChannelMask": (
         0xDA,
-        (),
-        (t.Channels,),
+        tuple({}.values()),
+        tuple(
+            {
+                "zllSecondaryChannelMask": t.Channels,
+            }.values()
+        ),
     ),
     "setZllPrimaryChannelMask": (
         0xDB,
-        (t.Channels,),
-        (),
+        tuple(
+            {
+                "zllPrimaryChannelMask": t.Channels,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setZllSecondaryChannelMask": (
         0xDC,
-        (t.Channels,),
-        (),
+        tuple(
+            {
+                "zllSecondaryChannelMask": t.Channels,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
+    # TODO: are these green power frames in the correct protocol version?
     "gpProxyTableGetEntry": (
         0xC8,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberGpProxyTableEntry),
+        tuple(
+            {
+                "proxyIndex": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "entry": t.EmberGpProxyTableEntry,
+            }.values()
+        ),
     ),
     "gpProxyTableLookup": (
         0xC0,
-        (t.EmberGpAddress,),
-        (t.uint8_t,),
+        tuple(
+            {
+                "addr": t.EmberGpAddress,
+            }.values()
+        ),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
     ),
     "gpSinkTableGetEntry": (
         0xDD,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberGpSinkTableEntry),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "entry": t.EmberGpSinkTableEntry,
+            }.values()
+        ),
     ),
     "gpSinkTableLookup": (
         0xDE,
-        (t.EmberGpAddress,),
-        (t.uint8_t,),
+        tuple(
+            {
+                "addr": t.EmberGpAddress,
+            }.values()
+        ),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
     ),
     "gpSinkTableSetEntry": (
         0xDF,
-        (t.uint8_t, t.EmberGpSinkTableEntry),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "sinkIndex": t.uint8_t,
+                "entry": t.EmberGpSinkTableEntry,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "gpSinkTableRemoveEntry": (
         0xE0,
-        (t.uint8_t,),
-        (),
+        tuple(
+            {
+                "sinkIndex": t.uint8_t,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "gpSinkTableFindOrAllocateEntry": (
         0xE1,
-        (t.EmberGpAddress,),
-        (t.uint8_t,),
+        tuple(
+            {
+                "addr": t.EmberGpAddress,
+            }.values()
+        ),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
     ),
     "gpClearSinkTable": (
         0xE2,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
     # Changed commands
     "zllSetRxOnWhenIdle": (
         0xB5,
-        (t.uint32_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "durationMs": t.uint32_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "networkInit": (
         0x17,
-        (t.EmberNetworkInitBitmask,),
-        (t.EmberStatus,),
+        tuple(
+            {"networkInitBitmask": t.EmberNetworkInitBitmask}.values()
+        ),  # XXX: We deviate here, since the struct has a single membe.values())r
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
 }
 

--- a/bellows/ezsp/v6/commands.py
+++ b/bellows/ezsp/v6/commands.py
@@ -373,7 +373,7 @@ COMMANDS = {
     "networkInit": (
         0x17,
         {
-            "networkInitBitmask": t.EmberNetworkInitBitmask,  # XXX: We deviate here, since the struct has a single membe.values())r
+            "networkInitBitmask": t.EmberNetworkInitBitmask,  # XXX: We deviate here, since the struct has a single member
         },
         {
             "status": t.EmberStatus,

--- a/bellows/ezsp/v6/commands.py
+++ b/bellows/ezsp/v6/commands.py
@@ -5,507 +5,379 @@ COMMANDS = {
     **COMMANDS_v5,
     "getPhyInterfaceCount": (
         0xFC,
-        tuple({}.values()),
-        tuple(
-            {
-                "interfaceCount": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "interfaceCount": t.uint8_t,
+        },
     ),
     "unusedPanIdFoundHandler": (
         0xD2,
-        tuple({}.values()),
-        tuple(
-            {
-                "panId": t.uint16_t,
-                "channel": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "panId": t.uint16_t,
+            "channel": t.uint8_t,
+        },
     ),
     "findUnusedPanId": (
         0xD3,
-        tuple(
-            {
-                "channelMask": t.Channels,
-                "duration": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "channelMask": t.Channels,
+            "duration": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getRadioParameters": (
         0xFD,
-        tuple(
-            {
-                "phyIndex": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "parameters": t.EmberMultiPhyRadioParameters,
-            }.values()
-        ),
+        {
+            "phyIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "parameters": t.EmberMultiPhyRadioParameters,
+        },
     ),
     "getSourceRouteTableTotalSize": (
         0xC3,
-        tuple({}.values()),
-        tuple(
-            {
-                "sourceRouteTableTotalSize": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "sourceRouteTableTotalSize": t.uint8_t,
+        },
     ),
     "getSourceRouteTableFilledSize": (
         0xC2,
-        tuple({}.values()),
-        tuple(
-            {
-                "sourceRouteTableFilledSize": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "sourceRouteTableFilledSize": t.uint8_t,
+        },
     ),
     "getSourceRouteTableEntry": (
         0xC1,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "destination": t.EmberNodeId,
-                "closerIndex": t.uint8_t,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "destination": t.EmberNodeId,
+            "closerIndex": t.uint8_t,
+        },
     ),
     "setRoutingShortcutThreshold": (
         0xD0,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getRoutingShortcutThreshold": (
         0xD1,
-        tuple({}.values()),
-        tuple(
-            {
-                "routingShortcutThresh": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "routingShortcutThresh": t.uint8_t,
+        },
     ),
     "setBrokenRouteErrorCode": (
         0x11,
-        tuple(
-            {
-                "errorCode": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "errorCode": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "multiPhyStart": (
         0xF8,
-        tuple(
-            {
-                "phyIndex": t.uint8_t,
-                "page": t.uint8_t,
-                "channel": t.uint8_t,
-                "power": t.int8s,
-                "bitmask": t.EmberMultiPhyNwkConfig,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "phyIndex": t.uint8_t,
+            "page": t.uint8_t,
+            "channel": t.uint8_t,
+            "power": t.int8s,
+            "bitmask": t.EmberMultiPhyNwkConfig,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "multiPhyStop": (
         0xF9,
-        tuple(
-            {
-                "phyIndex": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "phyIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "multiPhySetRadioPower": (
         0xFA,
-        tuple(
-            {
-                "phyIndex": t.uint8_t,
-                "power": t.int8s,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "phyIndex": t.uint8_t,
+            "power": t.int8s,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "sendLinkPowerDeltaRequest": (
         0xF7,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "multiPhySetRadioChannel": (
         0xFB,
-        tuple(
-            {
-                "phyIndex": t.uint8_t,
-                "page": t.uint8_t,
-                "channel": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "phyIndex": t.uint8_t,
+            "page": t.uint8_t,
+            "channel": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getDutyCycleState": (
         0x35,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "returnedState": t.EmberDutyCycleState,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+            "returnedState": t.EmberDutyCycleState,
+        },
     ),
     "setDutyCycleLimitsInStack": (
         0x40,
-        tuple(
-            {
-                "limits": t.EmberDutyCycleLimits,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "limits": t.EmberDutyCycleLimits,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getDutyCycleLimits": (
         0x4B,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "limits": t.EmberDutyCycleLimits,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+            "limits": t.EmberDutyCycleLimits,
+        },
     ),
     "getCurrentDutyCycle": (
         0x4C,
-        tuple(
-            {
-                "maxDevices": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "arrayOfDeviceDutyCycles": t.FixedList[t.uint8_t, 134],
-            }.values()
-        ),
+        {
+            "maxDevices": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "arrayOfDeviceDutyCycles": t.FixedList[t.uint8_t, 134],
+        },
     ),
     "dutyCycleHandler": (
         0x4D,
-        tuple({}.values()),
-        tuple(
-            {
-                "channelPage": t.uint8_t,
-                "channel": t.uint8_t,
-                "state": t.EmberDutyCycleState,
-                "arrayOfDeviceDutyCycles": t.LVList[t.EmberPerDeviceDutyCycle],
-            }.values()
-        ),
+        {},
+        {
+            "channelPage": t.uint8_t,
+            "channel": t.uint8_t,
+            "state": t.EmberDutyCycleState,
+            "arrayOfDeviceDutyCycles": t.LVList[t.EmberPerDeviceDutyCycle],
+        },
     ),
     "sendMulticastWithAlias": (
         0x3A,
-        tuple(
-            {
-                "hops": t.EmberApsFrame,
-                "nonmemberRadius": t.uint8_t,
-                "alias": t.uint8_t,
-                "nwkSequence": t.uint16_t,
-                "messageTag": t.uint8_t,
-                "messageLength": t.uint8_t,
-                "messageContents": t.LVBytes,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "sequence": t.uint8_t,
-            }.values()
-        ),
+        {
+            "hops": t.EmberApsFrame,
+            "nonmemberRadius": t.uint8_t,
+            "alias": t.uint8_t,
+            "nwkSequence": t.uint16_t,
+            "messageTag": t.uint8_t,
+            "messageLength": t.uint8_t,
+            "messageContents": t.LVBytes,
+        },
+        {
+            "status": t.EmberStatus,
+            "sequence": t.uint8_t,
+        },
     ),
     "writeNodeData": (
         0xFE,
-        tuple(
-            {
-                "erase": t.Bool,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "erase": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "sendTrustCenterLinkKey": (
         0x67,
-        tuple(
-            {
-                "destinationNodeId": t.EmberNodeId,
-                "destinationEui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "destinationNodeId": t.EmberNodeId,
+            "destinationEui64": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllSetSecurityStateWithoutKey": (
         0xCF,
-        tuple(
-            {
-                "securityState": t.EmberZllInitialSecurityState,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "securityState": t.EmberZllInitialSecurityState,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "zllSetRadioIdleMode": (
         0xD4,
-        tuple(
-            {
-                "mode": t.EmberRadioPowerMode,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "mode": t.EmberRadioPowerMode,
+        },
+        {},
     ),
     "setZllNodeType": (
         0xD5,
-        tuple(
-            {
-                "nodeType": t.EmberNodeType,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "nodeType": t.EmberNodeType,
+        },
+        {},
     ),
     "setZllAdditionalState": (
         0xD6,
-        tuple(
-            {
-                "state": t.uint16_t,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "state": t.uint16_t,
+        },
+        {},
     ),
     "zllOperationInProgress": (
         0xD7,
-        tuple({}.values()),
-        tuple(
-            {
-                "zllOperationInProgress": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "zllOperationInProgress": t.Bool,
+        },
     ),
     "zllRxOnWhenIdleGetActive": (
         0xD8,
-        tuple({}.values()),
-        tuple(
-            {
-                "zllRxOnWhenIdleGetActive": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "zllRxOnWhenIdleGetActive": t.Bool,
+        },
     ),
     "getZllPrimaryChannelMask": (
         0xD9,
-        tuple({}.values()),
-        tuple(
-            {
-                "zllPrimaryChannelMask": t.Channels,
-            }.values()
-        ),
+        {},
+        {
+            "zllPrimaryChannelMask": t.Channels,
+        },
     ),
     "getZllSecondaryChannelMask": (
         0xDA,
-        tuple({}.values()),
-        tuple(
-            {
-                "zllSecondaryChannelMask": t.Channels,
-            }.values()
-        ),
+        {},
+        {
+            "zllSecondaryChannelMask": t.Channels,
+        },
     ),
     "setZllPrimaryChannelMask": (
         0xDB,
-        tuple(
-            {
-                "zllPrimaryChannelMask": t.Channels,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "zllPrimaryChannelMask": t.Channels,
+        },
+        {},
     ),
     "setZllSecondaryChannelMask": (
         0xDC,
-        tuple(
-            {
-                "zllSecondaryChannelMask": t.Channels,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "zllSecondaryChannelMask": t.Channels,
+        },
+        {},
     ),
     # TODO: are these green power frames in the correct protocol version?
     "gpProxyTableGetEntry": (
         0xC8,
-        tuple(
-            {
-                "proxyIndex": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "entry": t.EmberGpProxyTableEntry,
-            }.values()
-        ),
+        {
+            "proxyIndex": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "entry": t.EmberGpProxyTableEntry,
+        },
     ),
     "gpProxyTableLookup": (
         0xC0,
-        tuple(
-            {
-                "addr": t.EmberGpAddress,
-            }.values()
-        ),
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
+        {
+            "addr": t.EmberGpAddress,
+        },
+        {
+            "index": t.uint8_t,
+        },
     ),
     "gpSinkTableGetEntry": (
         0xDD,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "entry": t.EmberGpSinkTableEntry,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "entry": t.EmberGpSinkTableEntry,
+        },
     ),
     "gpSinkTableLookup": (
         0xDE,
-        tuple(
-            {
-                "addr": t.EmberGpAddress,
-            }.values()
-        ),
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
+        {
+            "addr": t.EmberGpAddress,
+        },
+        {
+            "index": t.uint8_t,
+        },
     ),
     "gpSinkTableSetEntry": (
         0xDF,
-        tuple(
-            {
-                "sinkIndex": t.uint8_t,
-                "entry": t.EmberGpSinkTableEntry,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "sinkIndex": t.uint8_t,
+            "entry": t.EmberGpSinkTableEntry,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "gpSinkTableRemoveEntry": (
         0xE0,
-        tuple(
-            {
-                "sinkIndex": t.uint8_t,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "sinkIndex": t.uint8_t,
+        },
+        {},
     ),
     "gpSinkTableFindOrAllocateEntry": (
         0xE1,
-        tuple(
-            {
-                "addr": t.EmberGpAddress,
-            }.values()
-        ),
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
+        {
+            "addr": t.EmberGpAddress,
+        },
+        {
+            "index": t.uint8_t,
+        },
     ),
     "gpClearSinkTable": (
         0xE2,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
     # Changed commands
     "zllSetRxOnWhenIdle": (
         0xB5,
-        tuple(
-            {
-                "durationMs": t.uint32_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "durationMs": t.uint32_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "networkInit": (
         0x17,
-        tuple(
-            {"networkInitBitmask": t.EmberNetworkInitBitmask}.values()
-        ),  # XXX: We deviate here, since the struct has a single membe.values())r
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "networkInitBitmask": t.EmberNetworkInitBitmask,  # XXX: We deviate here, since the struct has a single membe.values())r
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
 }
 

--- a/bellows/ezsp/v7/__init__.py
+++ b/bellows/ezsp/v7/__init__.py
@@ -29,7 +29,7 @@ class EZSPv7(EZSPv6):
         self,
     ) -> AsyncGenerator[tuple[t.NWK, t.EUI64, t.EmberNodeType], None]:
         for idx in range(0, 255 + 1):
-            (status, rsp) = await self.getChildData(idx)
+            (status, rsp) = await self.getChildData(index=idx)
             status = t.sl_Status.from_ember_status(status)
 
             if status == t.sl_Status.NOT_JOINED:

--- a/bellows/ezsp/v7/commands.py
+++ b/bellows/ezsp/v7/commands.py
@@ -5,233 +5,181 @@ COMMANDS = {
     **COMMANDS_v6,
     "sendPanIdUpdate": (
         0x57,
-        tuple(
-            {
-                "newPan": t.EmberPanId,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "newPan": t.EmberPanId,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getTrueRandomEntropySource": (
         0x4F,
-        tuple({}.values()),
-        tuple(
-            {
-                "entropySource": t.EmberEntropySource,
-            }.values()
-        ),
+        {},
+        {
+            "entropySource": t.EmberEntropySource,
+        },
     ),
     "joinNetworkDirectly": (
         0x3B,
-        tuple(
-            {
-                "localNodeType": t.EmberNodeType,
-                "beacon": t.EmberBeaconData,
-                "radioTxPower": t.int8s,
-                "clearBeaconsAfterNetworkUp": t.Bool,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "localNodeType": t.EmberNodeType,
+            "beacon": t.EmberBeaconData,
+            "radioTxPower": t.int8s,
+            "clearBeaconsAfterNetworkUp": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getFirstBeacon": (
         0x3D,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "beaconIterator": t.EmberBeaconIterator,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+            "beaconIterator": t.EmberBeaconIterator,
+        },
     ),
     "getNextBeacon": (
         0x04,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "beaconData": t.EmberBeaconData,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+            "beaconData": t.EmberBeaconData,
+        },
     ),
     "getNumStoredBeacons": (
         0x08,
-        tuple({}.values()),
-        tuple(
-            {
-                "numStoredBeacons": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "numStoredBeacons": t.uint8_t,
+        },
     ),
     "clearStoredBeacons": (
         0x3C,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
     "unicastCurrentNetworkKey": (
         0x50,
-        tuple(
-            {
-                "targetShort": t.EmberNodeId,
-                "targetLong": t.EUI64,
-                "parentShortId": t.EmberNodeId,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "targetShort": t.EmberNodeId,
+            "targetLong": t.EUI64,
+            "parentShortId": t.EmberNodeId,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setMacPollCcaWaitTime": (
         0xF4,
-        tuple(
-            {
-                "waitBeforeRetryIntervalMs": t.uint8_t,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "waitBeforeRetryIntervalMs": t.uint8_t,
+        },
+        {},
     ),
     "setBeaconClassificationParams": (
         0xEF,
-        tuple(
-            {
-                "param": t.EmberBeaconClassificationParams,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "param": t.EmberBeaconClassificationParams,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getBeaconClassificationParams": (
         0xF3,
-        tuple({}.values()),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "param": t.EmberBeaconClassificationParams,
-            }.values()
-        ),
+        {},
+        {
+            "status": t.EmberStatus,
+            "param": t.EmberBeaconClassificationParams,
+        },
     ),
     "updateTcLinkKey": (
         0x6C,
-        tuple(
-            {
-                "maxAttempts": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "maxAttempts": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "getTransientKeyTableEntry": (
         0x6D,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "keyStruct": t.EmberTransientKeyDataV5,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "keyStruct": t.EmberTransientKeyDataV5,
+        },
     ),
     "zllClearTokens": (
         0x25,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
     "setParentClassificationEnabled": (
         0xE7,
-        tuple(
-            {
-                "enabled": t.Bool,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "enabled": t.Bool,
+        },
+        {},
     ),
     "getParentClassificationEnabled": (
         0xF0,
-        tuple({}.values()),
-        tuple(
-            {
-                "enabled": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "enabled": t.Bool,
+        },
     ),
     "setLongUpTime": (
         0xE3,
-        tuple(
-            {
-                "hasLongUpTime": t.Bool,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "hasLongUpTime": t.Bool,
+        },
+        {},
     ),
     "setHubConnectivity": (
         0xE4,
-        tuple(
-            {
-                "connected": t.Bool,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "connected": t.Bool,
+        },
+        {},
     ),
     "isUpTimeLong": (
         0xE5,
-        tuple({}.values()),
-        tuple(
-            {
-                "hasLongUpTime": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "hasLongUpTime": t.Bool,
+        },
     ),
     "isHubConnected": (
         0xE6,
-        tuple({}.values()),
-        tuple(
-            {
-                "connected": t.Bool,
-            }.values()
-        ),
+        {},
+        {
+            "connected": t.Bool,
+        },
     ),
     "gpSinkTableClearAll": (
         0xE2,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
     "gpSinkTableInit": (
         0x70,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
     # Changed commands
     "getChildData": (
         0x4A,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "childData": t.EmberChildDataV7,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "childData": t.EmberChildDataV7,
+        },
     ),
 }
 

--- a/bellows/ezsp/v7/commands.py
+++ b/bellows/ezsp/v7/commands.py
@@ -5,119 +5,233 @@ COMMANDS = {
     **COMMANDS_v6,
     "sendPanIdUpdate": (
         0x57,
-        (t.EmberPanId,),
-        (t.Bool,),
+        tuple(
+            {
+                "newPan": t.EmberPanId,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getTrueRandomEntropySource": (
         0x4F,
-        (),
-        (t.EmberEntropySource,),
+        tuple({}.values()),
+        tuple(
+            {
+                "entropySource": t.EmberEntropySource,
+            }.values()
+        ),
     ),
     "joinNetworkDirectly": (
         0x3B,
-        (t.EmberNodeType, t.EmberBeaconData, t.int8s, t.Bool),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "localNodeType": t.EmberNodeType,
+                "beacon": t.EmberBeaconData,
+                "radioTxPower": t.int8s,
+                "clearBeaconsAfterNetworkUp": t.Bool,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getFirstBeacon": (
         0x3D,
-        (),
-        (t.EmberStatus, t.EmberBeaconIterator),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "beaconIterator": t.EmberBeaconIterator,
+            }.values()
+        ),
     ),
     "getNextBeacon": (
         0x04,
-        (),
-        (t.EmberStatus, t.EmberBeaconData),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "beaconData": t.EmberBeaconData,
+            }.values()
+        ),
     ),
     "getNumStoredBeacons": (
         0x08,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "numStoredBeacons": t.uint8_t,
+            }.values()
+        ),
     ),
     "clearStoredBeacons": (
         0x3C,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
     "unicastCurrentNetworkKey": (
         0x50,
-        (t.EmberNodeId, t.EUI64, t.EmberNodeId),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "targetShort": t.EmberNodeId,
+                "targetLong": t.EUI64,
+                "parentShortId": t.EmberNodeId,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "setMacPollCcaWaitTime": (
         0xF4,
-        (t.uint8_t,),
-        (),
+        tuple(
+            {
+                "waitBeforeRetryIntervalMs": t.uint8_t,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setBeaconClassificationParams": (
         0xEF,
-        (),
-        (t.EmberStatus, t.EmberBeaconClassificationParams),
+        tuple(
+            {
+                "param": t.EmberBeaconClassificationParams,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getBeaconClassificationParams": (
         0xF3,
-        (),
-        (t.EmberStatus, t.EmberBeaconClassificationParams),
+        tuple({}.values()),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "param": t.EmberBeaconClassificationParams,
+            }.values()
+        ),
     ),
     "updateTcLinkKey": (
         0x6C,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "maxAttempts": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "getTransientKeyTableEntry": (
         0x6D,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberTransientKeyDataV5),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "keyStruct": t.EmberTransientKeyDataV5,
+            }.values()
+        ),
     ),
     "zllClearTokens": (
         0x25,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
     "setParentClassificationEnabled": (
         0xE7,
-        (t.Bool,),
-        (),
+        tuple(
+            {
+                "enabled": t.Bool,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "getParentClassificationEnabled": (
         0xF0,
-        (),
-        (t.Bool,),
+        tuple({}.values()),
+        tuple(
+            {
+                "enabled": t.Bool,
+            }.values()
+        ),
     ),
     "setLongUpTime": (
         0xE3,
-        (t.Bool,),
-        (),
+        tuple(
+            {
+                "hasLongUpTime": t.Bool,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setHubConnectivity": (
         0xE4,
-        (t.Bool,),
-        (),
+        tuple(
+            {
+                "connected": t.Bool,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "isUpTimeLong": (
         0xE5,
-        (),
-        (t.Bool,),
+        tuple({}.values()),
+        tuple(
+            {
+                "hasLongUpTime": t.Bool,
+            }.values()
+        ),
     ),
     "isHubConnected": (
         0xE6,
-        (),
-        (t.Bool,),
+        tuple({}.values()),
+        tuple(
+            {
+                "connected": t.Bool,
+            }.values()
+        ),
     ),
     "gpSinkTableClearAll": (
         0xE2,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
     "gpSinkTableInit": (
         0x70,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
     # Changed commands
     "getChildData": (
         0x4A,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberChildDataV7),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "childData": t.EmberChildDataV7,
+            }.values()
+        ),
     ),
 }
 

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -41,12 +41,14 @@ class EZSPv8(EZSPv7):
         """Temporarily change TC policy while allowing new joins."""
         await super().pre_permit(time_s)
         await self.setPolicy(
-            t.EzspPolicyId.TRUST_CENTER_POLICY,
-            t.EzspDecisionBitmask.ALLOW_JOINS
-            | t.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS,
+            valueId=t.EzspPolicyId.TRUST_CENTER_POLICY,
+            value=(
+                t.EzspDecisionBitmask.ALLOW_JOINS
+                | t.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS
+            ),
         )
         await asyncio.sleep(time_s + 2)
         await self.setPolicy(
-            t.EzspPolicyId.TRUST_CENTER_POLICY,
-            self.tc_policy,
+            valueId=t.EzspPolicyId.TRUST_CENTER_POLICY,
+            value=self.tc_policy,
         )

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -5,46 +5,107 @@ COMMANDS = {
     **COMMANDS_v7,
     "getNeighborFrameCounter": (
         0x003E,
-        (t.EUI64,),
-        (t.EmberStatus, t.uint32_t),
+        tuple(
+            {
+                "eui64": t.EUI64,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "frameCounter": t.uint32_t,
+            }.values()
+        ),
     ),
     "incomingNetworkStatusHandler": (
         0x00C4,
-        (),
+        tuple({}.values()),
         tuple(
-            {"errorCode": t.EmberStackError, "target": t.EmberNodeId}.values(),
+            {
+                "errorCode": t.EmberStackError,
+                "target": t.EmberNodeId,
+            }.values()
         ),
     ),
     "sendRawMessageExtended": (
         0x0051,
-        (t.LVBytes, t.uint8_t, t.Bool),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "message": t.LVBytes,
+                "priority": t.uint8_t,
+                "useCca": t.Bool,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "setMacPollFailureWaitTime": (
         0x00F4,
-        (t.uint8_t,),
-        (),
+        tuple(
+            {
+                "waitBeforeRetryIntervalMs": t.uint32_t,
+            }.values()
+        ),
+        tuple({}.values()),
     ),
     "setSourceRouteDiscoveryMode": (
         0x005A,
-        (t.uint8_t,),
-        (t.uint32_t,),
+        tuple(
+            {
+                "mode": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "remainingTime": t.uint32_t,
+            }.values()
+        ),
     ),
     # Changed
     "getTransientKeyTableEntry": (
         0x006D,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberTransientKeyDataV8),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "transient_key_data": t.EmberTransientKeyDataV8,
+            }.values()
+        ),
     ),
     "getTransientLinkKey": (
         0x00CE,
-        (t.EUI64,),
-        (t.EmberStatus, t.EmberTransientKeyDataV8),
+        tuple(
+            {
+                "eui64": t.EUI64,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "transient_key_data": t.EmberTransientKeyDataV8,
+            }.values()
+        ),
     ),
     "setSourceRoute": (
         0x00AE,
-        (t.EmberNodeId, t.LVList[t.EmberNodeId]),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "destination": t.EmberNodeId,
+                "relays": t.LVList[t.EmberNodeId],
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
 }
 

--- a/bellows/ezsp/v8/commands.py
+++ b/bellows/ezsp/v8/commands.py
@@ -5,107 +5,79 @@ COMMANDS = {
     **COMMANDS_v7,
     "getNeighborFrameCounter": (
         0x003E,
-        tuple(
-            {
-                "eui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "frameCounter": t.uint32_t,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+            "frameCounter": t.uint32_t,
+        },
     ),
     "incomingNetworkStatusHandler": (
         0x00C4,
-        tuple({}.values()),
-        tuple(
-            {
-                "errorCode": t.EmberStackError,
-                "target": t.EmberNodeId,
-            }.values()
-        ),
+        {},
+        {
+            "errorCode": t.EmberStackError,
+            "target": t.EmberNodeId,
+        },
     ),
     "sendRawMessageExtended": (
         0x0051,
-        tuple(
-            {
-                "message": t.LVBytes,
-                "priority": t.uint8_t,
-                "useCca": t.Bool,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "message": t.LVBytes,
+            "priority": t.uint8_t,
+            "useCca": t.Bool,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setMacPollFailureWaitTime": (
         0x00F4,
-        tuple(
-            {
-                "waitBeforeRetryIntervalMs": t.uint32_t,
-            }.values()
-        ),
-        tuple({}.values()),
+        {
+            "waitBeforeRetryIntervalMs": t.uint32_t,
+        },
+        {},
     ),
     "setSourceRouteDiscoveryMode": (
         0x005A,
-        tuple(
-            {
-                "mode": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "remainingTime": t.uint32_t,
-            }.values()
-        ),
+        {
+            "mode": t.uint8_t,
+        },
+        {
+            "remainingTime": t.uint32_t,
+        },
     ),
     # Changed
     "getTransientKeyTableEntry": (
         0x006D,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "transient_key_data": t.EmberTransientKeyDataV8,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "transient_key_data": t.EmberTransientKeyDataV8,
+        },
     ),
     "getTransientLinkKey": (
         0x00CE,
-        tuple(
-            {
-                "eui64": t.EUI64,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "transient_key_data": t.EmberTransientKeyDataV8,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+        },
+        {
+            "status": t.EmberStatus,
+            "transient_key_data": t.EmberTransientKeyDataV8,
+        },
     ),
     "setSourceRoute": (
         0x00AE,
-        tuple(
-            {
-                "destination": t.EmberNodeId,
-                "relays": t.LVList[t.EmberNodeId],
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "destination": t.EmberNodeId,
+            "relays": t.LVList[t.EmberNodeId],
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
 }
 

--- a/bellows/ezsp/v9/__init__.py
+++ b/bellows/ezsp/v9/__init__.py
@@ -27,8 +27,8 @@ class EZSPv9(EZSPv8):
     async def write_child_data(self, children: dict[t.EUI64, t.NWK]) -> None:
         for index, (eui64, nwk) in enumerate(children.items()):
             await self.setChildData(
-                index,
-                t.EmberChildDataV7(
+                index=index,
+                child_data=t.EmberChildDataV7(
                     eui64=eui64,
                     type=t.EmberNodeType.SLEEPY_END_DEVICE,
                     id=nwk,

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -15,44 +15,98 @@ COMMANDS = {
     **COMMANDS_v8,
     "setChildData": (
         0x00AC,
-        (t.uint8_t, t.EmberChildDataV7),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "index": t.uint8_t,
+                "child_data": t.EmberChildDataV7,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "setNeighborFrameCounter": (
         0x00AD,
-        (t.EUI64,),
-        (t.EmberStatus, t.uint32_t),
+        tuple(
+            {
+                "eui64": t.EUI64,
+                "frame_counter": t.uint32_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "setRadioIeee802154CcaMode": (
         0x0095,
-        (t.uint8_t,),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "cca_mode": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     # 18 Token Interface Frames
     "getTokenCount": (
         0x0100,
-        (),
-        (t.uint8_t,),
+        tuple({}.values()),
+        tuple(
+            {
+                "count": t.uint8_t,
+            }.values()
+        ),
     ),
     "getTokenInfo": (
         0x0101,
-        (t.uint8_t,),
-        (t.EmberStatus, t.EmberTokenInfo),
+        tuple(
+            {
+                "index": t.uint8_t,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+                "token_info": t.EmberTokenInfo,
+            }.values()
+        ),
     ),
     "getTokenData": (
         0x0102,
-        (t.uint32_t, t.uint32_t),
+        tuple(
+            {
+                "token": t.uint32_t,
+                "index": t.uint32_t,
+            }.values()
+        ),
         GetTokenDataRsp,
     ),
     "setTokenData": (
         0x0103,
-        (t.uint32_t, t.uint32_t, t.LVBytes32),
-        (t.EmberStatus,),
+        tuple(
+            {
+                "token": t.uint32_t,
+                "index": t.uint32_t,
+                "token_data": t.LVBytes32,
+            }.values()
+        ),
+        tuple(
+            {
+                "status": t.EmberStatus,
+            }.values()
+        ),
     ),
     "resetNode": (
         0x0104,
-        (),
-        (),
+        tuple({}.values()),
+        tuple({}.values()),
     ),
 }
 

--- a/bellows/ezsp/v9/commands.py
+++ b/bellows/ezsp/v9/commands.py
@@ -15,98 +15,74 @@ COMMANDS = {
     **COMMANDS_v8,
     "setChildData": (
         0x00AC,
-        tuple(
-            {
-                "index": t.uint8_t,
-                "child_data": t.EmberChildDataV7,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+            "child_data": t.EmberChildDataV7,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setNeighborFrameCounter": (
         0x00AD,
-        tuple(
-            {
-                "eui64": t.EUI64,
-                "frame_counter": t.uint32_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "eui64": t.EUI64,
+            "frame_counter": t.uint32_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "setRadioIeee802154CcaMode": (
         0x0095,
-        tuple(
-            {
-                "cca_mode": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "cca_mode": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     # 18 Token Interface Frames
     "getTokenCount": (
         0x0100,
-        tuple({}.values()),
-        tuple(
-            {
-                "count": t.uint8_t,
-            }.values()
-        ),
+        {},
+        {
+            "count": t.uint8_t,
+        },
     ),
     "getTokenInfo": (
         0x0101,
-        tuple(
-            {
-                "index": t.uint8_t,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-                "token_info": t.EmberTokenInfo,
-            }.values()
-        ),
+        {
+            "index": t.uint8_t,
+        },
+        {
+            "status": t.EmberStatus,
+            "token_info": t.EmberTokenInfo,
+        },
     ),
     "getTokenData": (
         0x0102,
-        tuple(
-            {
-                "token": t.uint32_t,
-                "index": t.uint32_t,
-            }.values()
-        ),
+        {
+            "token": t.uint32_t,
+            "index": t.uint32_t,
+        },
         GetTokenDataRsp,
     ),
     "setTokenData": (
         0x0103,
-        tuple(
-            {
-                "token": t.uint32_t,
-                "index": t.uint32_t,
-                "token_data": t.LVBytes32,
-            }.values()
-        ),
-        tuple(
-            {
-                "status": t.EmberStatus,
-            }.values()
-        ),
+        {
+            "token": t.uint32_t,
+            "index": t.uint32_t,
+            "token_data": t.LVBytes32,
+        },
+        {
+            "status": t.EmberStatus,
+        },
     ),
     "resetNode": (
         0x0104,
-        tuple({}.values()),
-        tuple({}.values()),
+        {},
+        {},
     ),
 }
 

--- a/bellows/types/__init__.py
+++ b/bellows/types/__init__.py
@@ -3,18 +3,6 @@ from .named import *  # noqa: F401,F403
 from .struct import *  # noqa: F401,F403
 
 
-def deserialize(data, schema):
-    result = []
-    for type_ in schema:
-        value, data = type_.deserialize(data)
-        result.append(value)
-    return result, data
-
-
-def serialize(data, schema):
-    return b"".join(t(v).serialize() for t, v in zip(schema, data))
-
-
 def deserialize_dict(data, schema):
     result = {}
     for key, type_ in schema.items():
@@ -23,5 +11,10 @@ def deserialize_dict(data, schema):
     return result, data
 
 
-def serialize_dict(data, schema):
-    return b"".join(t(v).serialize() for v, (n, t) in zip(data, schema.items()))
+def serialize_dict(args, kwargs, schema):
+    params = {
+        **dict(zip(schema.keys(), args)),
+        **kwargs,
+    }
+
+    return b"".join(t(params[k]).serialize() for k, t in schema.items())

--- a/bellows/types/__init__.py
+++ b/bellows/types/__init__.py
@@ -13,3 +13,15 @@ def deserialize(data, schema):
 
 def serialize(data, schema):
     return b"".join(t(v).serialize() for t, v in zip(schema, data))
+
+
+def deserialize_dict(data, schema):
+    result = {}
+    for key, type_ in schema.items():
+        value, data = type_.deserialize(data)
+        result[key] = value
+    return result, data
+
+
+def serialize_dict(data, schema):
+    return b"".join(t(v).serialize() for v, (n, t) in zip(data, schema.items()))

--- a/bellows/types/struct.py
+++ b/bellows/types/struct.py
@@ -703,6 +703,6 @@ class SecurityManagerNetworkKeyInfo(EzspStruct):
 class EmberMultiPhyRadioParameters(EzspStruct):
     """Holds radio parameters."""
 
-    radioTxPower: named.int8s
-    radioPage: named.uint8_t
-    radioChannel: named.uint8_t
+    radioTxPower: basic.int8s
+    radioPage: basic.uint8_t
+    radioChannel: basic.uint8_t

--- a/bellows/types/struct.py
+++ b/bellows/types/struct.py
@@ -698,3 +698,11 @@ class SecurityManagerNetworkKeyInfo(EzspStruct):
     network_key_sequence_number: basic.uint8_t
     alt_network_key_sequence_number: basic.uint8_t
     network_key_frame_counter: basic.uint32_t
+
+
+class EmberMultiPhyRadioParameters(EzspStruct):
+    """Holds radio parameters."""
+
+    radioTxPower: named.int8s
+    radioPage: named.uint8_t
+    radioChannel: named.uint8_t

--- a/bellows/zigbee/repairs.py
+++ b/bellows/zigbee/repairs.py
@@ -29,7 +29,9 @@ async def fix_invalid_tclk_partner_ieee(ezsp: EZSP) -> bool:
     )
 
     try:
-        rsp = await ezsp.getTokenData(t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER, 0)
+        rsp = await ezsp.getTokenData(
+            token=t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER, index=0
+        )
         assert t.sl_Status.from_ember_status(rsp.status) == t.sl_Status.OK
     except (InvalidCommandError, AttributeError, AssertionError):
         LOGGER.warning("NV3 interface not available in this firmware, please upgrade!")
@@ -40,9 +42,9 @@ async def fix_invalid_tclk_partner_ieee(ezsp: EZSP) -> bool:
     assert token.eui64 == state.trustCenterLongAddress
 
     (status,) = await ezsp.setTokenData(
-        t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
-        0,
-        token.replace(eui64=ieee).serialize(),
+        token=t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
+        index=0,
+        token_data=token.replace(eui64=ieee).serialize(),
     )
     assert t.sl_Status.from_ember_status(status) == t.sl_Status.OK
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1473,7 +1473,7 @@ async def test_handle_no_such_device(app, ieee):
     p2 = patch.object(app, "handle_join")
     with p1 as lookup_mock, p2 as handle_join_mock:
         await app._handle_no_such_device(sentinel.nwk)
-        assert lookup_mock.mock_calls == [call(nodeId=sentinel.nwk, linkKey=True)]
+        assert lookup_mock.mock_calls == [call(nodeId=sentinel.nwk)]
         assert handle_join_mock.call_count == 0
 
     p1 = patch.object(
@@ -1483,7 +1483,7 @@ async def test_handle_no_such_device(app, ieee):
     )
     with p1 as lookup_mock, p2 as handle_join_mock:
         await app._handle_no_such_device(sentinel.nwk)
-        assert lookup_mock.mock_calls == [call(address=sentinel.ieee, linkKey=True)]
+        assert lookup_mock.mock_calls == [call(nodeId=sentinel.nwk)]
         assert handle_join_mock.call_count == 1
         assert handle_join_mock.call_args[0][0] == sentinel.nwk
         assert handle_join_mock.call_args[0][1] == sentinel.ieee

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -42,8 +42,8 @@ def test_ids(commands):
 def test_parms(commands):
     """Test that parameter descriptions seem valid"""
     for command, params in commands.items():
-        assert isinstance(params[1], tuple), command
-        assert isinstance(params[2], tuple), command
+        assert isinstance(params[1], (tuple, dict)), command
+        assert isinstance(params[2], (tuple, dict)), command
 
 
 def test_handlers(commands):

--- a/tests/test_ezsp_v10.py
+++ b/tests/test_ezsp_v10.py
@@ -52,8 +52,8 @@ async def test_write_child_data(ezsp_f) -> None:
 
     assert ezsp_f.setChildData.mock_calls == [
         call(
-            0,
-            t.EmberChildDataV10(
+            index=0,
+            child_data=t.EmberChildDataV10(
                 eui64=t.EUI64.convert("00:0b:57:ff:fe:2b:d4:57"),
                 type=t.EmberNodeType.SLEEPY_END_DEVICE,
                 id=0xC06B,
@@ -64,8 +64,8 @@ async def test_write_child_data(ezsp_f) -> None:
             ),
         ),
         call(
-            1,
-            t.EmberChildDataV10(
+            index=1,
+            child_data=t.EmberChildDataV10(
                 eui64=t.EUI64.convert("00:18:4b:00:1c:a1:b8:46"),
                 type=t.EmberNodeType.SLEEPY_END_DEVICE,
                 id=0x1234,

--- a/tests/test_ezsp_v13.py
+++ b/tests/test_ezsp_v13.py
@@ -114,7 +114,7 @@ async def test_read_link_keys(ezsp_f):
 
 
 async def test_get_network_key_and_tc_link_key(ezsp_f):
-    def export_key(security_context):
+    def export_key(context):
         key = {
             t.SecurityManagerKeyType.NETWORK: t.KeyData.convert(
                 "2ccade06b3090c310315b3d574d3c85a"
@@ -122,7 +122,7 @@ async def test_get_network_key_and_tc_link_key(ezsp_f):
             t.SecurityManagerKeyType.TC_LINK: t.KeyData.convert(
                 "abcdabcdabcdabcdabcdabcdabcdabcd"
             ),
-        }[security_context.core_key_type]
+        }[context.core_key_type]
 
         return (key, t.EmberStatus.SUCCESS)
 
@@ -209,14 +209,14 @@ async def test_write_link_keys(ezsp_f):
 
     assert ezsp_f.importLinkKey.mock_calls == [
         call(
-            0,
-            t.EUI64.convert("CC:CC:CC:FF:FE:E6:8E:CA"),
-            t.KeyData.convert("85:7C:05:00:3E:76:1A:F9:68:9A:49:41:6A:60:5C:76"),
+            index=0,
+            address=t.EUI64.convert("CC:CC:CC:FF:FE:E6:8E:CA"),
+            key=t.KeyData.convert("85:7C:05:00:3E:76:1A:F9:68:9A:49:41:6A:60:5C:76"),
         ),
         call(
-            1,
-            t.EUI64.convert("EC:1B:BD:FF:FE:2F:41:A4"),
-            t.KeyData.convert("CA:02:E8:BB:75:7C:94:F8:93:39:D3:9C:B3:CD:A7:BE"),
+            index=1,
+            address=t.EUI64.convert("EC:1B:BD:FF:FE:2F:41:A4"),
+            key=t.KeyData.convert("CA:02:E8:BB:75:7C:94:F8:93:39:D3:9C:B3:CD:A7:BE"),
         ),
     ]
 
@@ -227,4 +227,6 @@ async def test_factory_reset(ezsp_f) -> None:
     await ezsp_f.factory_reset()
 
     assert ezsp_f.clearKeyTable.mock_calls == [call()]
-    assert ezsp_f.tokenFactoryReset.mock_calls == [call(False, False)]
+    assert ezsp_f.tokenFactoryReset.mock_calls == [
+        call(excludeOutgoingFC=False, excludeBootCounter=False)
+    ]

--- a/tests/test_ezsp_v14.py
+++ b/tests/test_ezsp_v14.py
@@ -65,8 +65,8 @@ async def test_read_address_table(ezsp_f):
 
 
 async def test_get_network_key_and_tc_link_key(ezsp_f):
-    def export_key(security_context):
-        if security_context.core_key_type == t.SecurityManagerKeyType.NETWORK:
+    def export_key(context):
+        if context.core_key_type == t.SecurityManagerKeyType.NETWORK:
             return (
                 t.sl_Status.OK,
                 t.KeyData.convert("2ccade06b3090c310315b3d574d3c85a"),
@@ -80,7 +80,7 @@ async def test_get_network_key_and_tc_link_key(ezsp_f):
                     psa_key_alg_permission=0,
                 ),
             )
-        elif security_context.core_key_type == t.SecurityManagerKeyType.TC_LINK:
+        elif context.core_key_type == t.SecurityManagerKeyType.TC_LINK:
             return (
                 t.sl_Status.OK,
                 t.KeyData.convert("abcdabcdabcdabcdabcdabcdabcdabcd"),
@@ -171,12 +171,12 @@ async def test_send_broadcast(ezsp_f) -> None:
     assert message_tag == 0x42
     assert ezsp_f.sendBroadcast.mock_calls == [
         call(
-            0x0000,
-            t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
-            34,
-            t.EmberApsFrame(),
-            12,
-            0x42,
-            b"hello",
+            alias=0x0000,
+            destination=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+            sequence=34,
+            aps_frame=t.EmberApsFrame(),
+            radius=12,
+            message_tag=0x42,
+            message=b"hello",
         )
     ]

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -138,7 +138,7 @@ async def test_read_link_keys(ezsp_f):
 
 
 async def test_get_network_key_and_tc_link_key(ezsp_f):
-    def get_key(key_type):
+    def get_key(keyType):
         key = {
             t.EmberKeyType.CURRENT_NETWORK_KEY: t.EmberKeyStruct(
                 bitmask=(
@@ -165,7 +165,7 @@ async def test_get_network_key_and_tc_link_key(ezsp_f):
                 sequenceNumber=0,
                 partnerEUI64=t.EUI64.convert("00:12:4b:00:1c:a1:b8:46"),
             ),
-        }[key_type]
+        }[keyType]
 
         return (t.EmberStatus.SUCCESS, key)
 
@@ -228,14 +228,14 @@ async def test_write_link_keys(ezsp_f, caplog) -> None:
 
     assert ezsp_f.addOrUpdateKeyTableEntry.mock_calls == [
         call(
-            t.EUI64.convert("11:11:11:11:11:11:11:11"),
-            True,
-            t.KeyData.convert("2ccade06b3090c310315b3d574d3c85a"),
+            address=t.EUI64.convert("11:11:11:11:11:11:11:11"),
+            linkKey=True,
+            keyData=t.KeyData.convert("2ccade06b3090c310315b3d574d3c85a"),
         ),
         call(
-            t.EUI64.convert("22:22:22:22:22:22:22:22"),
-            True,
-            t.KeyData.convert("abcdabcdabcdabcdabcdabcdabcdabcd"),
+            address=t.EUI64.convert("22:22:22:22:22:22:22:22"),
+            linkKey=True,
+            keyData=t.KeyData.convert("abcdabcdabcdabcdabcdabcdabcdabcd"),
         ),
     ]
 
@@ -248,7 +248,9 @@ async def test_write_link_keys(ezsp_f, caplog) -> None:
 async def test_initialize_network(ezsp_f) -> None:
     ezsp_f.networkInitExtended = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
     assert await ezsp_f.initialize_network() == t.sl_Status.OK
-    assert ezsp_f.networkInitExtended.mock_calls == [call(0x0000)]
+    assert ezsp_f.networkInitExtended.mock_calls == [
+        call(networkInitStruct=t.EmberNetworkInitBitmask.NETWORK_INIT_NO_OPTIONS)
+    ]
 
 
 async def test_write_nwk_frame_counter(ezsp_f) -> None:
@@ -281,11 +283,11 @@ async def test_send_unicast(ezsp_f) -> None:
     assert message_tag == 0x42
     assert ezsp_f.sendUnicast.mock_calls == [
         call(
-            t.EmberOutgoingMessageType.OUTGOING_DIRECT,
-            t.EmberNodeId(0x1234),
-            t.EmberApsFrame(),
-            0x42,
-            b"hello",
+            type=t.EmberOutgoingMessageType.OUTGOING_DIRECT,
+            indexOrDestination=t.EmberNodeId(0x1234),
+            apsFrame=t.EmberApsFrame(),
+            messageTag=0x42,
+            messageContents=b"hello",
         )
     ]
 
@@ -304,11 +306,11 @@ async def test_send_multicast(ezsp_f) -> None:
     assert message_tag == 0x42
     assert ezsp_f.sendMulticast.mock_calls == [
         call(
-            t.EmberApsFrame(),
-            12,
-            34,
-            0x42,
-            b"hello",
+            apsFrame=t.EmberApsFrame(),
+            hops=12,
+            nonmemberRadius=34,
+            messageTag=0x42,
+            messageContents=b"hello",
         )
     ]
 
@@ -328,10 +330,10 @@ async def test_send_broadcast(ezsp_f) -> None:
     assert message_tag == 0x42
     assert ezsp_f.sendBroadcast.mock_calls == [
         call(
-            t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
-            t.EmberApsFrame(),
-            12,
-            0x42,
-            b"hello",
+            destination=t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+            apsFrame=t.EmberApsFrame(),
+            radius=12,
+            messageTag=0x42,
+            messageContents=b"hello",
         )
     ]

--- a/tests/test_ezsp_v5.py
+++ b/tests/test_ezsp_v5.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 import zigpy.state
@@ -29,38 +29,39 @@ def test_ezsp_frame_rx(ezsp_f):
 
 async def test_pre_permit(ezsp_f):
     """Test pre permit."""
-    p2 = patch.object(
-        ezsp_f,
-        "addTransientLinkKey",
-        new=AsyncMock(return_value=[t.EmberStatus.SUCCESS]),
-    )
-    with p2 as tclk_mock:
-        await ezsp_f.pre_permit(1)
-    assert tclk_mock.await_count == 1
+    ezsp_f.addTransientLinkKey = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
+    await ezsp_f.pre_permit(1)
+
+    assert ezsp_f.addTransientLinkKey.mock_calls == [
+        call(
+            partner=t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
+            transientKey=t.KeyData(b"ZigBeeAlliance09"),
+        )
+    ]
 
 
 async def test_read_address_table(ezsp_f):
-    def get_addr_table_node_id(index):
+    def get_addr_table_node_id(addressTableIndex):
         return (
             {
                 16: t.EmberNodeId(0x44CB),
                 17: t.EmberNodeId(0x0702),
                 18: t.EmberNodeId(0x0000),  # bogus entry
-            }.get(index, t.EmberNodeId(0xFFFF)),
+            }.get(addressTableIndex, t.EmberNodeId(0xFFFF)),
         )
 
     ezsp_f.getAddressTableRemoteNodeId = AsyncMock(side_effect=get_addr_table_node_id)
 
-    def get_addr_table_eui64(index):
-        if index < 16:
+    def get_addr_table_eui64(addressTableIndex):
+        if addressTableIndex < 16:
             return (t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),)
-        elif 16 <= index <= 18:
+        elif 16 <= addressTableIndex <= 18:
             return (
                 {
                     16: t.EUI64.convert("cc:cc:cc:ff:fe:e6:8e:ca"),
                     17: t.EUI64.convert("ec:1b:bd:ff:fe:2f:41:a4"),
                     18: t.EUI64.convert("00:00:00:00:00:00:00:00"),
-                }[index],
+                }[addressTableIndex],
             )
         else:
             return (t.EUI64.convert("00:00:00:00:00:00:00:00"),)
@@ -82,8 +83,8 @@ async def test_write_nwk_frame_counter(ezsp_f) -> None:
 
     assert ezsp_f.setValue.mock_calls == [
         call(
-            t.EzspValueId.VALUE_NWK_FRAME_COUNTER,
-            t.uint32_t(12345678).serialize(),
+            valueId=t.EzspValueId.VALUE_NWK_FRAME_COUNTER,
+            value=t.uint32_t(12345678).serialize(),
         ),
     ]
 
@@ -95,7 +96,7 @@ async def test_write_aps_frame_counter(ezsp_f) -> None:
 
     assert ezsp_f.setValue.mock_calls == [
         call(
-            t.EzspValueId.VALUE_APS_FRAME_COUNTER,
-            t.uint32_t(12345678).serialize(),
+            valueId=t.EzspValueId.VALUE_APS_FRAME_COUNTER,
+            value=t.uint32_t(12345678).serialize(),
         ),
     ]

--- a/tests/test_ezsp_v6.py
+++ b/tests/test_ezsp_v6.py
@@ -31,5 +31,5 @@ async def test_initialize_network(ezsp_f) -> None:
     ezsp_f.networkInit = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
     assert await ezsp_f.initialize_network() == t.sl_Status.OK
     assert ezsp_f.networkInit.mock_calls == [
-        call(networkInitBitmask=t.NETWORK_INIT_NO_OPTIONS)
+        call(networkInitBitmask=t.EmberNetworkInitBitmask.NETWORK_INIT_NO_OPTIONS)
     ]

--- a/tests/test_ezsp_v6.py
+++ b/tests/test_ezsp_v6.py
@@ -30,4 +30,6 @@ def test_ezsp_frame_rx(ezsp_f):
 async def test_initialize_network(ezsp_f) -> None:
     ezsp_f.networkInit = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
     assert await ezsp_f.initialize_network() == t.sl_Status.OK
-    assert ezsp_f.networkInit.mock_calls == [call(0x0000)]
+    assert ezsp_f.networkInit.mock_calls == [
+        call(networkInitBitmask=t.NETWORK_INIT_NO_OPTIONS)
+    ]

--- a/tests/test_ezsp_v9.py
+++ b/tests/test_ezsp_v9.py
@@ -52,8 +52,8 @@ async def test_write_child_data(ezsp_f) -> None:
 
     assert ezsp_f.setChildData.mock_calls == [
         call(
-            0,
-            t.EmberChildDataV7(
+            index=0,
+            child_data=t.EmberChildDataV7(
                 eui64=t.EUI64.convert("00:0b:57:ff:fe:2b:d4:57"),
                 type=t.EmberNodeType.SLEEPY_END_DEVICE,
                 id=0xC06B,
@@ -63,8 +63,8 @@ async def test_write_child_data(ezsp_f) -> None:
             ),
         ),
         call(
-            1,
-            t.EmberChildDataV7(
+            index=1,
+            child_data=t.EmberChildDataV7(
                 eui64=t.EUI64.convert("00:18:4b:00:1c:a1:b8:46"),
                 type=t.EmberNodeType.SLEEPY_END_DEVICE,
                 id=0x1234,

--- a/tests/test_zigbee_repairs.py
+++ b/tests/test_zigbee_repairs.py
@@ -96,9 +96,9 @@ async def test_fix_invalid_tclk(ezsp_tclk_f: EZSP, caplog) -> None:
 
     assert ezsp_tclk_f.setTokenData.mock_calls == [
         call(
-            t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
-            0,
-            t.NV3StackTrustCenterToken(
+            token=t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
+            index=0,
+            token_data=t.NV3StackTrustCenterToken(
                 mode=228,
                 eui64=t.EUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA"),
                 key=t.KeyData.convert(
@@ -160,9 +160,9 @@ async def test_fix_invalid_tclk_all_versions(
 
         assert ezsp.setTokenData.mock_calls == [
             call(
-                t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
-                0,
-                t.NV3StackTrustCenterToken(
+                token=t.NV3KeyId.NVM3KEY_STACK_TRUST_CENTER,
+                index=0,
+                token_data=t.NV3StackTrustCenterToken(
                     mode=228,
                     eui64=t.EUI64.convert("AA:AA:AA:AA:AA:AA:AA:AA"),
                     key=t.KeyData.convert(


### PR DESCRIPTION
I've converted the types of every command schema for EZSP v5-v14 from a tuple of types to a dict of types. Only EZSPv4 is left. There is currently a compatibility shim to handle tuple schemas but it will be removed once v4 is finished.

This really helps with log file and code readability. ~~Future command sending syntax will allow mixing and matching args and kwargs but bellows will migrate to kwarg-only syntax.~~