### PR TITLE
Parse EZSP `readCounters` laxly

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -244,3 +244,11 @@ class ProtocolHandler(abc.ABC):
     @abc.abstractmethod
     async def set_source_route(self, nwk: t.NWK, relays: list[t.NWK]) -> t.sl_Status:
         raise NotImplementedError
+
+    @abc.abstractmethod
+    async def read_counters(self) -> dict[t.EmberCounterType, int]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def read_and_clear_counters(self) -> dict[t.EmberCounterType, int]:
+        raise NotImplementedError

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -185,3 +185,11 @@ class EZSPv4(protocol.ProtocolHandler):
     async def set_source_route(self, nwk: t.NWK, relays: list[t.NWK]) -> t.sl_Status:
         (res,) = await self.setSourceRoute(destination=nwk, relayList=relays)
         return t.sl_Status.from_ember_status(res)
+
+    async def read_counters(self) -> dict[t.EmberCounterType, t.uint16_t]:
+        (res,) = await self.readCounters()
+        return dict(zip(t.EmberCounterType, res))
+
+    async def read_and_clear_counters(self) -> dict[t.EmberCounterType, t.uint16_t]:
+        (res,) = await self.readAndClearCounters()
+        return dict(zip(t.EmberCounterType, res))

--- a/bellows/ezsp/v4/commands.py
+++ b/bellows/ezsp/v4/commands.py
@@ -275,14 +275,14 @@ COMMANDS = {
         0x65,
         {},
         {
-            "values": t.FixedList[t.uint16_t, len(t.EmberCounterType)],
+            "values": t.List[t.uint16_t],
         },
     ),
     "readCounters": (
         0xF1,
         {},
         {
-            "values": t.FixedList[t.uint16_t, len(t.EmberCounterType)],
+            "values": t.List[t.uint16_t],
         },
     ),
     "counterRolloverHandler": (

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -890,12 +890,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 )
 
                 if remainder > 0:
-                    (res,) = await self._ezsp.readCounters()
+                    current_counters = await self._ezsp.read_counters()
                 else:
-                    (res,) = await self._ezsp.readAndClearCounters()
+                    current_counters = await self._ezsp.read_and_clear_counters()
 
-                # We allow `zip` to truncate `res` here
-                for cnt_type, value in zip(t.EmberCounterType, res):
+                for cnt_type, value in current_counters.items():
                     counters[cnt_type.name[8:]].update(value)
 
                 if remainder == 0:

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -894,6 +894,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 else:
                     (res,) = await self._ezsp.readAndClearCounters()
 
+                # We allow `zip` to truncate `res` here
                 for cnt_type, value in zip(t.EmberCounterType, res):
                     counters[cnt_type.name[8:]].update(value)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1210,10 +1210,10 @@ async def test_ezsp_value_counter(app, monkeypatch):
             if nop_success % 2:
                 raise EzspError
             else:
-                return ([0, 1, 2, 3],)
+                return {t.EmberCounterType(i): v for i, v in enumerate([0, 1, 2, 3])}
         raise asyncio.TimeoutError
 
-    app._ezsp.readCounters = AsyncMock(side_effect=counters_mock)
+    app._ezsp.read_counters = AsyncMock(side_effect=counters_mock)
     app._ezsp.nop = AsyncMock(side_effect=EzspError)
     app._ezsp.getValue = AsyncMock(
         return_value=(t.EzspStatus.ERROR_OUT_OF_MEMORY, b"\x20")
@@ -1222,7 +1222,7 @@ async def test_ezsp_value_counter(app, monkeypatch):
     app._ctrl_event.set()
 
     await app._watchdog_feed()
-    assert app._ezsp.readCounters.await_count != 0
+    assert app._ezsp.read_counters.await_count != 0
     assert app._ezsp.nop.await_count == 0
 
     cnt = t.EmberCounterType

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -363,3 +363,19 @@ async def test_add_transient_link_key(ezsp_f) -> None:
         key=t.KeyData("ZigBeeAlliance09"),
     )
     assert status == t.sl_Status.OK
+
+
+@pytest.mark.parametrize("length", [40, 41])
+async def test_read_counters(ezsp_f, length: int) -> None:
+    """Test parsing of a `readCounters` response, including truncation."""
+    ezsp_f.readCounters.return_value = (list(range(length)),)
+    ezsp_f.readAndClearCounters.return_value = (list(range(length)),)
+    counters1 = await ezsp_f.read_counters()
+    counters2 = await ezsp_f.read_and_clear_counters()
+    assert (
+        ezsp_f.readCounters.mock_calls
+        == ezsp_f.readAndClearCounters.mock_calls
+        == [call()]
+    )
+
+    assert counters1 == counters2 == {t.EmberCounterType(i): i for i in range(length)}

--- a/tests/test_ezsp_v7.py
+++ b/tests/test_ezsp_v7.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from bellows.ash import DataFrame
 import bellows.ezsp.v7
 import bellows.types as t
 
@@ -60,3 +61,22 @@ async def test_read_child_data(ezsp_f):
             t.EmberNodeType.SLEEPY_END_DEVICE,
         )
     ]
+
+
+def test_read_counters(ezsp_f):
+    """Test parsing of a truncated `readCounters` response."""
+    data_frame = DataFrame(
+        frm_num=1,
+        re_tx=0,
+        ack_num=2,
+        ezsp_frame=bytes.fromhex(
+            "2080ff00f10000000000000000000000000000000000000000000000000000000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000"
+        ),
+    )
+    ezsp_f(data_frame.ezsp_frame)
+
+    assert len(ezsp_f._handle_callback.mock_calls) == 1
+    mock_call = ezsp_f._handle_callback.mock_calls[0]
+    assert mock_call.args == ("readCounters", [[0] * 40])

--- a/tests/test_ezsp_v7.py
+++ b/tests/test_ezsp_v7.py
@@ -61,22 +61,3 @@ async def test_read_child_data(ezsp_f):
             t.EmberNodeType.SLEEPY_END_DEVICE,
         )
     ]
-
-
-def test_read_counters(ezsp_f):
-    """Test parsing of a truncated `readCounters` response."""
-    data_frame = DataFrame(
-        frm_num=1,
-        re_tx=0,
-        ack_num=2,
-        ezsp_frame=bytes.fromhex(
-            "2080ff00f10000000000000000000000000000000000000000000000000000000000000000"
-            "00000000000000000000000000000000000000000000000000000000000000000000000000"
-            "0000000000000000000000"
-        ),
-    )
-    ezsp_f(data_frame.ezsp_frame)
-
-    assert len(ezsp_f._handle_callback.mock_calls) == 1
-    mock_call = ezsp_f._handle_callback.mock_calls[0]
-    assert mock_call.args == ("readCounters", [[0] * 40])


### PR DESCRIPTION
A few counters were added over time so the response length is not always the same. We should instead parse the output as a list of an unknown size instead of an array of a known size.

https://github.com/home-assistant/core/issues/123474