### PR TITLE
Move EZSP send lock from `EZSP` to individual protocol handlers

### DIFF
--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -578,7 +578,7 @@ class AshProtocol(asyncio.Protocol):
         self._enter_failed_state(self._ncp_reset_code)
 
     def _enter_failed_state(self, reset_code: t.NcpResetCode) -> None:
-        self._ncp_state == NcpState.FAILED
+        self._ncp_state = NcpState.FAILED
         self._cancel_pending_data_frames(NcpFailure(code=reset_code))
         self._ezsp_protocol.reset_received(reset_code)
 

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -631,7 +631,9 @@ class AshProtocol(asyncio.Protocol):
                             await ack_future
                     except NotAcked:
                         _LOGGER.debug(
-                            "NCP responded with NAK. Retrying (attempt %d)", attempt + 1
+                            "NCP responded with NAK to %r. Retrying (attempt %d)",
+                            frame,
+                            attempt + 1,
                         )
 
                         # For timing purposes, NAK can be treated as an ACK
@@ -650,9 +652,10 @@ class AshProtocol(asyncio.Protocol):
                         raise
                     except asyncio.TimeoutError:
                         _LOGGER.debug(
-                            "No ACK received in %0.2fs (attempt %d)",
+                            "No ACK received in %0.2fs (attempt %d) for %r",
                             self._t_rx_ack,
                             attempt + 1,
+                            frame,
                         )
                         # If a DATA frame acknowledgement is not received within the
                         # current timeout value, then t_rx_ack is doubled.

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -432,7 +432,7 @@ class AshProtocol(asyncio.Protocol):
             _LOGGER.debug(
                 "Truncating buffer to %s bytes, it is growing too fast", MAX_BUFFER_SIZE
             )
-            self._buffer = self._buffer[:MAX_BUFFER_SIZE]
+            self._buffer = self._buffer[-MAX_BUFFER_SIZE:]
 
         while self._buffer:
             if self._discarding_until_next_flag:

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -579,6 +579,9 @@ class AshProtocol(asyncio.Protocol):
         prefix: tuple[Reserved] = (),
         suffix: tuple[Reserved] = (Reserved.FLAG,),
     ) -> None:
+        if self._transport is None or self._transport.is_closing():
+            raise NcpFailure("Transport is closed, cannot send frame")
+
         if _LOGGER.isEnabledFor(logging.DEBUG):
             prefix_str = "".join([f"{r.name} + " for r in prefix])
             suffix_str = "".join([f" + {r.name}" for r in suffix])

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -62,7 +62,7 @@ TX_K = 1  # TODO: investigate why this cannot be raised without causing a firmwa
 # Maximum number of consecutive timeouts allowed while waiting to receive an ACK before
 # going to the FAILED state. The value 0 prevents the NCP from entering the error state
 # due to timeouts.
-ACK_TIMEOUTS = 4
+ACK_TIMEOUTS = 5
 
 
 def generate_random_sequence(length: int) -> bytes:

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -369,6 +369,7 @@ class AshProtocol(asyncio.Protocol):
         self._ezsp_protocol.connection_made(self)
 
     def connection_lost(self, exc):
+        self._transport = None
         self._cancel_pending_data_frames()
         self._ezsp_protocol.connection_lost(exc)
 
@@ -387,6 +388,7 @@ class AshProtocol(asyncio.Protocol):
 
         if self._transport is not None:
             self._transport.close()
+            self._transport = None
 
     @staticmethod
     def _stuff_bytes(data: bytes) -> bytes:

--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -564,6 +564,7 @@ class AshProtocol(asyncio.Protocol):
         self._enter_failed_state(self._ncp_reset_code)
 
     def _enter_failed_state(self, reset_code: t.NcpResetCode) -> None:
+        self._ncp_state == NcpState.FAILED
         self._cancel_pending_data_frames(NcpFailure(code=reset_code))
         self._ezsp_protocol.reset_received(reset_code)
 

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -12,8 +12,6 @@ import sys
 from typing import Any, Callable, Generator
 import urllib.parse
 
-from zigpy.datastructures import PriorityDynamicBoundedSemaphore
-
 if sys.version_info[:2] < (3, 11):
     from async_timeout import timeout as asyncio_timeout  # pragma: no cover
 else:
@@ -41,8 +39,6 @@ NETWORK_PROBE_TIMEOUT = 7
 NETWORK_OPS_TIMEOUT = 10
 NETWORK_COORDINATOR_STARTUP_RESET_WAIT = 1
 
