### PR TITLE
Ensure version-specific unit tests cover command sending format

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -193,11 +193,11 @@ class EZSP:
     def _get_command_priority(self, name: str) -> int:
         return {
             # Deprioritize any commands that send packets
-            "setSourceRoute": -1,
+            "set_source_route": -1,
             "setExtendedTimeout": -1,
-            "sendUnicast": -1,
-            "sendMulticast": -1,
-            "sendBroadcast": -1,
+            "send_unicast": -1,
+            "send_multicast": -1,
+            "send_broadcast": -1,
             # Prioritize watchdog commands
             "nop": 999,
             "readCounters": 999,
@@ -206,6 +206,8 @@ class EZSP:
         }.get(name, 0)
 
     async def _command(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        command = getattr(self._protocol, name)
+
         if not self.is_ezsp_running:
             LOGGER.debug(
                 "Couldn't send command %s(%s, %s). EZSP is not running",
@@ -216,7 +218,7 @@ class EZSP:
             raise EzspError("EZSP is not running")
 
         async with self._send_sem(priority=self._get_command_priority(name)):
-            return await self._protocol.command(name, *args, **kwargs)
+            return await command(*args, **kwargs)
 
     async def _list_command(
         self, name, item_frames, completion_frame, spos, *args, **kwargs

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -156,10 +156,11 @@ class ProtocolHandler(abc.ABC):
     async def pre_permit(self, time_s: int) -> None:
         """Schedule task before allowing new joins."""
 
+    @abc.abstractmethod
     async def add_transient_link_key(
         self, ieee: t.EUI64, key: t.KeyData
     ) -> t.sl_Status:
-        """Add a transient link key."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def read_child_data(

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -39,6 +39,11 @@ class EZSPv4(protocol.ProtocolHandler):
     async def pre_permit(self, time_s: int) -> None:
         pass
 
+    async def add_transient_link_key(
+        self, ieee: t.EUI64, key: t.KeyData
+    ) -> t.sl_Status:
+        return t.sl_Status.OK
+
     async def read_child_data(
         self,
     ) -> AsyncGenerator[tuple[t.NWK, t.EUI64, t.EmberNodeType], None]:

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -42,7 +42,7 @@ class EZSPv8(EZSPv7):
         await super().pre_permit(time_s)
         await self.setPolicy(
             policyId=t.EzspPolicyId.TRUST_CENTER_POLICY,
-            value=(
+            decisionId=(
                 t.EzspDecisionBitmask.ALLOW_JOINS
                 | t.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS
             ),
@@ -50,5 +50,5 @@ class EZSPv8(EZSPv7):
         await asyncio.sleep(time_s + 2)
         await self.setPolicy(
             policyId=t.EzspPolicyId.TRUST_CENTER_POLICY,
-            value=self.tc_policy,
+            decisionId=self.tc_policy,
         )

--- a/bellows/ezsp/v8/__init__.py
+++ b/bellows/ezsp/v8/__init__.py
@@ -41,7 +41,7 @@ class EZSPv8(EZSPv7):
         """Temporarily change TC policy while allowing new joins."""
         await super().pre_permit(time_s)
         await self.setPolicy(
-            valueId=t.EzspPolicyId.TRUST_CENTER_POLICY,
+            policyId=t.EzspPolicyId.TRUST_CENTER_POLICY,
             value=(
                 t.EzspDecisionBitmask.ALLOW_JOINS
                 | t.EzspDecisionBitmask.ALLOW_UNSECURED_REJOINS
@@ -49,6 +49,6 @@ class EZSPv8(EZSPv7):
         )
         await asyncio.sleep(time_s + 2)
         await self.setPolicy(
-            valueId=t.EzspPolicyId.TRUST_CENTER_POLICY,
+            policyId=t.EzspPolicyId.TRUST_CENTER_POLICY,
             value=self.tc_policy,
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from bellows.ezsp.protocol import ProtocolHandler
+
+
+def mock_ezsp_commands(ezsp: ProtocolHandler) -> ProtocolHandler:
+    for command_name, (_command_id, tx_schema, _rx_schema) in ezsp.COMMANDS.items():
+        # TODO: make this end-to-end instead of relying on this serialization hack
+        async def fake_sender(*args, _command_name=command_name, _ezsp=ezsp, **kwargs):
+            # Trigger an exception early
+            _ezsp._ezsp_frame(_command_name, *args, **kwargs)
+
+        setattr(ezsp, command_name, AsyncMock(wraps=fake_sender))

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -842,6 +842,7 @@ async def test_send_packet_unicast_source_route(make_app, packet):
     )
 
 
+@patch("bellows.zigbee.application.RETRY_DELAYS", [0.01, 0.01, 0.01])
 async def test_send_packet_unicast_retries_success(app, packet):
     await _test_send_packet_unicast(
         app,
@@ -861,6 +862,7 @@ async def test_send_packet_unicast_unexpected_failure(app, packet):
         )
 
 
+@patch("bellows.zigbee.application.RETRY_DELAYS", [0.01, 0.01, 0.01])
 async def test_send_packet_unicast_retries_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await _test_send_packet_unicast(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -25,12 +25,15 @@ from bellows.zigbee.application import ControllerApplication
 import bellows.zigbee.device
 from bellows.zigbee.util import map_rssi_to_energy
 
+from tests.common import mock_ezsp_commands
+
 APP_CONFIG = {
     config.CONF_DEVICE: {
         zigpy.config.CONF_DEVICE_PATH: "/dev/null",
         zigpy.config.CONF_DEVICE_BAUDRATE: 115200,
     },
     zigpy.config.CONF_DATABASE: None,
+    zigpy.config.CONF_STARTUP_ENERGY_SCAN: False,
 }
 
 
@@ -40,53 +43,14 @@ def ieee(init=0):
 
 
 @pytest.fixture
-def ezsp_mock(ieee):
-    """EZSP fixture"""
-    mock_ezsp = MagicMock(spec=ezsp.EZSP)
-    mock_ezsp.ezsp_version = 7
-    mock_ezsp.setManufacturerCode = AsyncMock()
-    mock_ezsp.getEui64 = AsyncMock(return_value=[ieee])
-    mock_ezsp.getConfigurationValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS, 0])
-    mock_ezsp.getCurrentSecurityState = AsyncMock(
-        return_value=[
-            t.EmberStatus.SUCCESS,
-            t.EmberCurrentSecurityState(
-                bitmask=(
-                    t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
-                    | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
-                    | 224
-                ),
-                trustCenterLongAddress=ieee,
-            ),
-        ]
-    )
-    mock_ezsp.set_source_route = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    mock_ezsp.addTransientLinkKey = AsyncMock(return_value=[0])
-    mock_ezsp.readCounters = AsyncMock(return_value=[[0] * 10])
-    mock_ezsp.readAndClearCounters = AsyncMock(return_value=[[0] * 10])
-    mock_ezsp.setPolicy = AsyncMock(return_value=[0])
-    mock_ezsp.addEndpoint = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    mock_ezsp.get_board_info = AsyncMock(
-        return_value=("Mock Manufacturer", "Mock board", "Mock version")
-    )
-    mock_ezsp.wait_for_stack_status.return_value.__enter__ = AsyncMock(
-        return_value=t.EmberStatus.NETWORK_UP
-    )
-    mock_ezsp.add_transient_link_key = AsyncMock(return_value=t.EmberStatus.SUCCESS)
-    mock_ezsp._protocol = AsyncMock()
-
-    type(mock_ezsp).is_ezsp_running = PropertyMock(return_value=True)
-
-    return mock_ezsp
-
-
-@pytest.fixture
-def make_app(monkeypatch, event_loop, ezsp_mock):
-    def inner(config):
+def make_app(monkeypatch, ieee):
+    def inner(config, **kwargs):
         app_cfg = ControllerApplication.SCHEMA({**APP_CONFIG, **config})
         app = ControllerApplication(app_cfg)
 
-        app._ezsp = ezsp_mock
+        app._ezsp = _create_app_for_startup(
+            app, nwk_type=t.EmberNodeType.COORDINATOR, ieee=ieee, **kwargs
+        )
         monkeypatch.setattr(bellows.zigbee.application, "APS_ACK_TIMEOUT", 0.05)
         app._ctrl_event.set()
         app._in_flight_msg = asyncio.Semaphore()
@@ -120,7 +84,7 @@ def _create_app_for_startup(
     ieee,
     auto_form=False,
     init=bellows.types.sl_Status.OK,
-    ezsp_version=4,
+    ezsp_version=8,
     board_info=True,
     network_state=t.EmberNetworkStatus.JOINED_NETWORK,
 ):
@@ -135,36 +99,28 @@ def _create_app_for_startup(
         channels=t.Channels.ALL_CHANNELS,
     )
 
-    async def mock_leave(*args, **kwargs):
-        app._ezsp.handle_callback("stackStatusHandler", [t.EmberStatus.NETWORK_DOWN])
-        return [t.EmberStatus.NETWORK_DOWN]
-
-    async def nop_mock():
-        return ([0] * 10,)
-
     app._in_flight_msg = None
-    ezsp_mock = MagicMock(spec=ezsp.EZSP)
-    type(ezsp_mock).ezsp_version = PropertyMock(return_value=ezsp_version)
-    ezsp_mock.initialize = AsyncMock(return_value=ezsp_mock)
+
+    gateway = AsyncMock()
+    ezsp_mock = ezsp.EZSP(device_config={})
+    ezsp_mock._gw = gateway
+    ezsp_mock._ezsp_version = ezsp_version
+    ezsp_mock._protocol = ezsp.EZSP._BY_VERSION[ezsp_version](
+        cb_handler=ezsp_mock.handle_callback,
+        gateway=ezsp_mock._gw,
+    )
+    ezsp_mock.start_ezsp()
+
     ezsp_mock.connect = AsyncMock()
-    ezsp_mock.nop = AsyncMock(side_effect=nop_mock)
-    ezsp_mock.readCounters = AsyncMock(side_effect=nop_mock)
-    ezsp_mock.readAndClearCounters = AsyncMock(side_effect=nop_mock)
-    ezsp_mock._protocol = AsyncMock()
-    ezsp_mock.setConcentrator = AsyncMock()
-    ezsp_mock.getTokenData = AsyncMock(
-        return_value=GetTokenDataRsp(status=t.EmberStatus.ERR_FATAL)
-    )
-    ezsp_mock._command = AsyncMock(return_value=t.EmberStatus.SUCCESS)
-    ezsp_mock.addEndpoint = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    ezsp_mock.setConfigurationValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    ezsp_mock.initialize_network = AsyncMock(return_value=init)
-    ezsp_mock.getNetworkParameters = AsyncMock(
-        return_value=[t.EmberStatus.SUCCESS, nwk_type, nwk_params]
-    )
+    ezsp_mock.close = AsyncMock(wraps=ezsp_mock.close)
+    ezsp_mock.startup_reset = AsyncMock()
     ezsp_mock.can_burn_userdata_custom_eui64 = AsyncMock(return_value=True)
     ezsp_mock.can_rewrite_custom_eui64 = AsyncMock(return_value=True)
-    ezsp_mock.startScan = AsyncMock(return_value=[[c, 1] for c in range(11, 26 + 1)])
+    ezsp_mock.update_policies = AsyncMock()
+    ezsp_mock.wait_for_stack_status = MagicMock()
+    ezsp_mock.wait_for_stack_status.return_value.__enter__ = AsyncMock(
+        return_value=t.EmberStatus.NETWORK_UP
+    )
 
     if board_info:
         ezsp_mock.get_board_info = AsyncMock(
@@ -173,68 +129,58 @@ def _create_app_for_startup(
     else:
         ezsp_mock.get_board_info = AsyncMock(side_effect=EzspError("Not supported"))
 
-    ezsp_mock.setPolicy = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    ezsp_mock.getMfgToken = AsyncMock(return_value=(b"Some token\xff",))
-    ezsp_mock.getNodeId = AsyncMock(return_value=[t.EmberNodeId(0x0000)])
-    ezsp_mock.getEui64 = AsyncMock(return_value=[ieee])
-    ezsp_mock.getValue = AsyncMock(return_value=(0, b"\x01" * 6))
-    ezsp_mock.leaveNetwork = AsyncMock(side_effect=mock_leave)
-    ezsp_mock.reset = AsyncMock()
-    ezsp_mock.version = AsyncMock()
-    ezsp_mock.getConfigurationValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS, 1])
-    ezsp_mock.update_policies = AsyncMock()
-    ezsp_mock.networkState = AsyncMock(return_value=[network_state])
-    ezsp_mock.factory_reset = AsyncMock()
-    ezsp_mock.write_nwk_frame_counter = AsyncMock()
-    ezsp_mock.write_aps_frame_counter = AsyncMock()
-    ezsp_mock.setInitialSecurityState = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
-    ezsp_mock.write_link_keys = AsyncMock()
-    ezsp_mock.write_child_data = AsyncMock()
-    ezsp_mock.formNetwork = AsyncMock()
+    proto = ezsp_mock._protocol
+    mock_ezsp_commands(proto)
 
-    ezsp_mock.get_network_key = AsyncMock(
+    def form_network():
+        proto.getNetworkParameters.return_value = [
+            t.EmberStatus.SUCCESS,
+            t.EmberNodeType.COORDINATOR,
+            nwk_params,
+        ]
+
+    app.form_network = AsyncMock(side_effect=form_network)
+
+    proto.initialize_network = AsyncMock(
+        return_value=init, spec=proto.initialize_network
+    )
+    proto.write_nwk_frame_counter = AsyncMock(spec=proto.write_nwk_frame_counter)
+    proto.write_aps_frame_counter = AsyncMock(spec=proto.write_aps_frame_counter)
+    proto.send_broadcast = AsyncMock(
+        spec=proto.send_broadcast, return_value=[t.sl_Status.OK, 0x12]
+    )
+    proto.write_link_keys = AsyncMock(spec=proto.write_link_keys)
+    proto.write_child_data = AsyncMock(spec=proto.write_child_data)
+    proto.add_transient_link_key = AsyncMock(
+        return_value=t.sl_Status.OK, spec=proto.add_transient_link_key
+    )
+
+    proto.get_network_key = AsyncMock(
         return_value=zigpy.state.Key(
             key=t.KeyData(b"ActualNetworkKey"),
             tx_counter=t.uint32_t(0x12345678),
             rx_counter=t.uint32_t(0x00000000),
             seq=t.uint8_t(1),
             partner_ieee=t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
-        )
+        ),
+        proto=proto.get_network_key,
     )
 
-    ezsp_mock.get_tc_link_key = AsyncMock(
+    proto.get_tc_link_key = AsyncMock(
         return_value=zigpy.state.Key(
             key=t.KeyData(b"thehashedlinkkey"),
             tx_counter=t.uint32_t(0x87654321),
             rx_counter=t.uint32_t(0x00000000),
             seq=t.uint8_t(0),
             partner_ieee=t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
-        )
+        ),
+        proto=proto.get_tc_link_key,
     )
 
-    ezsp_mock.getCurrentSecurityState = AsyncMock(
-        return_value=[
-            t.EmberStatus.SUCCESS,
-            t.EmberCurrentSecurityState(
-                bitmask=(
-                    t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
-                    | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
-                    | 224
-                ),
-                trustCenterLongAddress=ieee,
-            ),
-        ]
-    )
-    ezsp_mock.getMulticastTableEntry = AsyncMock(
-        return_value=[
-            t.EmberStatus.SUCCESS,
-            t.EmberMulticastTableEntry(multicastId=0x0000, endpoint=0, networkIndex=0),
-        ]
-    )
-    ezsp_mock.setMulticastTableEntry = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
+    proto.factory_reset = AsyncMock(proto=proto.factory_reset)
 
-    ezsp_mock.read_link_keys = MagicMock()
-    ezsp_mock.read_link_keys.return_value.__aiter__.return_value = [
+    proto.read_link_keys = MagicMock()
+    proto.read_link_keys.return_value.__aiter__.return_value = [
         zigpy.state.Key(
             key=t.KeyData(b"test_link_key_01"),
             tx_counter=12345,
@@ -251,8 +197,8 @@ def _create_app_for_startup(
         ),
     ]
 
-    ezsp_mock.read_child_data = MagicMock()
-    ezsp_mock.read_child_data.return_value.__aiter__.return_value = [
+    proto.read_child_data = MagicMock()
+    proto.read_child_data.return_value.__aiter__.return_value = [
         (
             0x1234,
             t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"),
@@ -265,22 +211,59 @@ def _create_app_for_startup(
         ),
     ]
 
-    ezsp_mock.read_address_table = MagicMock()
-    ezsp_mock.read_address_table.return_value.__aiter__.return_value = [
+    proto.read_address_table = MagicMock()
+    proto.read_address_table.return_value.__aiter__.return_value = [
         (0xABCD, t.EUI64.convert("ab:cd:00:11:22:33:44:55")),
         (0xDCBA, t.EUI64.convert("dc:ba:00:11:22:33:44:55")),
     ]
 
-    app.permit = AsyncMock()
+    if "getTokenData" in proto.COMMANDS:
+        proto.getTokenData.return_value = GetTokenDataRsp(
+            status=t.EmberStatus.ERR_FATAL
+        )
 
-    def form_network():
-        ezsp_mock.getNetworkParameters.return_value = [
-            t.EmberStatus.SUCCESS,
-            t.EmberNodeType.COORDINATOR,
-            nwk_params,
-        ]
+    proto.addEndpoint.return_value = [t.EmberStatus.SUCCESS]
+    proto.setManufacturerCode.return_value = [t.EmberStatus.SUCCESS]
+    proto.setConfigurationValue.return_value = [t.EmberStatus.SUCCESS]
+    proto.getNetworkParameters.return_value = [
+        t.EmberStatus.SUCCESS,
+        nwk_type,
+        nwk_params,
+    ]
+    proto.startScan.return_value = [[c, 1] for c in range(11, 26 + 1)]
+    proto.setPolicy.return_value = [t.EmberStatus.SUCCESS]
+    proto.getMfgToken.return_value = (b"Some token\xff",)
+    proto.getNodeId.return_value = [t.EmberNodeId(0x0000)]
+    proto.getEui64.return_value = [ieee]
+    proto.getValue.return_value = (0, b"\x01" * 6)
+    proto.setValue.return_value = (t.EmberStatus.SUCCESS,)
+    proto.readCounters.return_value = ([0x0000] * len(t.EmberCounterType),)
 
-    app.form_network = AsyncMock(side_effect=form_network)
+    async def mock_leave(*args, **kwargs):
+        app._ezsp.handle_callback("stackStatusHandler", [t.EmberStatus.NETWORK_DOWN])
+        return [t.EmberStatus.SUCCESS]
+
+    proto.leaveNetwork.side_effect = mock_leave
+    proto.getConfigurationValue.return_value = [t.EmberStatus.SUCCESS, 1]
+    proto.networkState.return_value = [network_state]
+    proto.setInitialSecurityState.return_value = [t.EmberStatus.SUCCESS]
+    proto.formNetwork.return_value = [t.EmberStatus.SUCCESS]
+    proto.getCurrentSecurityState.return_value = (
+        t.EmberStatus.SUCCESS,
+        t.EmberCurrentSecurityState(
+            bitmask=(
+                t.EmberCurrentSecurityBitmask.GLOBAL_LINK_KEY
+                | t.EmberCurrentSecurityBitmask.HAVE_TRUST_CENTER_LINK_KEY
+                | 224
+            ),
+            trustCenterLongAddress=ieee,
+        ),
+    )
+    proto.getMulticastTableEntry.return_value = (
+        t.EmberStatus.SUCCESS,
+        t.EmberMulticastTableEntry(multicastId=0x0000, endpoint=0, networkIndex=0),
+    )
+    proto.setMulticastTableEntry.return_value = [t.EmberStatus.SUCCESS]
 
     return ezsp_mock
 
@@ -321,8 +304,7 @@ async def _test_startup(
     ) as ezsp_mock:
         await app.startup(auto_form=auto_form)
 
-    assert ezsp_mock.write_config.call_count == 1
-    assert ezsp_mock.addEndpoint.call_count >= 2
+    assert ezsp_mock._protocol.addEndpoint.call_count >= 2
 
 
 async def test_startup(app, ieee):
@@ -673,7 +655,7 @@ def test_leave_handler(app, ieee):
 
 
 async def test_force_remove(app, ieee):
-    app._ezsp.removeDevice = AsyncMock()
+    app._ezsp._protocol.removeDevice.return_value = [t.EmberStatus.SUCCESS]
     dev = MagicMock()
     await app.force_remove(dev)
 
@@ -686,9 +668,9 @@ def test_sequence(app):
 
 
 async def test_permit_ncp(app):
-    app._ezsp.permitJoining = AsyncMock()
+    app._ezsp._protocol.permitJoining.return_value = [t.EmberStatus.SUCCESS]
     await app.permit_ncp(60)
-    assert app._ezsp.permitJoining.call_count == 1
+    assert app._ezsp._protocol.permitJoining.mock_calls == [call(60)]
 
 
 async def test_permit_with_link_key(app, ieee):
@@ -700,11 +682,16 @@ async def test_permit_with_link_key(app, ieee):
         )
 
     assert permit_mock.await_count == 1
-    assert app._ezsp.add_transient_link_key.await_count == 1
+    assert app._ezsp._protocol.add_transient_link_key.mock_calls == [
+        call(
+            ieee,
+            zigpy_t.KeyData.convert("11:22:33:44:55:66:77:88:11:22:33:44:55:66:77:88"),
+        )
+    ]
 
 
 async def test_permit_with_link_key_failure(app, ieee):
-    app._ezsp.add_transient_link_key.return_value = t.EmberStatus.ERR_FATAL
+    app._ezsp._protocol.add_transient_link_key.return_value = t.EmberStatus.ERR_FATAL
 
     with patch("zigpy.application.ControllerApplication.permit") as permit_mock:
         with pytest.raises(ControllerError):
@@ -717,7 +704,7 @@ async def test_permit_with_link_key_failure(app, ieee):
             )
 
     assert permit_mock.await_count == 0
-    assert app._ezsp.add_transient_link_key.await_count == 1
+    assert app._ezsp._protocol.add_transient_link_key.await_count == 1
 
 
 @pytest.fixture
@@ -771,7 +758,9 @@ async def _test_send_packet_unicast(
 
         return [status, 0x12]
 
-    app._ezsp.send_unicast = AsyncMock(side_effect=send_unicast)
+    app._ezsp.send_unicast = AsyncMock(
+        side_effect=send_unicast, spec=app._ezsp.send_unicast
+    )
     app.get_sequence = MagicMock(return_value=sentinel.msg_tag)
 
     expected_unicast_calls = len(statuses)
@@ -833,7 +822,9 @@ async def test_send_packet_unicast_ieee_no_fallback(app, packet, caplog):
 
 async def test_send_packet_unicast_source_route(make_app, packet):
     app = make_app({zigpy.config.CONF_SOURCE_ROUTING: True})
-    app._ezsp.set_source_route = AsyncMock(return_value=(t.sl_Status.OK,))
+    app._ezsp._protocol.set_source_route = AsyncMock(
+        return_value=t.sl_Status.OK, spec=app._ezsp._protocol.set_source_route
+    )
 
     packet.source_route = [0x0001, 0x0002]
     await _test_send_packet_unicast(
@@ -845,7 +836,7 @@ async def test_send_packet_unicast_source_route(make_app, packet):
         ),
     )
 
-    app._ezsp.set_source_route.assert_called_once_with(
+    app._ezsp._protocol.set_source_route.assert_called_once_with(
         nwk=packet.dst.address,
         relays=[0x0001, 0x0002],
     )
@@ -999,9 +990,6 @@ async def test_send_packet_broadcast_ignored_delivery_failure(app, packet):
     )
     packet.radius = 30
 
-    app._ezsp.send_broadcast = AsyncMock(
-        return_value=(bellows.types.sl_Status.OK, 0x12)
-    )
     app.get_sequence = MagicMock(return_value=sentinel.msg_tag)
 
     asyncio.get_running_loop().call_soon(
@@ -1054,8 +1042,9 @@ async def test_send_packet_multicast(app, packet):
     packet.radius = 5
     packet.non_member_radius = 6
 
-    app._ezsp.send_multicast = AsyncMock(
-        return_value=(bellows.types.sl_Status.OK, 0x12)
+    app._ezsp._protocol.send_multicast = AsyncMock(
+        return_value=(bellows.types.sl_Status.OK, 0x12),
+        spec=app._ezsp._protocol.send_multicast,
     )
     app.get_sequence = MagicMock(return_value=sentinel.msg_tag)
 
@@ -1124,13 +1113,14 @@ def test_reset_frame(app):
 
 
 @pytest.mark.parametrize("ezsp_version", (4, 7))
-async def test_watchdog(app, monkeypatch, ezsp_version):
+async def test_watchdog(make_app, monkeypatch, ezsp_version):
     from bellows.zigbee import application
+
+    app = make_app({}, ezsp_version=ezsp_version)
 
     monkeypatch.setattr(application.ControllerApplication, "_watchdog_period", 0.01)
     monkeypatch.setattr(application, "EZSP_COUNTERS_CLEAR_IN_WATCHDOG_PERIODS", 2)
     nop_success = 7
-    app._ezsp.ezsp_version = ezsp_version
 
     async def nop_mock():
         nonlocal nop_success
@@ -1142,10 +1132,10 @@ async def test_watchdog(app, monkeypatch, ezsp_version):
                 return ([0] * 10,)
         raise asyncio.TimeoutError
 
-    app._ezsp.getValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS, b"\xFE"])
-    app._ezsp.nop = AsyncMock(side_effect=nop_mock)
-    app._ezsp.readCounters = AsyncMock(side_effect=nop_mock)
-    app._ezsp.readAndClearCounters = AsyncMock(side_effect=nop_mock)
+    app._ezsp._protocol.getValue.return_value = [t.EmberStatus.SUCCESS, b"\xFE"]
+    app._ezsp._protocol.nop.side_effect = nop_mock
+    app._ezsp._protocol.readCounters.side_effect = nop_mock
+    app._ezsp._protocol.readAndClearCounters.side_effect = nop_mock
     app._ctrl_event.set()
     app.connection_lost = MagicMock()
 
@@ -1163,9 +1153,9 @@ async def test_watchdog(app, monkeypatch, ezsp_version):
         await app._watchdog_feed()
 
     if ezsp_version == 4:
-        assert app._ezsp.nop.await_count > 4
+        assert app._ezsp._protocol.nop.await_count > 4
     else:
-        assert app._ezsp.readCounters.await_count >= 4
+        assert app._ezsp._protocol.readCounters.await_count >= 4
 
 
 async def test_watchdog_counters(app, monkeypatch, caplog):
@@ -1184,23 +1174,25 @@ async def test_watchdog_counters(app, monkeypatch, caplog):
                 return ([0, 1, 2, 3],)
         raise asyncio.TimeoutError
 
-    app._ezsp.getValue = AsyncMock(return_value=[t.EmberStatus.SUCCESS, b"\xFE"])
-    app._ezsp.readCounters = AsyncMock(side_effect=counters_mock)
-    app._ezsp.nop = AsyncMock(side_effect=EzspError)
+    app._ezsp._protocol.getValue = AsyncMock(
+        return_value=[t.EmberStatus.SUCCESS, b"\xFE"]
+    )
+    app._ezsp._protocol.readCounters = AsyncMock(side_effect=counters_mock)
+    app._ezsp._protocol.nop = AsyncMock(side_effect=EzspError)
     app._handle_reset_request = MagicMock()
     app._ctrl_event.set()
 
     caplog.set_level(logging.DEBUG, "bellows.zigbee.application")
     await app._watchdog_feed()
-    assert app._ezsp.readCounters.await_count != 0
-    assert app._ezsp.nop.await_count == 0
+    assert app._ezsp._protocol.readCounters.await_count != 0
+    assert app._ezsp._protocol.nop.await_count == 0
 
     # don't do counters on older firmwares
-    app._ezsp.ezsp_version = 4
-    app._ezsp.readCounters.reset_mock()
+    app._ezsp._ezsp_version = 4
+    app._ezsp._protocol.readCounters.reset_mock()
     await app._watchdog_feed()
-    assert app._ezsp.readCounters.await_count == 0
-    assert app._ezsp.nop.await_count != 0
+    assert app._ezsp._protocol.readCounters.await_count == 0
+    assert app._ezsp._protocol.nop.await_count != 0
 
 
 async def test_ezsp_value_counter(app, monkeypatch):
@@ -1513,16 +1505,12 @@ async def test_cleanup_tc_link_key(app):
     assert ezsp.eraseKeyTableEntry.mock_calls == [call(index=sentinel.index)]
 
 
-@patch("zigpy.application.ControllerApplication.permit", new=AsyncMock())
+# @patch("zigpy.application.ControllerApplication.permit", new=AsyncMock())
 async def test_permit(app):
     """Test permit method."""
-    ezsp = app._ezsp
-    ezsp.addTransientLinkKey = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
-    ezsp.pre_permit = AsyncMock()
-    await app.permit(10, None)
-    await asyncio.sleep(0)
-    assert ezsp.addTransientLinkKey.await_count == 0
-    assert ezsp.pre_permit.await_count == 1
+    await app.permit(10)
+    await asyncio.sleep(0.1)
+    assert app._ezsp._protocol.add_transient_link_key.await_count == 1
 
 
 @patch("bellows.zigbee.application.MFG_ID_RESET_DELAY", new=0.01)
@@ -1534,7 +1522,7 @@ async def test_permit(app):
         ("01:22:33:00:00:00:00:11", None),
     ),
 )
-async def test_set_mfg_id(ieee, expected_mfg_id, app, ezsp_mock):
+async def test_set_mfg_id(ieee, expected_mfg_id, app):
     """Test setting manufacturer id based on IEEE address."""
 
     app.handle_join = MagicMock()
@@ -1563,12 +1551,12 @@ async def test_set_mfg_id(ieee, expected_mfg_id, app, ezsp_mock):
     )
     await asyncio.sleep(0.20)
     if expected_mfg_id is not None:
-        assert ezsp_mock.setManufacturerCode.mock_calls == [
+        assert app._ezsp._protocol.setManufacturerCode.mock_calls == [
             call(code=expected_mfg_id),
             call(code=bellows.zigbee.application.DEFAULT_MFG_ID),
         ]
     else:
-        assert ezsp_mock.setManufacturerCode.mock_calls == []
+        assert app._ezsp._protocol.setManufacturerCode.mock_calls == []
 
 
 async def test_ensure_network_running_joined(app):
@@ -1618,7 +1606,7 @@ async def test_ensure_network_running_not_joined_success(app):
 
 async def test_startup_coordinator_existing_groups_joined(app, ieee):
     """Coordinator joins groups loaded from the database."""
-    with mock_for_startup(app, ieee) as ezsp_mock:
+    with mock_for_startup(app, ieee):
         await app.connect()
 
         db_device = app.add_device(ieee, 0x0000)
@@ -1629,7 +1617,7 @@ async def test_startup_coordinator_existing_groups_joined(app, ieee):
 
         await app.start_network()
 
-    assert ezsp_mock.setMulticastTableEntry.mock_calls == [
+    assert app._ezsp._protocol.setMulticastTableEntry.mock_calls == [
         call(
             0,
             t.EmberMulticastTableEntry(multicastId=0x1234, endpoint=1, networkIndex=0),
@@ -1639,11 +1627,11 @@ async def test_startup_coordinator_existing_groups_joined(app, ieee):
 
 async def test_startup_new_coordinator_no_groups_joined(app, ieee):
     """Coordinator freshy added to the database has no groups to join."""
-    with mock_for_startup(app, ieee) as ezsp_mock:
+    with mock_for_startup(app, ieee):
         await app.connect()
         await app.start_network()
 
-    assert ezsp_mock.setMulticastTableEntry.mock_calls == []
+    assert app._ezsp._protocol.setMulticastTableEntry.mock_calls == []
 
 
 @pytest.mark.parametrize(
@@ -1714,21 +1702,20 @@ async def test_energy_scanning_partial(app):
     assert results == {c: map_rssi_to_energy(c) for c in [11, 13, 14, 15, 20, 25, 26]}
 
 
-async def test_connect_failure(
-    app: ControllerApplication, ezsp_mock: ezsp.EZSP
-) -> None:
+async def test_connect_failure(app: ControllerApplication) -> None:
     """Test that a failure to connect propagates."""
-    ezsp_mock.write_config = AsyncMock(side_effect=OSError())
-    ezsp_mock.connect = AsyncMock()
+    ezsp = app._ezsp
+    app._ezsp.write_config = AsyncMock(side_effect=OSError())
+    app._ezsp.connect = AsyncMock()
     app._ezsp = None
 
-    with patch("bellows.ezsp.EZSP", return_value=ezsp_mock):
+    with patch("bellows.ezsp.EZSP", return_value=ezsp):
         with pytest.raises(OSError):
             await app.connect()
 
     assert app._ezsp is None
 
-    assert len(ezsp_mock.close.mock_calls) == 1
+    assert len(ezsp.close.mock_calls) == 1
 
 
 async def test_repair_tclk_partner_ieee(
@@ -1821,7 +1808,7 @@ def zigpy_backup() -> zigpy.backups.NetworkBackup:
             source=f"bellows@{importlib.metadata.version('bellows')}",
             metadata={
                 "ezsp": {
-                    "stack_version": 4,
+                    "stack_version": 8,
                     "can_burn_userdata_custom_eui64": True,
                     "can_rewrite_custom_eui64": True,
                 }
@@ -1835,9 +1822,7 @@ async def test_load_network_info(
     ieee: zigpy_t.EUI64,
     zigpy_backup: zigpy.backups.NetworkBackup,
 ) -> None:
-    with mock_for_startup(app, ieee):
-        await app.connect()
-        await app.load_network_info(load_devices=True)
+    await app.load_network_info(load_devices=True)
 
     assert app.state.node_info == zigpy_backup.node_info
     assert app.state.network_info == zigpy_backup.network_info
@@ -1848,20 +1833,19 @@ async def test_write_network_info(
     ieee: zigpy_t.EUI64,
     zigpy_backup: zigpy.backups.NetworkBackup,
 ) -> None:
-    with mock_for_startup(app, ieee):
-        await app.connect()
+    with patch.object(app, "_reset"):
         await app.write_network_info(
             node_info=zigpy_backup.node_info,
             network_info=zigpy_backup.network_info,
         )
 
-    assert app._ezsp.write_nwk_frame_counter.mock_calls == [
+    assert app._ezsp._protocol.write_nwk_frame_counter.mock_calls == [
         call(zigpy_backup.network_info.network_key.tx_counter)
     ]
-    assert app._ezsp.write_aps_frame_counter.mock_calls == [
+    assert app._ezsp._protocol.write_aps_frame_counter.mock_calls == [
         call(zigpy_backup.network_info.tc_link_key.tx_counter)
     ]
-    assert app._ezsp.formNetwork.mock_calls == [
+    assert app._ezsp._protocol.formNetwork.mock_calls == [
         call(
             parameters=t.EmberNetworkParameters(
                 panId=zigpy_backup.network_info.pan_id,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1092,20 +1092,20 @@ async def test_send_packet_multicast(app, packet):
 
 def test_is_controller_running(app):
     ezsp_running = PropertyMock(return_value=False)
-    type(app._ezsp).is_ezsp_running = ezsp_running
-    app._ctrl_event.clear()
-    assert app.is_controller_running is False
-    app._ctrl_event.set()
-    assert app.is_controller_running is False
-    assert ezsp_running.call_count == 1
+    with patch.object(type(app._ezsp), "is_ezsp_running", ezsp_running):
+        app._ctrl_event.clear()
+        assert app.is_controller_running is False
+        app._ctrl_event.set()
+        assert app.is_controller_running is False
+        assert ezsp_running.call_count == 1
 
     ezsp_running = PropertyMock(return_value=True)
-    type(app._ezsp).is_ezsp_running = ezsp_running
-    app._ctrl_event.clear()
-    assert app.is_controller_running is False
-    app._ctrl_event.set()
-    assert app.is_controller_running is True
-    assert ezsp_running.call_count == 1
+    with patch.object(type(app._ezsp), "is_ezsp_running", ezsp_running):
+        app._ctrl_event.clear()
+        assert app.is_controller_running is False
+        app._ctrl_event.set()
+        assert app.is_controller_running is True
+        assert ezsp_running.call_count == 1
 
 
 def test_reset_frame(app):

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -480,9 +480,9 @@ async def test_ash_protocol_startup(caplog):
     ]
 
 
-@patch("bellows.ash.T_RX_ACK_INIT", ash.T_RX_ACK_INIT / 100)
-@patch("bellows.ash.T_RX_ACK_MIN", ash.T_RX_ACK_MIN / 100)
-@patch("bellows.ash.T_RX_ACK_MAX", ash.T_RX_ACK_MAX / 100)
+@patch("bellows.ash.T_RX_ACK_INIT", ash.T_RX_ACK_INIT / 1000)
+@patch("bellows.ash.T_RX_ACK_MIN", ash.T_RX_ACK_MIN / 1000)
+@patch("bellows.ash.T_RX_ACK_MAX", ash.T_RX_ACK_MAX / 1000)
 @pytest.mark.parametrize(
     "transport_cls",
     [

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -291,9 +291,9 @@ async def test_ezsp_init(conn_mock, reset_mock, version_mock):
     """Test initialize method."""
     zigpy_config = config.CONFIG_SCHEMA({"device": DEVICE_CONFIG})
     await ezsp.EZSP.initialize(zigpy_config)
-    assert conn_mock.await_count == 1
-    assert reset_mock.await_count == 1
-    assert version_mock.await_count == 1
+    assert conn_mock.call_count == 1
+    assert reset_mock.call_count == 1
+    assert version_mock.call_count == 1
 
 
 @patch.object(ezsp.EZSP, "version", side_effect=RuntimeError("Uh oh"))
@@ -307,9 +307,9 @@ async def test_ezsp_init_failure(conn_mock, close_mock, reset_mock, version_mock
     with pytest.raises(RuntimeError):
         await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.await_count == 1
-    assert reset_mock.await_count == 1
-    assert version_mock.await_count == 1
+    assert conn_mock.call_count == 1
+    assert reset_mock.call_count == 1
+    assert version_mock.call_count == 1
     assert close_mock.call_count == 1
 
 
@@ -396,14 +396,14 @@ async def test_pre_permit(ezsp_f):
     with patch("bellows.ezsp.v4.EZSPv4.pre_permit") as pre_mock:
         await ezsp_f.pre_permit(sentinel.time)
         assert pre_mock.call_count == 1
-        assert pre_mock.await_count == 1
+        assert pre_mock.call_count == 1
 
 
 async def test_update_policies(ezsp_f):
     with patch("bellows.ezsp.v4.EZSPv4.update_policies") as pol_mock:
         await ezsp_f.update_policies(sentinel.time)
         assert pol_mock.call_count == 1
-        assert pol_mock.await_count == 1
+        assert pol_mock.call_count == 1
 
 
 async def test_set_source_routing_set_concentrator(ezsp_f):
@@ -411,7 +411,7 @@ async def test_set_source_routing_set_concentrator(ezsp_f):
     with patch.object(ezsp_f, "setConcentrator", new=AsyncMock()) as cnc_mock:
         cnc_mock.return_value = (t.EmberStatus.SUCCESS,)
         await ezsp_f.set_source_routing()
-        assert cnc_mock.await_count == 1
+        assert cnc_mock.call_count == 1
 
         cnc_mock.return_value = (t.EmberStatus.ERR_FATAL,)
         await ezsp_f.set_source_routing()
@@ -634,10 +634,10 @@ async def test_ezsp_init_zigbeed(conn_mock, reset_mock, version_mock):
 
     await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.await_count == 1
+    assert conn_mock.call_count == 1
     assert reset_mock.await_count == 0  # Reset is not called
-    assert gw_wait_reset_mock.await_count == 1
-    assert version_mock.await_count == 1
+    assert gw_wait_reset_mock.call_count == 1
+    assert version_mock.call_count == 1
 
 
 @patch.object(ezsp.EZSP, "version", new_callable=AsyncMock)
@@ -664,10 +664,10 @@ async def test_ezsp_init_zigbeed_timeout(conn_mock, reset_mock, version_mock):
 
     await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.await_count == 1
-    assert reset_mock.await_count == 1  # Reset will be called
-    assert gw_wait_reset_mock.await_count == 1
-    assert version_mock.await_count == 1
+    assert conn_mock.call_count == 1
+    assert reset_mock.call_count == 1  # Reset will be called
+    assert gw_wait_reset_mock.call_count == 1
+    assert version_mock.call_count == 1
 
 
 async def test_wait_for_stack_status(ezsp_f):

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -291,6 +291,7 @@ async def test_ezsp_init(conn_mock, reset_mock, version_mock):
     """Test initialize method."""
     zigpy_config = config.CONFIG_SCHEMA({"device": DEVICE_CONFIG})
     await ezsp.EZSP.initialize(zigpy_config)
+    await asyncio.sleep(0.1)  # TODO: figure out why this is necessary
     assert conn_mock.await_count == 1
     assert reset_mock.await_count == 1
     assert version_mock.await_count == 1
@@ -307,6 +308,7 @@ async def test_ezsp_init_failure(conn_mock, close_mock, reset_mock, version_mock
     with pytest.raises(RuntimeError):
         await ezsp.EZSP.initialize(zigpy_config)
 
+    await asyncio.sleep(0.1)  # TODO: figure out why this is necessary
     assert conn_mock.await_count == 1
     assert reset_mock.await_count == 1
     assert version_mock.await_count == 1

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -180,6 +180,7 @@ async def test_form_network_fail(ezsp_f):
         await _test_form_network(ezsp_f, [t.EmberStatus.FAILURE], b"\x90")
 
 
+@patch("bellows.ezsp.NETWORK_OPS_TIMEOUT", 0.1)
 async def test_form_network_fail_stack_status(ezsp_f):
     with pytest.raises(Exception):
         await _test_form_network(ezsp_f, [t.EmberStatus.SUCCESS], b"\x00")

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -291,9 +291,9 @@ async def test_ezsp_init(conn_mock, reset_mock, version_mock):
     """Test initialize method."""
     zigpy_config = config.CONFIG_SCHEMA({"device": DEVICE_CONFIG})
     await ezsp.EZSP.initialize(zigpy_config)
-    assert conn_mock.call_count == 1
-    assert reset_mock.call_count == 1
-    assert version_mock.call_count == 1
+    assert conn_mock.await_count == 1
+    assert reset_mock.await_count == 1
+    assert version_mock.await_count == 1
 
 
 @patch.object(ezsp.EZSP, "version", side_effect=RuntimeError("Uh oh"))
@@ -307,9 +307,9 @@ async def test_ezsp_init_failure(conn_mock, close_mock, reset_mock, version_mock
     with pytest.raises(RuntimeError):
         await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.call_count == 1
-    assert reset_mock.call_count == 1
-    assert version_mock.call_count == 1
+    assert conn_mock.await_count == 1
+    assert reset_mock.await_count == 1
+    assert version_mock.await_count == 1
     assert close_mock.call_count == 1
 
 
@@ -396,14 +396,14 @@ async def test_pre_permit(ezsp_f):
     with patch("bellows.ezsp.v4.EZSPv4.pre_permit") as pre_mock:
         await ezsp_f.pre_permit(sentinel.time)
         assert pre_mock.call_count == 1
-        assert pre_mock.call_count == 1
+        assert pre_mock.await_count == 1
 
 
 async def test_update_policies(ezsp_f):
     with patch("bellows.ezsp.v4.EZSPv4.update_policies") as pol_mock:
         await ezsp_f.update_policies(sentinel.time)
         assert pol_mock.call_count == 1
-        assert pol_mock.call_count == 1
+        assert pol_mock.await_count == 1
 
 
 async def test_set_source_routing_set_concentrator(ezsp_f):
@@ -411,7 +411,7 @@ async def test_set_source_routing_set_concentrator(ezsp_f):
     with patch.object(ezsp_f, "setConcentrator", new=AsyncMock()) as cnc_mock:
         cnc_mock.return_value = (t.EmberStatus.SUCCESS,)
         await ezsp_f.set_source_routing()
-        assert cnc_mock.call_count == 1
+        assert cnc_mock.await_count == 1
 
         cnc_mock.return_value = (t.EmberStatus.ERR_FATAL,)
         await ezsp_f.set_source_routing()
@@ -634,10 +634,10 @@ async def test_ezsp_init_zigbeed(conn_mock, reset_mock, version_mock):
 
     await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.call_count == 1
+    assert conn_mock.await_count == 1
     assert reset_mock.await_count == 0  # Reset is not called
-    assert gw_wait_reset_mock.call_count == 1
-    assert version_mock.call_count == 1
+    assert gw_wait_reset_mock.await_count == 1
+    assert version_mock.await_count == 1
 
 
 @patch.object(ezsp.EZSP, "version", new_callable=AsyncMock)
@@ -664,10 +664,10 @@ async def test_ezsp_init_zigbeed_timeout(conn_mock, reset_mock, version_mock):
 
     await ezsp.EZSP.initialize(zigpy_config)
 
-    assert conn_mock.call_count == 1
-    assert reset_mock.call_count == 1  # Reset will be called
-    assert gw_wait_reset_mock.call_count == 1
-    assert version_mock.call_count == 1
+    assert conn_mock.await_count == 1
+    assert reset_mock.await_count == 1  # Reset will be called
+    assert gw_wait_reset_mock.await_count == 1
+    assert version_mock.await_count == 1
 
 
 async def test_wait_for_stack_status(ezsp_f):

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -291,7 +291,6 @@ async def test_ezsp_init(conn_mock, reset_mock, version_mock):
     """Test initialize method."""
     zigpy_config = config.CONFIG_SCHEMA({"device": DEVICE_CONFIG})
     await ezsp.EZSP.initialize(zigpy_config)
-    await asyncio.sleep(0.1)  # TODO: figure out why this is necessary
     assert conn_mock.await_count == 1
     assert reset_mock.await_count == 1
     assert version_mock.await_count == 1
@@ -308,7 +307,6 @@ async def test_ezsp_init_failure(conn_mock, close_mock, reset_mock, version_mock
     with pytest.raises(RuntimeError):
         await ezsp.EZSP.initialize(zigpy_config)
 
-    await asyncio.sleep(0.1)  # TODO: figure out why this is necessary
     assert conn_mock.await_count == 1
     assert reset_mock.await_count == 1
     assert version_mock.await_count == 1

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -112,6 +112,8 @@ async def test_command(ezsp_f):
 
 
 async def test_command_ezsp_stopped(ezsp_f):
+    ezsp_f.stop_ezsp()
+
     with pytest.raises(EzspError):
         await ezsp_f._command("version")
 

--- a/tests/test_ezsp_v10.py
+++ b/tests/test_ezsp_v10.py
@@ -5,11 +5,16 @@ import pytest
 import bellows.ezsp.v10
 import bellows.types as t
 
+from tests.common import mock_ezsp_commands
+
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v10 protocol handler."""
-    return bellows.ezsp.v10.EZSPv10(MagicMock(), MagicMock())
+    ezsp = bellows.ezsp.v10.EZSPv10(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):
@@ -41,7 +46,7 @@ async def test_pre_permit(ezsp_f):
 
 
 async def test_write_child_data(ezsp_f) -> None:
-    ezsp_f.setChildData = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
+    ezsp_f.setChildData.return_value = [t.EmberStatus.SUCCESS]
 
     await ezsp_f.write_child_data(
         {

--- a/tests/test_ezsp_v11.py
+++ b/tests/test_ezsp_v11.py
@@ -4,11 +4,16 @@ import pytest
 
 import bellows.ezsp.v11
 
+from tests.common import mock_ezsp_commands
+
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v11 protocol handler."""
-    return bellows.ezsp.v11.EZSPv11(MagicMock(), MagicMock())
+    ezsp = bellows.ezsp.v11.EZSPv11(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):

--- a/tests/test_ezsp_v12.py
+++ b/tests/test_ezsp_v12.py
@@ -4,11 +4,16 @@ import pytest
 
 import bellows.ezsp.v12
 
+from tests.common import mock_ezsp_commands
+
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v12 protocol handler."""
-    return bellows.ezsp.v12.EZSPv12(MagicMock(), MagicMock())
+    ezsp = bellows.ezsp.v12.EZSPv12(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -354,3 +354,12 @@ async def test_source_route(ezsp_f) -> None:
     assert ezsp_f.setSourceRoute.mock_calls == [
         call(destination=0x1234, relayList=[0x5678, 0xABCD])
     ]
+
+
+async def test_add_transient_link_key(ezsp_f) -> None:
+    # It's a no-op
+    status = await ezsp_f.add_transient_link_key(
+        ieee=t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
+        key=t.KeyData.convert("ZigBeeAlliance09"),
+    )
+    assert status == t.sl_Status.OK

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -360,6 +360,6 @@ async def test_add_transient_link_key(ezsp_f) -> None:
     # It's a no-op
     status = await ezsp_f.add_transient_link_key(
         ieee=t.EUI64.convert("ff:ff:ff:ff:ff:ff:ff:ff"),
-        key=t.KeyData.convert("ZigBeeAlliance09"),
+        key=t.KeyData("ZigBeeAlliance09"),
     )
     assert status == t.sl_Status.OK

--- a/tests/test_ezsp_v6.py
+++ b/tests/test_ezsp_v6.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import MagicMock, call
 
 import pytest
 import zigpy.state
@@ -6,11 +6,16 @@ import zigpy.state
 import bellows.ezsp.v6
 import bellows.types as t
 
+from tests.common import mock_ezsp_commands
+
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v6 protocol handler."""
-    return bellows.ezsp.v6.EZSPv6(MagicMock(), MagicMock())
+    ezsp = bellows.ezsp.v6.EZSPv6(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):
@@ -28,7 +33,7 @@ def test_ezsp_frame_rx(ezsp_f):
 
 
 async def test_initialize_network(ezsp_f) -> None:
-    ezsp_f.networkInit = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
+    ezsp_f.networkInit.return_value = (t.EmberStatus.SUCCESS,)
     assert await ezsp_f.initialize_network() == t.sl_Status.OK
     assert ezsp_f.networkInit.mock_calls == [
         call(networkInitBitmask=t.EmberNetworkInitBitmask.NETWORK_INIT_NO_OPTIONS)

--- a/tests/test_ezsp_v7.py
+++ b/tests/test_ezsp_v7.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock
+
 import pytest
-from unitest.mock import MagicMock
 
 import bellows.ezsp.v7
 import bellows.types as t

--- a/tests/test_ezsp_v7.py
+++ b/tests/test_ezsp_v7.py
@@ -1,15 +1,19 @@
-from unittest import mock
-
 import pytest
+from unitest.mock import MagicMock
 
 import bellows.ezsp.v7
 import bellows.types as t
+
+from tests.common import mock_ezsp_commands
 
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v7 protocol handler."""
-    return bellows.ezsp.v7.EZSPv7(mock.MagicMock(), mock.MagicMock())
+    ezsp = bellows.ezsp.v7.EZSPv7(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):
@@ -45,7 +49,7 @@ async def test_read_child_data(ezsp_f):
             ),
         )
 
-    ezsp_f.getChildData = mock.AsyncMock(side_effect=get_child_data)
+    ezsp_f.getChildData.side_effect = get_child_data
 
     child_data = [row async for row in ezsp_f.read_child_data()]
     assert child_data == [

--- a/tests/test_ezsp_v9.py
+++ b/tests/test_ezsp_v9.py
@@ -5,11 +5,16 @@ import pytest
 import bellows.ezsp.v9
 import bellows.types as t
 
+from tests.common import mock_ezsp_commands
+
 
 @pytest.fixture
 def ezsp_f():
     """EZSP v9 protocol handler."""
-    return bellows.ezsp.v9.EZSPv9(MagicMock(), MagicMock())
+    ezsp = bellows.ezsp.v9.EZSPv9(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    return ezsp
 
 
 def test_ezsp_frame(ezsp_f):
@@ -41,7 +46,7 @@ async def test_pre_permit(ezsp_f):
 
 
 async def test_write_child_data(ezsp_f) -> None:
-    ezsp_f.setChildData = AsyncMock(return_value=[t.EmberStatus.SUCCESS])
+    ezsp_f.setChildData.return_value = [t.EmberStatus.SUCCESS]
 
     await ezsp_f.write_child_data(
         {
@@ -77,7 +82,7 @@ async def test_write_child_data(ezsp_f) -> None:
 
 
 async def test_source_route(ezsp_f) -> None:
-    ezsp_f.setSourceRoute = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
+    ezsp_f.setSourceRoute.return_value = (t.EmberStatus.SUCCESS,)
 
     status = await ezsp_f.set_source_route(nwk=0x1234, relays=[0x5678, 0xABCD])
     assert status == t.sl_Status.OK

--- a/tests/test_multicast.py
+++ b/tests/test_multicast.py
@@ -7,16 +7,20 @@ import bellows.ezsp
 import bellows.multicast
 import bellows.types as t
 
+from tests.common import mock_ezsp_commands
+
 CUSTOM_SIZE = 12
 
 
 @pytest.fixture
 def ezsp_f():
-    e = MagicMock()
-    e.getConfigurationValue = AsyncMock(
-        return_value=[t.EmberStatus.SUCCESS, CUSTOM_SIZE]
-    )
-    return e
+    """EZSP v8 protocol handler."""
+    ezsp = bellows.ezsp.v8.EZSPv8(MagicMock(), MagicMock())
+    mock_ezsp_commands(ezsp)
+
+    ezsp.getConfigurationValue.return_value = [t.EmberStatus.SUCCESS, CUSTOM_SIZE]
+
+    return ezsp
 
 
 @pytest.fixture

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ import zigpy.zdo.types as zdo_t
 import bellows.types as t
 import bellows.zigbee.util as util
 
-from tests.test_application import ezsp_mock, ieee
+from tests.test_application import ieee
 
 
 @pytest.fixture
@@ -89,7 +89,7 @@ def zigpy_key(network_info, node_info):
 
 
 @pytest.fixture
-def ezsp_key(ezsp_mock, network_info, node_info, zigpy_key):
+def ezsp_key(network_info, node_info, zigpy_key):
     return t.EmberKeyStruct(
         bitmask=(
             t.EmberKeyStructBitmask.KEY_HAS_SEQUENCE_NUMBER


### PR DESCRIPTION
In the future, we need to migrate bellows to a more robust framework that tests end-to-end command serialization and response parsing. Until then, I've replaced all blind mocks with those that also try to serialize the command.

There was a single error with EZSPv8 that has since been corrected.

Fixes https://github.com/zigpy/bellows/issues/640