### PR TITLE
Fix form CLI command

### DIFF
--- a/bellows/cli/util.py
+++ b/bellows/cli/util.py
@@ -52,7 +52,7 @@ def app(f, app_startup=True, extra_config=None):
             zigpy_conf.CONF_DEVICE: {
                 zigpy_conf.CONF_DEVICE_PATH: ctx.obj["device"],
                 zigpy_conf.CONF_DEVICE_BAUDRATE: ctx.obj["baudrate"],
-                zigpy_conf.CONF_FLOW_CONTROL: ctx.obj["flow_control"],
+                zigpy_conf.CONF_DEVICE_FLOW_CONTROL: ctx.obj["flow_control"],
             },
             zigpy_conf.CONF_DATABASE: ctx.obj["database_file"],
         }


### PR DESCRIPTION
The `bellows form` command currently fails with the following error:

```
  File "/home/.virtualenvs/bellows/lib/python3.10/site-packages/bellows/cli/util.py", line 55, in async_inner
    zigpy_conf.CONF_FLOW_CONTROL: ctx.obj["flow_control"],
AttributeError: module 'zigpy.config' has no attribute 'CONF_FLOW_CONTROL'. Did you mean: 'CONF_DEVICE_FLOW_CONTROL'?
```