-MAX_COMMAND_CONCURRENCY = 1
-
 
 class EZSP:
     _BY_VERSION = {
@@ -66,7 +62,6 @@ class EZSP:
         self._ezsp_version = v4.EZSPv4.VERSION
         self._gw = None
         self._protocol = None
-        self._send_sem = PriorityDynamicBoundedSemaphore(value=MAX_COMMAND_CONCURRENCY)
 
         self._stack_status_listeners: collections.defaultdict[
             t.sl_Status, list[asyncio.Future]
@@ -190,21 +185,6 @@ class EZSP:
             self._gw.close()
             self._gw = None
 
-    def _get_command_priority(self, name: str) -> int:
-        return {
-            # Deprioritize any commands that send packets
-            "set_source_route": -1,
-            "setExtendedTimeout": -1,
-            "send_unicast": -1,
-            "send_multicast": -1,
-            "send_broadcast": -1,
-            # Prioritize watchdog commands
-            "nop": 999,
-            "readCounters": 999,
-            "readAndClearCounters": 999,
-            "getValue": 999,
-        }.get(name, 0)
-
     async def _command(self, name: str, *args: Any, **kwargs: Any) -> Any:
         command = getattr(self._protocol, name)
 
@@ -217,8 +197,7 @@ class EZSP:
             )
             raise EzspError("EZSP is not running")
 
-        async with self._send_sem(priority=self._get_command_priority(name)):
-            return await command(*args, **kwargs)
+        return await command(*args, **kwargs)
 
     async def _list_command(
         self, name, item_frames, completion_frame, spos, *args, **kwargs

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -6,6 +6,7 @@ import binascii
 import functools
 import logging
 import sys
+import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Iterable
 
 import zigpy.state
@@ -15,6 +16,8 @@ if sys.version_info[:2] < (3, 11):
 else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
+from zigpy.datastructures import PriorityDynamicBoundedSemaphore
+
 from bellows.config import CONF_EZSP_POLICIES
 from bellows.exception import InvalidCommandError
 import bellows.types as t
@@ -23,7 +26,9 @@ if TYPE_CHECKING:
     from bellows.uart import Gateway
 
 LOGGER = logging.getLogger(__name__)
+
 EZSP_CMD_TIMEOUT = 6  # Sum of all ASH retry timeouts: 0.4 + 0.8 + 1.6 + 3.2
+MAX_COMMAND_CONCURRENCY = 1
 
 
 class ProtocolHandler(abc.ABC):
@@ -42,6 +47,9 @@ class ProtocolHandler(abc.ABC):
             for name, (cmd_id, tx_schema, rx_schema) in self.COMMANDS.items()
         }
         self.tc_policy = 0
+        self._send_semaphore = PriorityDynamicBoundedSemaphore(
+            value=MAX_COMMAND_CONCURRENCY
+        )
 
         # Cached by `set_extended_timeout` so subsequent calls are a little faster
         self._address_table_size: int | None = None
@@ -65,18 +73,58 @@ class ProtocolHandler(abc.ABC):
     def _ezsp_frame_tx(self, name: str) -> bytes:
         """Serialize the named frame."""
 
+    def _get_command_priority(self, name: str) -> int:
+        return {
+            # Deprioritize any commands that send packets
+            "setSourceRoute": -1,
+            "setExtendedTimeout": -1,
+            "sendUnicast": -1,
+            "sendMulticast": -1,
+            "sendBroadcast": -1,
+            # Prioritize watchdog commands
+            "nop": 999,
+            "readCounters": 999,
+            "readAndClearCounters": 999,
+            "getValue": 999,
+        }.get(name, 0)
+
     async def command(self, name, *args, **kwargs) -> Any:
         """Serialize command and send it."""
-        LOGGER.debug("Sending command  %s: %s %s", name, args, kwargs)
-        data = self._ezsp_frame(name, *args, **kwargs)
-        cmd_id, _, rx_schema = self.COMMANDS[name]
-        future = asyncio.get_running_loop().create_future()
-        self._awaiting[self._seq] = (cmd_id, rx_schema, future)
-        self._seq = (self._seq + 1) % 256
+        delay_time = 0
+        was_delayed = False
 
-        async with asyncio_timeout(EZSP_CMD_TIMEOUT):
-            await self._gw.send_data(data)
-            return await future
+        if self._send_semaphore.locked():
+            LOGGER.debug(
+                "Send semaphore is locked, delaying before sending %s(%r, %r)",
+                name,
+                args,
+                kwargs,
+            )
+            delay_time = time.monotonic()
+            was_delayed = True
+
+        async with self._send_semaphore(priority=self._get_command_priority(name)):
+            if was_delayed:
+                LOGGER.debug(
+                    "Sending command  %s: %s %s after %0.2fs delay",
+                    name,
+                    args,
+                    kwargs,
+                    time.monotonic() - delay_time,
+                )
+            else:
+                LOGGER.debug("Sending command  %s: %s %s", name, args, kwargs)
+
+            data = self._ezsp_frame(name, *args, **kwargs)
+            cmd_id, _, rx_schema = self.COMMANDS[name]
+
+            future = asyncio.get_running_loop().create_future()
+            self._awaiting[self._seq] = (cmd_id, rx_schema, future)
+            self._seq = (self._seq + 1) % 256
+
+            async with asyncio_timeout(EZSP_CMD_TIMEOUT):
+                await self._gw.send_data(data)
+                return await future
 
     async def update_policies(self, policy_config: dict) -> None:
         """Set up the policies for what the NCP should do."""

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -123,8 +123,9 @@ class ProtocolHandler(abc.ABC):
             self._awaiting[self._seq] = (cmd_id, rx_schema, future)
             self._seq = (self._seq + 1) % 256
 
+            await self._gw.send_data(data)
+
             async with asyncio_timeout(EZSP_CMD_TIMEOUT):
-                await self._gw.send_data(data)
                 return await future
 
     async def update_policies(self, policy_config: dict) -> None:

--- a/bellows/ezsp/protocol.py
+++ b/bellows/ezsp/protocol.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-EZSP_CMD_TIMEOUT = 6  # Sum of all ASH retry timeouts: 0.4 + 0.8 + 1.6 + 3.2
+EZSP_CMD_TIMEOUT = 10
 MAX_COMMAND_CONCURRENCY = 1
 
 

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -19,21 +19,6 @@ RESET_TIMEOUT = 5
 
 
 class Gateway(asyncio.Protocol):
-    FLAG = b"\x7E"  # Marks end of frame
-    ESCAPE = b"\x7D"
-    XON = b"\x11"  # Resume transmission
-    XOFF = b"\x13"  # Stop transmission
-    SUBSTITUTE = b"\x18"
-    CANCEL = b"\x1A"  # Terminates a frame in progress
-    STUFF = 0x20
-    RANDOMIZE_START = 0x42
-    RANDOMIZE_SEQ = 0xB8
-
-    RESERVED = FLAG + ESCAPE + XON + XOFF + SUBSTITUTE + CANCEL
-
-    class Terminator:
-        pass
-
     def __init__(self, application, connected_future=None, connection_done_future=None):
         self._application = application
 

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -498,7 +498,6 @@ async def test_ash_protocol_startup(caplog):
 )
 async def test_ash_end_to_end(transport_cls: type[FakeTransport]) -> None:
     random.seed(2)
