### PR TITLE
Do not read XNCP flow control on older radios

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -180,6 +180,10 @@ class EZSP:
         )
 
     async def get_xncp_features(self) -> xncp.FirmwareFeatures:
+        # Some older gateways seem to have their own XNCP protocol. Ignore them.
+        if self._ezsp_version < 13:
+            return FirmwareFeatures.NONE
+
         try:
             self._xncp_features = await self.xncp_get_supported_firmware_features()
         except InvalidCommandError:

--- a/bellows/ezsp/xncp.py
+++ b/bellows/ezsp/xncp.py
@@ -112,8 +112,8 @@ class XncpCommandPayload(t.Struct):
 
 
 class FlowControlType(t.enum8):
-    Software = 0x00
-    Hardware = 0x01
+    SOFTWARE = 0x00
+    HARDWARE = 0x01
 
 
 @register_command(XncpCommandId.GET_SUPPORTED_FEATURES_REQ)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -32,12 +32,7 @@ from bellows.config import (
     CONF_USE_THREAD,
     CONFIG_SCHEMA,
 )
-from bellows.exception import (
-    ControllerError,
-    EzspError,
-    InvalidCommandError,
-    StackAlreadyRunning,
-)
+from bellows.exception import ControllerError, EzspError, StackAlreadyRunning
 import bellows.ezsp
 from bellows.ezsp.xncp import FirmwareFeatures
 import bellows.multicast
@@ -299,9 +294,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         can_burn_userdata_custom_eui64 = await ezsp.can_burn_userdata_custom_eui64()
         can_rewrite_custom_eui64 = await ezsp.can_rewrite_custom_eui64()
 
-        try:
-            flow_control = await self._ezsp.xncp_get_flow_control_type()
-        except InvalidCommandError:
+        if FirmwareFeatures.FLOW_CONTROL_TYPE in ezsp._xncp_features:
+            flow_control = await ezsp.xncp_get_flow_control_type()
+        else:
             flow_control = None
 
         self.state.network_info = zigpy.state.NetworkInfo(

--- a/tests/test_xncp.py
+++ b/tests/test_xncp.py
@@ -171,13 +171,13 @@ async def test_xncp_get_flow_control_type(ezsp_f: EZSP) -> None:
             t.EmberStatus.SUCCESS,
             xncp.XncpCommand.from_payload(
                 xncp.GetFlowControlTypeRsp(
-                    flow_control_type=xncp.FlowControlType.Hardware
+                    flow_control_type=xncp.FlowControlType.HARDWARE
                 )
             ).serialize(),
         ]
     )
 
-    assert await ezsp_f.xncp_get_flow_control_type() == xncp.FlowControlType.Hardware
+    assert await ezsp_f.xncp_get_flow_control_type() == xncp.FlowControlType.HARDWARE
     assert customFrame.mock_calls == [
         call(xncp.XncpCommand.from_payload(xncp.GetFlowControlTypeReq()).serialize())
     ]
@@ -185,6 +185,8 @@ async def test_xncp_get_flow_control_type(ezsp_f: EZSP) -> None:
 
 async def test_xncp_get_xncp_features_fixes(ezsp_f: EZSP) -> None:
     """Test XNCP `get_xncp_features`, with fixes."""
+    ezsp_f._ezsp_version = 13
+
     ezsp_f._mock_commands["customFrame"] = customFrame = AsyncMock(
         return_value=[
             t.EmberStatus.SUCCESS,
@@ -219,6 +221,10 @@ async def test_xncp_get_xncp_features_fixes(ezsp_f: EZSP) -> None:
             xncp.FirmwareFeatures.MANUAL_SOURCE_ROUTE
             | xncp.FirmwareFeatures.MEMBER_OF_ALL_GROUPS
         )
+
+    # XNCP is ignored for older EmberZNet
+    ezsp_f._ezsp_version = 8
+    assert (await ezsp_f.get_xncp_features()) == xncp.FirmwareFeatures.NONE
 
     assert customFrame.mock_calls == [
         call(xncp.XncpCommand.from_payload(xncp.GetSupportedFeaturesReq()).serialize()),


### PR DESCRIPTION
This fixes the last issue I'm able to identify with the hacked Lidl gateway. All XNCP features are now locked behind feature flags and I've disabled them entirely for all EZSP versions lower than 13, the earliest with our protocol extensions.