### PR TITLE
Disable XNCP `MEMBER_OF_ALL_GROUPS` on current firmwares

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -179,7 +179,7 @@ class EZSP:
             ver,
         )
 
-    async def get_xncp_features(self) -> None:
+    async def get_xncp_features(self) -> xncp.FirmwareFeatures:
         try:
             self._xncp_features = await self.xncp_get_supported_firmware_features()
         except InvalidCommandError:
@@ -193,6 +193,7 @@ class EZSP:
                 self._xncp_features &= ~FirmwareFeatures.MEMBER_OF_ALL_GROUPS
 
         LOGGER.debug("XNCP features: %s", self._xncp_features)
+        return self._xncp_features
 
     async def disconnect(self):
         self.stop_ezsp()

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -185,6 +185,13 @@ class EZSP:
         except InvalidCommandError:
             self._xncp_features = xncp.FirmwareFeatures.NONE
 
+        # Disable the XNCP feature flag, it doesn't seem to work correctly
+        if FirmwareFeatures.MEMBER_OF_ALL_GROUPS in self._xncp_features:
+            _, _, version = await self.get_board_info()
+
+            if version == "7.4.4.0 build 0":
+                self._xncp_features &= ~FirmwareFeatures.MEMBER_OF_ALL_GROUPS
+
         LOGGER.debug("XNCP features: %s", self._xncp_features)
 
     async def disconnect(self):


### PR DESCRIPTION
I noticed that I'm not able to see multicast group packets anymore on current firmware builds, even though this feature worked in testing. The rebase and project restructure may have disabled something.

Until this is fixed and new firmwares are released, we should revert back to the old behavior even if this feature flag is advertised. Otherwise, group traffic is no longer seen by the coordinator at all.