### PR TITLE
Use the new zigpy packet priority attribute

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -741,7 +741,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # Source routing uses address discovery to discover routes
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
 
-        async with self._limit_concurrency():
+        async with self._limit_concurrency(priority=packet.priority):
             message_tag = self.get_sequence()
             pending_tag = (packet.dst.address, message_tag)
             with self._pending.new(pending_tag) as req:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "click-log>=0.2.1",
     "pure_pcapy3==1.0.1",
     "voluptuous",
-    "zigpy>=0.65.3",
+    "zigpy>=0.68.0",
     'async-timeout; python_version<"3.11"',
 ]
 


### PR DESCRIPTION
The zigpy change is backwards compatible but radio libraries need to opt in to use it.