### PR TITLE
Improve transmission reliability for sleepy end-devices

### DIFF
--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -43,6 +43,9 @@ class ProtocolHandler(abc.ABC):
         }
         self.tc_policy = 0
 
+        # Cached by `set_extended_timeout` so subsequent calls are a little faster
+        self._address_table_size: int | None = None
+
     def _ezsp_frame(self, name: str, *args: Any, **kwargs: Any) -> bytes:
         """Serialize the named frame and data."""
         c, tx_schema, rx_schema = self.COMMANDS[name]

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -252,3 +252,9 @@ class ProtocolHandler(abc.ABC):
     @abc.abstractmethod
     async def read_and_clear_counters(self) -> dict[t.EmberCounterType, int]:
         raise NotImplementedError
+
+    @abc.abstractmethod
+    async def set_extended_timeout(
+        self, nwk: t.NWK, ieee: t.EUI64, extended_timeout: bool = True
+    ) -> None:
+        raise NotImplementedError()

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -217,6 +217,10 @@ class EZSPv4(protocol.ProtocolHandler):
         )
 
         if t.sl_Status.from_ember_status(status) != t.sl_Status.OK:
+            # Last-ditch effort
+            await self.setExtendedTimeout(
+                remoteEui64=ieee, extendedTimeout=extended_timeout
+            )
             return
 
         # Replace a random entry in the address table

--- a/bellows/ezsp/v4/__init__.py
+++ b/bellows/ezsp/v4/__init__.py
@@ -212,19 +212,22 @@ class EZSPv4(protocol.ProtocolHandler):
             )
             return
 
-        (status, addr_table_size) = await self.getConfigurationValue(
-            t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE
-        )
-
-        if t.sl_Status.from_ember_status(status) != t.sl_Status.OK:
-            # Last-ditch effort
-            await self.setExtendedTimeout(
-                remoteEui64=ieee, extendedTimeout=extended_timeout
+        if self._address_table_size is None:
+            (status, addr_table_size) = await self.getConfigurationValue(
+                t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE
             )
-            return
+
+            if t.sl_Status.from_ember_status(status) != t.sl_Status.OK:
+                # Last-ditch effort
+                await self.setExtendedTimeout(
+                    remoteEui64=ieee, extendedTimeout=extended_timeout
+                )
+                return
+
+            self._address_table_size = addr_table_size
 
         # Replace a random entry in the address table
-        index = random.randint(0, addr_table_size - 1)
+        index = random.randint(0, self._address_table_size - 1)
 
         await self.replaceAddressTableEntry(
             addressTableIndex=index,

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -749,8 +749,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     async with self._req_lock:
                         if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
                             if packet.extended_timeout and device is not None:
-                                await self._ezsp.setExtendedTimeout(
-                                    remoteEui64=device.ieee, extendedTimeout=True
+                                await self._ezsp.set_extended_timeout(
+                                    nwk=device.nwk,
+                                    ieee=device.ieee,
+                                    extended_timeout=True,
                                 )
 
                             if packet.source_route is not None:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -178,6 +178,7 @@ def _create_app_for_startup(
     )
 
     proto.factory_reset = AsyncMock(proto=proto.factory_reset)
+    proto.set_extended_timeout = AsyncMock(proto=proto.set_extended_timeout)
 
     proto.read_link_keys = MagicMock()
     proto.read_link_keys.return_value.__aiter__.return_value = [

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -843,6 +843,19 @@ async def test_send_packet_unicast_source_route(make_app, packet):
     )
 
 
+async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
+    app.add_device(nwk=packet.dst.address, ieee=ieee)
+
+    await _test_send_packet_unicast(
+        app,
+        packet.replace(extended_timeout=True),
+    )
+
+    assert app._ezsp._protocol.set_extended_timeout.mock_calls == [
+        call(nwk=packet.dst.address, ieee=ieee, extended_timeout=True)
+    ]
+
+
 @patch("bellows.zigbee.application.RETRY_DELAYS", [0.01, 0.01, 0.01])
 async def test_send_packet_unicast_retries_success(app, packet):
     await _test_send_packet_unicast(

--- a/tests/test_ezsp_v4.py
+++ b/tests/test_ezsp_v4.py
@@ -420,6 +420,35 @@ async def test_set_extended_timeout_no_entry(ezsp_f) -> None:
         )
     ]
 
+    # The address table size is cached
+    with patch("bellows.ezsp.v4.random.randint") as mock_random:
+        mock_random.return_value = 1
+        await ezsp_f.set_extended_timeout(
+            nwk=0x1234,
+            ieee=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"),
+            extended_timeout=True,
+        )
+
+    # Still called only once
+    assert ezsp_f.getConfigurationValue.mock_calls == [
+        call(t.EzspConfigId.CONFIG_ADDRESS_TABLE_SIZE)
+    ]
+
+    assert ezsp_f.replaceAddressTableEntry.mock_calls == [
+        call(
+            addressTableIndex=0,
+            newEui64=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"),
+            newId=0x1234,
+            newExtendedTimeout=True,
+        ),
+        call(
+            addressTableIndex=1,
+            newEui64=t.EUI64.convert("aa:bb:cc:dd:ee:ff:00:11"),
+            newId=0x1234,
+            newExtendedTimeout=True,
+        ),
+    ]
+
 
 async def test_set_extended_timeout_already_set(ezsp_f) -> None:
     # No-op, it's already set


### PR DESCRIPTION
End devices are flagged as needing an "extended timeout" by their IEEE but we often times never inform the stack of the NWK -> IEEE mapping. We fix this by injecting a random entry into the address table if one does not already exist.