-    asyncio.get_running_loop()
 
     host_ezsp = MagicMock()
     ncp_ezsp = MagicMock()

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -557,8 +557,9 @@ async def test_ash_end_to_end(transport_cls: type[FakeTransport]) -> None:
         send_task = asyncio.create_task(host.send_data(b"ncp NAKing"))
         await asyncio.sleep(host._t_rx_ack)
 
-    # It'll still succeed
-    await send_task
+    # The NCP is in a failed state, we can't send it
+    with pytest.raises(ash.NcpFailure):
+        await send_task
 
     ncp_ezsp.data_received.reset_mock()
     host_ezsp.data_received.reset_mock()

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -177,6 +177,10 @@ def test_stuffing():
     assert ash.AshProtocol._stuff_bytes(b"\x7F") == b"\x7F"
     assert ash.AshProtocol._unstuff_bytes(b"\x7F") == b"\x7F"
 
+    with pytest.raises(ash.ParsingError):
+        # AB is not a sequence of bytes that can be unescaped
+        assert ash.AshProtocol._unstuff_bytes(b"\x7D\xAB")
+
 
 def test_pseudo_random_data_sequence():
     assert ash.PSEUDO_RANDOM_DATA_SEQUENCE.startswith(b"\x42\x21\xA8\x54\x2A")

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -11,11 +11,6 @@ from bellows import ash
 import bellows.types as t
 
 
-@pytest.fixture(autouse=True, scope="function")
-def random_seed():
-    random.seed(0)
-
-
 class AshNcpProtocol(ash.AshProtocol):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -502,6 +497,7 @@ async def test_ash_protocol_startup(caplog):
     ],
 )
 async def test_ash_end_to_end(transport_cls: type[FakeTransport]) -> None:
+    random.seed(2)
     asyncio.get_running_loop()
 
     host_ezsp = MagicMock()

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -188,6 +188,7 @@ def test_eof_received(gw):
 async def test_connection_lost_reset_error_propagation(monkeypatch):
     app = MagicMock()
     transport = MagicMock()
+    transport.is_closing.return_value = False
 
     async def mockconnect(loop, protocol_factory, **kwargs):
         protocol = protocol_factory()


### PR DESCRIPTION
We recently moved a lot of code into individual EZSP protocol handlers. This introduced a "hole" where protocol handlers could run multiple commands at once within a single semaphore.

This PR moves the semaphore into the protocol handlers, closing this hole. I've also adjusted protocol timeouts to better handle TCP failures, making communication with TCP coordinators a bit more resilient. I think after this PR we may be able to immediately disconnect on watchdog failure as opposed to allowing up to five to fail.

CC @tube0013 