### PR TITLE
Do not read build string without first checking XNCP feature bitmap

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -362,11 +362,11 @@ class EZSP:
             patch, ver_info_bytes = t.uint8_t.deserialize(ver_info_bytes)
             special, ver_info_bytes = t.uint8_t.deserialize(ver_info_bytes)
             version = f"{major}.{minor}.{patch}.{special} build {build}"
+            build_string = None
 
-            try:
-                build_string = await self.xncp_get_build_string()
-            except InvalidCommandError:
-                build_string = None
+            if FirmwareFeatures.BUILD_STRING in self._xncp_features:
+                with contextlib.suppress(InvalidCommandError):
+                    build_string = await self.xncp_get_build_string()
 
             if build_string:
                 version = f"{version} ({build_string})"

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -388,6 +388,9 @@ async def test_board_info(
 
         return replacement
 
+    if not isinstance(xncp_build_string, InvalidCommandError):
+        ezsp_f._xncp_features |= xncp.FirmwareFeatures.BUILD_STRING
+
     with patch.object(
         ezsp_f,
         "_command",


### PR DESCRIPTION
Apparently the hacked Xiaomi gateway uses `customCommand` for something and us sending this command corrupts it. This is the last use of `customCommand` that wasn't locked behind checking the XNCP features bitmap.

See https://github.com/home-assistant/core/issues/133200