### PR TITLE
Application-level retries

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -44,7 +44,6 @@ from bellows.zigbee.device import EZSPEndpoint, EZSPGroupEndpoint
 import bellows.zigbee.util as util
 
 APS_ACK_TIMEOUT = 120
-RETRY_DELAYS = [0.5, 1.0, 1.5]
 COUNTER_EZSP_BUFFERS = "EZSP_FREE_BUFFERS"
 COUNTER_NWK_CONFLICTS = "nwk_conflicts"
 COUNTER_RESET_REQ = "reset_requests"
@@ -826,7 +825,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         aps_frame.sourceEndpoint = t.uint8_t(packet.src_ep)
         aps_frame.destinationEndpoint = t.uint8_t(packet.dst_ep or 0)
         aps_frame.options = t.EmberApsOption.APS_OPTION_NONE
-        aps_frame.options |= t.EmberApsOption.APS_OPTION_RETRY
 
         if packet.dst.addr_mode == zigpy.types.AddrMode.Group:
             aps_frame.groupId = t.uint16_t(packet.dst.address)
@@ -843,100 +841,74 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             message_tag = self.get_sequence()
             pending_tag = (packet.dst.address, message_tag)
             with self._pending.new(pending_tag) as req:
-                for attempt, retry_delay in enumerate(RETRY_DELAYS):
-                    async with self._req_lock:
-                        if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
-                            if packet.extended_timeout and device is not None:
-                                await self._ezsp.set_extended_timeout(
-                                    nwk=device.nwk,
-                                    ieee=device.ieee,
-                                    extended_timeout=True,
+                async with self._req_lock:
+                    if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
+                        if packet.extended_timeout and device is not None:
+                            await self._ezsp.set_extended_timeout(
+                                nwk=device.nwk,
+                                ieee=device.ieee,
+                                extended_timeout=True,
+                            )
+
+                        if packet.source_route is not None:
+                            if (
+                                FirmwareFeatures.MANUAL_SOURCE_ROUTE
+                                in self._ezsp._xncp_features
+                                and self.config[CONF_BELLOWS_CONFIG][
+                                    CONF_MANUAL_SOURCE_ROUTING
+                                ]
+                            ):
+                                await self._ezsp.xncp_set_manual_source_route(
+                                    nwk=packet.dst.address,
+                                    relays=packet.source_route,
+                                )
+                            else:
+                                await self._ezsp.set_source_route(
+                                    nwk=packet.dst.address,
+                                    relays=packet.source_route,
                                 )
 
-                            if packet.source_route is not None:
-                                if (
-                                    FirmwareFeatures.MANUAL_SOURCE_ROUTE
-                                    in self._ezsp._xncp_features
-                                    and self.config[CONF_BELLOWS_CONFIG][
-                                        CONF_MANUAL_SOURCE_ROUTING
-                                    ]
-                                ):
-                                    await self._ezsp.xncp_set_manual_source_route(
-                                        nwk=packet.dst.address,
-                                        relays=packet.source_route,
-                                    )
-                                else:
-                                    await self._ezsp.set_source_route(
-                                        nwk=packet.dst.address,
-                                        relays=packet.source_route,
-                                    )
-
-                            status, _ = await self._ezsp.send_unicast(
-                                nwk=packet.dst.address,
-                                aps_frame=aps_frame,
-                                message_tag=message_tag,
-                                data=packet.data.serialize(),
-                            )
-                        elif packet.dst.addr_mode == zigpy.types.AddrMode.Group:
-                            status, _ = await self._ezsp.send_multicast(
-                                aps_frame=aps_frame,
-                                radius=packet.radius,
-                                non_member_radius=packet.non_member_radius,
-                                message_tag=message_tag,
-                                data=packet.data.serialize(),
-                            )
-                        elif packet.dst.addr_mode == zigpy.types.AddrMode.Broadcast:
-                            status, _ = await self._ezsp.send_broadcast(
-                                address=packet.dst.address,
-                                aps_frame=aps_frame,
-                                radius=packet.radius,
-                                message_tag=message_tag,
-                                aps_sequence=packet.tsn,
-                                data=packet.data.serialize(),
-                            )
-
-                    if status == t.sl_Status.OK:
-                        break
-                    elif status not in (
-                        t.sl_Status.ZIGBEE_MAX_MESSAGE_LIMIT_REACHED,
-                        t.sl_Status.TRANSMIT_BUSY,
-                        t.sl_Status.ALLOCATION_FAILED,
-                    ):
-                        raise zigpy.exceptions.DeliveryError(
-                            f"Failed to enqueue message: {status!r}", status
+                        status, _ = await self._ezsp.send_unicast(
+                            nwk=packet.dst.address,
+                            aps_frame=aps_frame,
+                            message_tag=message_tag,
+                            data=packet.data.serialize(),
                         )
-                    else:
-                        if attempt < len(RETRY_DELAYS):
-                            LOGGER.debug(
-                                "Request %s failed to enqueue, retrying in %ss: %s",
-                                pending_tag,
-                                retry_delay,
-                                status,
-                            )
-                            await asyncio.sleep(retry_delay)
-                else:
+                    elif packet.dst.addr_mode == zigpy.types.AddrMode.Group:
+                        status, _ = await self._ezsp.send_multicast(
+                            aps_frame=aps_frame,
+                            radius=packet.radius,
+                            non_member_radius=packet.non_member_radius,
+                            message_tag=message_tag,
+                            data=packet.data.serialize(),
+                        )
+                    elif packet.dst.addr_mode == zigpy.types.AddrMode.Broadcast:
+                        status, _ = await self._ezsp.send_broadcast(
+                            address=packet.dst.address,
+                            aps_frame=aps_frame,
+                            radius=packet.radius,
+                            message_tag=message_tag,
+                            aps_sequence=packet.tsn,
+                            data=packet.data.serialize(),
+                        )
+
+                if status != t.sl_Status.OK:
                     raise zigpy.exceptions.DeliveryError(
-                        (
-                            f"Failed to enqueue message after {len(RETRY_DELAYS)}"
-                            f" attempts: {status!r}"
-                        ),
-                        status,
+                        f"Failed to enqueue message: {status!r}", status
                     )
 
                 # Only throw a delivery exception for packets sent with NWK addressing.
                 # https://github.com/home-assistant/core/issues/79832
                 # Broadcasts/multicasts don't have ACKs or confirmations either.
-                if packet.dst.addr_mode != zigpy.types.AddrMode.NWK:
-                    return
+                if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
+                    # Wait for `messageSentHandler` message
+                    async with asyncio_timeout(APS_ACK_TIMEOUT):
+                        send_status, _ = await req.result
 
-                # Wait for `messageSentHandler` message
-                async with asyncio_timeout(APS_ACK_TIMEOUT):
-                    send_status, _ = await req.result
-
-                if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
-                    raise zigpy.exceptions.DeliveryError(
-                        f"Failed to deliver message: {send_status!r}", send_status
-                    )
+                    if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
+                        raise zigpy.exceptions.DeliveryError(
+                            f"Failed to deliver message: {send_status!r}", send_status
+                        )
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -886,12 +886,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             data=packet.data.serialize(),
                         )
 
-                        route_status_handler_future = (
-                            asyncio.get_running_loop().create_future()
-                        )
-                        self._request_status_handlers[packet.dst.address].append(
-                            route_status_handler_future
-                        )
+                        if packet.extended_timeout:
+                            route_status_handler_future = (
+                                asyncio.get_running_loop().create_future()
+                            )
+                            self._request_status_handlers[packet.dst.address].append(
+                                route_status_handler_future
+                            )
                     elif packet.dst.addr_mode == zigpy.types.AddrMode.Group:
                         status, _ = await self._ezsp.send_multicast(
                             aps_frame=aps_frame,
@@ -931,12 +932,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             f"Failed to deliver message: {send_status!r}", send_status
                         )
 
+                    # Only wait for routing status notifications for messages sent
+                    # indirectly
+                    if not packet.extended_timeout:
+                        return
+
                     try:
-                        async with asyncio_timeout(
-                            ROUTE_STATUS_TIMEOUT_BATTERY
-                            if packet.extended_timeout
-                            else ROUTE_STATUS_TIMEOUT_MAINS
-                        ):
+                        async with asyncio_timeout(ROUTE_STATUS_TIMEOUT_BATTERY):
                             route_status = await route_status_handler_future
                     except asyncio.TimeoutError:
                         route_status = None

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -45,10 +45,8 @@ from bellows.zigbee import repairs
 from bellows.zigbee.device import EZSPEndpoint, EZSPGroupEndpoint
 import bellows.zigbee.util as util
 
-APS_ACK_TIMEOUT = 8
-
-ROUTE_STATUS_TIMEOUT_MAINS = 0.5
-ROUTE_STATUS_TIMEOUT_BATTERY = 8
+MESSAGE_SEND_TIMEOUT_MAINS = 0.7
+MESSAGE_SEND_TIMEOUT_BATTERY = 8
 
 COUNTER_EZSP_BUFFERS = "EZSP_FREE_BUFFERS"
 COUNTER_NWK_CONFLICTS = "nwk_conflicts"
@@ -898,7 +896,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             data=packet.data.serialize(),
                         )
 
-                        if packet.extended_timeout:
+                        if (
+                            packet.extended_timeout
+                            and zigpy.types.TransmitOptions.ACK not in packet.tx_options
+                        ):
                             route_status_handler_future = (
                                 asyncio.get_running_loop().create_future()
                             )
@@ -936,7 +937,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         return
 
                     # Wait for `messageSentHandler` message
-                    async with asyncio_timeout(APS_ACK_TIMEOUT):
+                    async with asyncio_timeout(
+                        MESSAGE_SEND_TIMEOUT_MAINS
+                        if not packet.extended_timeout
+                        else MESSAGE_SEND_TIMEOUT_BATTERY
+                    ):
                         send_status, _ = await req.result
 
                     if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
@@ -944,16 +949,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             f"Failed to deliver message: {send_status!r}", send_status
                         )
 
-                    # Only wait for routing status notifications for messages sent
-                    # indirectly, ignoring the coordinator
-                    if (
-                        not packet.extended_timeout
-                        or packet.dst.address == self.state.node_info.nwk
-                    ):
+                    if route_status_handler_future is None:
                         return
 
                     try:
-                        async with asyncio_timeout(ROUTE_STATUS_TIMEOUT_BATTERY):
+                        async with asyncio_timeout(MESSAGE_SEND_TIMEOUT_BATTERY):
                             route_status = await route_status_handler_future
                     except asyncio.TimeoutError:
                         route_status = None

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1086,12 +1086,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
         self.handle_relays(nwk=nwk, relays=relays)
 
-        handlers = self._request_status_handlers[nwk]
-        if not handlers:
-            return
-
-        handlers.popleft().set_result(None)
-
     def handle_route_error(self, status: t.sl_Status, nwk: t.EmberNodeId) -> None:
         LOGGER.debug("Processing route error: status=%s, nwk=%s", status, nwk)
 

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict, deque
-import contextlib
 from datetime import datetime, timezone
 import logging
 import os
@@ -856,8 +855,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # We disable extended timeout if we enable ACKs
             extended_timeout = False
 
-        route_status_handler_future: asyncio.Future | None = None
-
         async with self._limit_concurrency(priority=packet.priority):
             message_tag = self.get_sequence()
             pending_tag = (packet.dst.address, message_tag)
@@ -895,17 +892,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             message_tag=message_tag,
                             data=packet.data.serialize(),
                         )
-
-                        if (
-                            packet.extended_timeout
-                            and zigpy.types.TransmitOptions.ACK not in packet.tx_options
-                        ):
-                            route_status_handler_future = (
-                                asyncio.get_running_loop().create_future()
-                            )
-                            self._request_status_handlers[packet.dst.address].append(
-                                route_status_handler_future
-                            )
                     elif packet.dst.addr_mode == zigpy.types.AddrMode.Group:
                         status, _ = await self._ezsp.send_multicast(
                             aps_frame=aps_frame,
@@ -924,50 +910,29 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             data=packet.data.serialize(),
                         )
 
-                try:
-                    if status != t.sl_Status.OK:
-                        raise zigpy.exceptions.DeliveryError(
-                            f"Failed to enqueue message: {status!r}", status
-                        )
+                if status != t.sl_Status.OK:
+                    raise zigpy.exceptions.DeliveryError(
+                        f"Failed to enqueue message: {status!r}", status
+                    )
 
-                    # Only throw a delivery exception for packets sent with NWK addressing.
-                    # https://github.com/home-assistant/core/issues/79832
-                    # Broadcasts/multicasts don't have ACKs or confirmations either.
-                    if packet.dst.addr_mode != zigpy.types.AddrMode.NWK:
-                        return
+                # Only throw a delivery exception for packets sent with NWK addressing.
+                # https://github.com/home-assistant/core/issues/79832
+                # Broadcasts/multicasts don't have ACKs or confirmations either.
+                if packet.dst.addr_mode != zigpy.types.AddrMode.NWK:
+                    return
 
-                    # Wait for `messageSentHandler` message
-                    async with asyncio_timeout(
-                        MESSAGE_SEND_TIMEOUT_MAINS
-                        if not packet.extended_timeout
-                        else MESSAGE_SEND_TIMEOUT_BATTERY
-                    ):
-                        send_status, _ = await req.result
+                # Wait for `messageSentHandler` message
+                async with asyncio_timeout(
+                    MESSAGE_SEND_TIMEOUT_MAINS
+                    if not packet.extended_timeout
+                    else MESSAGE_SEND_TIMEOUT_BATTERY
+                ):
+                    send_status, _ = await req.result
 
-                    if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
-                        raise zigpy.exceptions.DeliveryError(
-                            f"Failed to deliver message: {send_status!r}", send_status
-                        )
-
-                    if route_status_handler_future is None:
-                        return
-
-                    try:
-                        async with asyncio_timeout(MESSAGE_SEND_TIMEOUT_BATTERY):
-                            route_status = await route_status_handler_future
-                    except asyncio.TimeoutError:
-                        route_status = None
-
-                    if route_status is not None:
-                        raise zigpy.exceptions.DeliveryError(
-                            f"Received a routing error: {route_status!r}", route_status
-                        )
-                finally:
-                    if route_status_handler_future is not None:
-                        with contextlib.suppress(ValueError):
-                            self._request_status_handlers[packet.dst.address].remove(
-                                route_status_handler_future
-                            )
+                if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
+                    raise zigpy.exceptions.DeliveryError(
+                        f"Failed to deliver message: {send_status!r}", send_status
+                    )
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""
@@ -1088,9 +1053,3 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     def handle_route_error(self, status: t.sl_Status, nwk: t.EmberNodeId) -> None:
         LOGGER.debug("Processing route error: status=%s, nwk=%s", status, nwk)
-
-        handlers = self._request_status_handlers[nwk]
-        if not handlers:
-            return
-
-        handlers.popleft().set_result(status)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -81,7 +81,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         {zigpy.config.CONF_DEVICE_BAUDRATE: 57600},
     ]
 
-    def __init__(self, config: dict):
+    def __init__(self, config: dict) -> None:
         super().__init__(config)
         self._ctrl_event = asyncio.Event()
         self._created_device_endpoints: list[zdo_t.SimpleDescriptor] = []
@@ -1029,3 +1029,25 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     def handle_route_error(self, status: t.sl_Status, nwk: t.EmberNodeId) -> None:
         LOGGER.debug("Processing route error: status=%s, nwk=%s", status, nwk)
+
+        try:
+            device = self.get_device(nwk=nwk)
+        except KeyError:
+            return
+
+        # XXX: We cannot handle routing errors directly if there is more than a single
+        # pending request. Should we delay this matching for 500ms to be able to fix
+        # this?
+        if len(device._pending) != 1:
+            LOGGER.debug(
+                "Device has %d pending requests, cannot uniquely assign error",
+                len(device._pending),
+            )
+            return
+
+        key = list(device._pending.keys())[0]
+        exc = zigpy.exceptions.DeliveryError(
+            f"Received a routing error: {status!r}", status
+        )
+
+        device._pending[key].result.set_exception(exc)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict, deque
+import contextlib
 from datetime import datetime, timezone
 import logging
 import os
@@ -946,9 +947,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         )
                 finally:
                     if route_status_handler_future is not None:
-                        self._request_status_handlers[packet.dst.address].remove(
-                            route_status_handler_future
-                        )
+                        with contextlib.suppress(ValueError):
+                            self._request_status_handlers[packet.dst.address].remove(
+                                route_status_handler_future
+                            )
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
         """Permit joining."""
@@ -1066,6 +1068,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             "Processing route record request: %s", (nwk, ieee, lqi, rssi, relays)
         )
         self.handle_relays(nwk=nwk, relays=relays)
+
+        handlers = self._request_status_handlers[nwk]
+        if not handlers:
+            return
+
+        handlers.popleft().set_result(None)
 
     def handle_route_error(self, status: t.sl_Status, nwk: t.EmberNodeId) -> None:
         LOGGER.debug("Processing route error: status=%s, nwk=%s", status, nwk)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections import defaultdict, deque
 from datetime import datetime, timezone
 import logging
 import os
@@ -97,9 +96,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         self._req_lock = asyncio.Lock()
         self._packet_capture_channel: int | None = None
-        self._request_status_handlers: defaultdict[
-            t.EmberNodeId, deque[asyncio.Future]
-        ] = defaultdict(deque)
 
     @property
     def controller_event(self):

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -933,8 +933,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         )
 
                     # Only wait for routing status notifications for messages sent
-                    # indirectly
-                    if not packet.extended_timeout:
+                    # indirectly, ignoring the coordinator
+                    if (
+                        not packet.extended_timeout
+                        or packet.dst.address == self.state.node_info.nwk
+                    ):
                         return
 
                     try:

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict, deque
 from datetime import datetime, timezone
 import logging
 import os
@@ -43,7 +44,11 @@ from bellows.zigbee import repairs
 from bellows.zigbee.device import EZSPEndpoint, EZSPGroupEndpoint
 import bellows.zigbee.util as util
 
-APS_ACK_TIMEOUT = 120
+APS_ACK_TIMEOUT = 8
+
+ROUTE_STATUS_TIMEOUT_MAINS = 0.5
+ROUTE_STATUS_TIMEOUT_BATTERY = 8
+
 COUNTER_EZSP_BUFFERS = "EZSP_FREE_BUFFERS"
 COUNTER_NWK_CONFLICTS = "nwk_conflicts"
 COUNTER_RESET_REQ = "reset_requests"
@@ -94,6 +99,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         self._req_lock = asyncio.Lock()
         self._packet_capture_channel: int | None = None
+        self._request_status_handlers: defaultdict[
+            t.EmberNodeId, deque[asyncio.Future]
+        ] = defaultdict(deque)
 
     @property
     def controller_event(self):
@@ -837,6 +845,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # Source routing uses address discovery to discover routes
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
 
+        route_status_handler_future: asyncio.Future | None = None
+
         async with self._limit_concurrency(priority=packet.priority):
             message_tag = self.get_sequence()
             pending_tag = (packet.dst.address, message_tag)
@@ -874,6 +884,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             message_tag=message_tag,
                             data=packet.data.serialize(),
                         )
+
+                        route_status_handler_future = (
+                            asyncio.get_running_loop().create_future()
+                        )
+                        self._request_status_handlers[packet.dst.address].append(
+                            route_status_handler_future
+                        )
                     elif packet.dst.addr_mode == zigpy.types.AddrMode.Group:
                         status, _ = await self._ezsp.send_multicast(
                             aps_frame=aps_frame,
@@ -892,15 +909,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                             data=packet.data.serialize(),
                         )
 
-                if status != t.sl_Status.OK:
-                    raise zigpy.exceptions.DeliveryError(
-                        f"Failed to enqueue message: {status!r}", status
-                    )
+                try:
+                    if status != t.sl_Status.OK:
+                        raise zigpy.exceptions.DeliveryError(
+                            f"Failed to enqueue message: {status!r}", status
+                        )
 
-                # Only throw a delivery exception for packets sent with NWK addressing.
-                # https://github.com/home-assistant/core/issues/79832
-                # Broadcasts/multicasts don't have ACKs or confirmations either.
-                if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
+                    # Only throw a delivery exception for packets sent with NWK addressing.
+                    # https://github.com/home-assistant/core/issues/79832
+                    # Broadcasts/multicasts don't have ACKs or confirmations either.
+                    if packet.dst.addr_mode != zigpy.types.AddrMode.NWK:
+                        return
+
                     # Wait for `messageSentHandler` message
                     async with asyncio_timeout(APS_ACK_TIMEOUT):
                         send_status, _ = await req.result
@@ -908,6 +928,26 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     if t.sl_Status.from_ember_status(send_status) != t.sl_Status.OK:
                         raise zigpy.exceptions.DeliveryError(
                             f"Failed to deliver message: {send_status!r}", send_status
+                        )
+
+                    try:
+                        async with asyncio_timeout(
+                            ROUTE_STATUS_TIMEOUT_BATTERY
+                            if packet.extended_timeout
+                            else ROUTE_STATUS_TIMEOUT_MAINS
+                        ):
+                            route_status = await route_status_handler_future
+                    except asyncio.TimeoutError:
+                        route_status = None
+
+                    if route_status is not None:
+                        raise zigpy.exceptions.DeliveryError(
+                            f"Received a routing error: {route_status!r}", route_status
+                        )
+                finally:
+                    if route_status_handler_future is not None:
+                        self._request_status_handlers[packet.dst.address].remove(
+                            route_status_handler_future
                         )
 
     async def permit(self, time_s: int = 60, node: t.EmberNodeId = None) -> None:
@@ -1030,24 +1070,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     def handle_route_error(self, status: t.sl_Status, nwk: t.EmberNodeId) -> None:
         LOGGER.debug("Processing route error: status=%s, nwk=%s", status, nwk)
 
-        try:
-            device = self.get_device(nwk=nwk)
-        except KeyError:
+        handlers = self._request_status_handlers[nwk]
+        if not handlers:
             return
 
-        # XXX: We cannot handle routing errors directly if there is more than a single
-        # pending request. Should we delay this matching for 500ms to be able to fix
-        # this?
-        if len(device._pending) != 1:
-            LOGGER.debug(
-                "Device has %d pending requests, cannot uniquely assign error",
-                len(device._pending),
-            )
-            return
-
-        key = list(device._pending.keys())[0]
-        exc = zigpy.exceptions.DeliveryError(
-            f"Received a routing error: {status!r}", status
-        )
-
-        device._pending[key].result.set_exception(exc)
+        handlers.popleft().set_result(status)

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -846,6 +846,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             # Source routing uses address discovery to discover routes
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
 
+        extended_timeout = packet.extended_timeout
+
+        # EmberZNet requires retrying to enable APS ACKs
+        if (
+            zigpy.types.TransmitOptions.ACK in packet.tx_options
+            and packet.dst.addr_mode == zigpy.types.AddrMode.NWK
+        ):
+            aps_frame.options |= t.EmberApsOption.APS_OPTION_RETRY
+
+            # We disable extended timeout if we enable ACKs
+            extended_timeout = False
+
         route_status_handler_future: asyncio.Future | None = None
 
         async with self._limit_concurrency(priority=packet.priority):
@@ -854,11 +866,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             with self._pending.new(pending_tag) as req:
                 async with self._req_lock:
                     if packet.dst.addr_mode == zigpy.types.AddrMode.NWK:
-                        if packet.extended_timeout and device is not None:
+                        if device is not None:
                             await self._ezsp.set_extended_timeout(
                                 nwk=device.nwk,
                                 ieee=device.ieee,
-                                extended_timeout=True,
+                                extended_timeout=extended_timeout,
                             )
 
                         if packet.source_route is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "click-log>=0.2.1",
     "voluptuous",
-    "zigpy>=0.75.0",
+    "zigpy>=0.78.0",
     'async-timeout; python_version<"3.11"',
 ]
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -977,29 +977,6 @@ async def test_send_packet_unicast_routing_error(
         )
 
 
-async def test_send_packet_unicast_routing_error_indirect(
-    app: ControllerApplication, packet
-) -> None:
-    with pytest.raises(zigpy.exceptions.DeliveryError):
-        asyncio.get_running_loop().call_later(
-            0.03,
-            app.ezsp_callback_handler,
-            "incomingRouteErrorHandler",
-            [t.EmberStatus.MAC_INDIRECT_TIMEOUT, packet.dst.address],
-        )
-
-        await _test_send_packet_unicast(
-            app,
-            # Without APS ACKs, we rely on route failures to notify of errors
-            packet.replace(
-                extended_timeout=True, tx_options=zigpy_t.TransmitOptions.NONE
-            ),
-            options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
-            status=t.EmberStatus.SUCCESS,
-            sent_handler_status=t.EmberStatus.SUCCESS,
-        )
-
-
 async def test_send_packet_unicast_concurrency(app, packet, monkeypatch):
     monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_MAINS", 0.5)
     monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_BATTERY", 0.5)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -738,31 +738,25 @@ async def _test_send_packet_unicast(
     app,
     packet,
     *,
-    statuses=(bellows.types.sl_Status.OK,),
+    status=bellows.types.sl_Status.OK,
     options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
 ):
     def send_unicast(*args, **kwargs):
-        nonlocal statuses
-
-        status = statuses[0]
-        statuses = statuses[1:]
-
-        if not statuses:
-            asyncio.get_running_loop().call_later(
-                0.01,
-                app.ezsp_callback_handler,
-                "messageSentHandler",
-                list(
-                    dict(
-                        type=t.EmberOutgoingMessageType.OUTGOING_DIRECT,
-                        indexOrDestination=0x1234,
-                        apsFrame=sentinel.aps,
-                        messageTag=sentinel.msg_tag,
-                        status=status,
-                        message=b"",
-                    ).values()
-                ),
-            )
+        asyncio.get_running_loop().call_later(
+            0.01,
+            app.ezsp_callback_handler,
+            "messageSentHandler",
+            list(
+                dict(
+                    type=t.EmberOutgoingMessageType.OUTGOING_DIRECT,
+                    indexOrDestination=0x1234,
+                    apsFrame=sentinel.aps,
+                    messageTag=sentinel.msg_tag,
+                    status=status,
+                    message=b"",
+                ).values()
+            ),
+        )
 
         return [status, 0x12]
 
@@ -771,12 +765,9 @@ async def _test_send_packet_unicast(
     )
     app.get_sequence = MagicMock(return_value=sentinel.msg_tag)
 
-    expected_unicast_calls = len(statuses)
-
     await app.send_packet(packet)
-    assert app._ezsp.send_unicast.call_count == expected_unicast_calls
 
-    assert app._ezsp.send_unicast.mock_calls[-1] == (
+    assert app._ezsp.send_unicast.mock_calls == [
         call(
             nwk=t.EmberNodeId(0x1234),
             aps_frame=t.EmberApsFrame(
@@ -791,7 +782,7 @@ async def _test_send_packet_unicast(
             message_tag=sentinel.msg_tag,
             data=b"some data",
         )
-    )
+    ]
 
     assert len(app._pending) == 0
 
@@ -902,17 +893,13 @@ async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
 
 async def test_send_packet_unicast_unexpected_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
-        await _test_send_packet_unicast(
-            app, packet, statuses=(t.EmberStatus.ERR_FATAL,)
-        )
+        await _test_send_packet_unicast(app, packet, status=t.EmberStatus.ERR_FATAL)
 
 
 async def test_send_packet_unicast_retries_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await _test_send_packet_unicast(
-            app,
-            packet,
-            statuses=(bellows.types.sl_Status.ALLOCATION_FAILED,) * 3,
+            app, packet, status=bellows.types.sl_Status.ALLOCATION_FAILED
         )
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -739,7 +739,10 @@ async def _test_send_packet_unicast(
     packet,
     *,
     status=bellows.types.sl_Status.OK,
-    options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
+    options=(
+        t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
+        | t.EmberApsOption.APS_OPTION_RETRY
+    ),
 ):
     def send_unicast(*args, **kwargs):
         asyncio.get_running_loop().call_later(
@@ -829,7 +832,10 @@ async def test_send_packet_unicast_source_route(make_app, packet):
     await _test_send_packet_unicast(
         app,
         packet,
-        options=t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY,
+        options=(
+            t.EmberApsOption.APS_OPTION_RETRY
+            | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+        ),
     )
 
     app._ezsp._protocol.set_source_route.assert_called_once_with(
@@ -856,7 +862,10 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
     await _test_send_packet_unicast(
         app,
         packet,
-        options=t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY,
+        options=(
+            t.EmberApsOption.APS_OPTION_RETRY
+            | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+        ),
     )
 
     app._ezsp.xncp_set_manual_source_route.assert_called_once_with(
@@ -865,7 +874,7 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
     )
 
 
-async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
+async def test_send_packet_unicast_extended_timeout_with_acks(app, ieee, packet):
     app.add_device(nwk=packet.dst.address, ieee=ieee)
 
     asyncio.get_running_loop().call_later(
@@ -883,9 +892,44 @@ async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
 
     await _test_send_packet_unicast(
         app,
-        packet.replace(extended_timeout=True),
+        packet.replace(
+            extended_timeout=True,
+            tx_options=zigpy.types.TransmitOptions.ACK,
+        ),
     )
 
+    # With APS ACK, we do not use extended timeouts
+    assert app._ezsp._protocol.set_extended_timeout.mock_calls == [
+        call(nwk=packet.dst.address, ieee=ieee, extended_timeout=False)
+    ]
+
+
+async def test_send_packet_unicast_extended_timeout_without_acks(app, ieee, packet):
+    app.add_device(nwk=packet.dst.address, ieee=ieee)
+
+    asyncio.get_running_loop().call_later(
+        0.1,
+        app.ezsp_callback_handler,
+        "incomingRouteRecordHandler",
+        {
+            "source": packet.dst.address,
+            "sourceEui": ieee,
+            "lastHopLqi": 123,
+            "lastHopRssi": -60,
+            "relayList": [0x1234],
+        }.values(),
+    )
+
+    await _test_send_packet_unicast(
+        app,
+        packet.replace(
+            extended_timeout=True,
+            tx_options=zigpy.types.TransmitOptions.NONE,
+        ),
+        options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
+    )
+
+    # Without APS ACKs, we can
     assert app._ezsp._protocol.set_extended_timeout.mock_calls == [
         call(nwk=packet.dst.address, ieee=ieee, extended_timeout=True)
     ]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -977,6 +977,29 @@ async def test_send_packet_unicast_routing_error(
         )
 
 
+async def test_send_packet_unicast_routing_error_indirect(
+    app: ControllerApplication, packet
+) -> None:
+    with pytest.raises(zigpy.exceptions.DeliveryError):
+        asyncio.get_running_loop().call_later(
+            0.03,
+            app.ezsp_callback_handler,
+            "incomingRouteErrorHandler",
+            [t.EmberStatus.MAC_INDIRECT_TIMEOUT, packet.dst.address],
+        )
+
+        await _test_send_packet_unicast(
+            app,
+            # Without APS ACKs, we rely on route failures to notify of errors
+            packet.replace(
+                extended_timeout=True, tx_options=zigpy_t.TransmitOptions.NONE
+            ),
+            options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
+            status=t.EmberStatus.SUCCESS,
+            sent_handler_status=t.EmberStatus.SUCCESS,
+        )
+
+
 async def test_send_packet_unicast_concurrency(app, packet, monkeypatch):
     monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_MAINS", 0.5)
     monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_BATTERY", 0.5)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -739,10 +739,7 @@ async def _test_send_packet_unicast(
     packet,
     *,
     statuses=(bellows.types.sl_Status.OK,),
-    options=(
-        t.EmberApsOption.APS_OPTION_RETRY
-        | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
-    ),
+    options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
 ):
     def send_unicast(*args, **kwargs):
         nonlocal statuses
@@ -841,10 +838,7 @@ async def test_send_packet_unicast_source_route(make_app, packet):
     await _test_send_packet_unicast(
         app,
         packet,
-        options=(
-            t.EmberApsOption.APS_OPTION_RETRY
-            | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
-        ),
+        options=t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY,
     )
 
     app._ezsp._protocol.set_source_route.assert_called_once_with(
@@ -871,10 +865,7 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
     await _test_send_packet_unicast(
         app,
         packet,
-        options=(
-            t.EmberApsOption.APS_OPTION_RETRY
-            | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
-        ),
+        options=t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY,
     )
 
     app._ezsp.xncp_set_manual_source_route.assert_called_once_with(
@@ -886,6 +877,19 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
 async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
     app.add_device(nwk=packet.dst.address, ieee=ieee)
 
+    asyncio.get_running_loop().call_later(
+        0.1,
+        app.ezsp_callback_handler,
+        "incomingRouteRecordHandler",
+        {
+            "source": packet.dst.address,
+            "sourceEui": ieee,
+            "lastHopLqi": 123,
+            "lastHopRssi": -60,
+            "relayList": [0x1234],
+        }.values(),
+    )
+
     await _test_send_packet_unicast(
         app,
         packet.replace(extended_timeout=True),
@@ -896,19 +900,6 @@ async def test_send_packet_unicast_extended_timeout(app, ieee, packet):
     ]
 
 
-@patch("bellows.zigbee.application.RETRY_DELAYS", [0.01, 0.01, 0.01])
-async def test_send_packet_unicast_retries_success(app, packet):
-    await _test_send_packet_unicast(
-        app,
-        packet,
-        statuses=(
-            bellows.types.sl_Status.ALLOCATION_FAILED,
-            bellows.types.sl_Status.ALLOCATION_FAILED,
-            bellows.types.sl_Status.OK,
-        ),
-    )
-
-
 async def test_send_packet_unicast_unexpected_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await _test_send_packet_unicast(
@@ -916,17 +907,12 @@ async def test_send_packet_unicast_unexpected_failure(app, packet):
         )
 
 
-@patch("bellows.zigbee.application.RETRY_DELAYS", [0.01, 0.01, 0.01])
 async def test_send_packet_unicast_retries_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await _test_send_packet_unicast(
             app,
             packet,
-            statuses=(
-                bellows.types.sl_Status.ALLOCATION_FAILED,
-                bellows.types.sl_Status.ALLOCATION_FAILED,
-                bellows.types.sl_Status.ALLOCATION_FAILED,
-            ),
+            statuses=(bellows.types.sl_Status.ALLOCATION_FAILED,) * 3,
         )
 
 
@@ -1023,10 +1009,7 @@ async def test_send_packet_broadcast(app, packet):
                 clusterId=packet.cluster_id,
                 sourceEndpoint=packet.src_ep,
                 destinationEndpoint=packet.dst_ep,
-                options=(
-                    t.EmberApsOption.APS_OPTION_RETRY
-                    | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
-                ),
+                options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
                 groupId=0x0000,
                 sequence=packet.tsn,
             ),
@@ -1074,10 +1057,7 @@ async def test_send_packet_broadcast_ignored_delivery_failure(app, packet):
                 clusterId=packet.cluster_id,
                 sourceEndpoint=packet.src_ep,
                 destinationEndpoint=packet.dst_ep,
-                options=(
-                    t.EmberApsOption.APS_OPTION_RETRY
-                    | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
-                ),
+                options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
                 groupId=0x0000,
                 sequence=packet.tsn,
             ),
@@ -1127,10 +1107,7 @@ async def test_send_packet_multicast(app, packet):
                 clusterId=packet.cluster_id,
                 sourceEndpoint=packet.src_ep,
                 destinationEndpoint=packet.dst_ep,
-                options=(
-                    t.EmberApsOption.APS_OPTION_RETRY
-                    | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
-                ),
+                options=t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY,
                 groupId=0x1234,
                 sequence=packet.tsn,
             ),

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -54,7 +54,12 @@ def make_app(monkeypatch, ieee):
         app._ezsp = _create_app_for_startup(
             app, nwk_type=t.EmberNodeType.COORDINATOR, ieee=ieee, **kwargs
         )
-        monkeypatch.setattr(bellows.zigbee.application, "APS_ACK_TIMEOUT", 0.05)
+        monkeypatch.setattr(
+            bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_MAINS", 0.05
+        )
+        monkeypatch.setattr(
+            bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_BATTERY", 0.05
+        )
         app._ctrl_event.set()
         app._in_flight_msg = asyncio.Semaphore()
         app.handle_message = MagicMock()
@@ -739,6 +744,7 @@ async def _test_send_packet_unicast(
     packet,
     *,
     status=bellows.types.sl_Status.OK,
+    sent_handler_status=bellows.types.sl_Status.OK,
     options=(
         t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
         | t.EmberApsOption.APS_OPTION_RETRY
@@ -755,7 +761,7 @@ async def _test_send_packet_unicast(
                     indexOrDestination=0x1234,
                     apsFrame=sentinel.aps,
                     messageTag=sentinel.msg_tag,
-                    status=status,
+                    status=sent_handler_status,
                     message=b"",
                 ).values()
             ),
@@ -947,8 +953,33 @@ async def test_send_packet_unicast_retries_failure(app, packet):
         )
 
 
+async def test_send_packet_unicast_delivery_failure_sent_handler(
+    app: ControllerApplication, packet
+) -> None:
+    with pytest.raises(zigpy.exceptions.DeliveryError):
+        await _test_send_packet_unicast(
+            app,
+            packet,
+            status=t.EmberStatus.SUCCESS,
+            sent_handler_status=t.EmberStatus.DELIVERY_FAILED,
+        )
+
+
+async def test_send_packet_unicast_routing_error(
+    app: ControllerApplication, packet
+) -> None:
+    with pytest.raises(zigpy.exceptions.DeliveryError):
+        await _test_send_packet_unicast(
+            app,
+            packet,
+            status=t.EmberStatus.SUCCESS,
+            sent_handler_status=t.EmberStatus.DELIVERY_FAILED,
+        )
+
+
 async def test_send_packet_unicast_concurrency(app, packet, monkeypatch):
-    monkeypatch.setattr(bellows.zigbee.application, "APS_ACK_TIMEOUT", 0.5)
+    monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_MAINS", 0.5)
+    monkeypatch.setattr(bellows.zigbee.application, "MESSAGE_SEND_TIMEOUT_BATTERY", 0.5)
 
     app._concurrent_requests_semaphore.max_value = 10
 


### PR DESCRIPTION
This removes the EmberZNet `APS_OPTION_RETRY` flag and moves retries into zigpy. A simple patch to zigpy is required: https://github.com/zigpy/zigpy/compare/dev...puddly:zigpy:puddly/application-level-retries

This will allow us to provide slightly more useful error codes (e.g. `MAC_INDIRECT_TIMEOUT`) and unblock the implicit transmit queue for each device, which can get blocked for 30+ seconds per request.

One issue with this type of introspection is that there genuinely *aren't* more status codes to return to the user: other than channel access failures or a missed APS ACK (which EmberZNet doesn't allow you to enable!), failures during delivery more or less are just that. Unless a routing device decides to broadcast a routing failure status (e.g. just `MAC_INDIRECT_TIMEOUT`), we really have no way to determine why an *individual* request failed like this. I'm working around this issue by just blindly assuming that status codes are received in the order the request was sent out. Realistically, I don't think it matters because two requests sent at the same time likely will both fail or both succeed.

I'm testing this change locally without any issues, even with intentionally disconnected devices (both mains-powered and battery-powered), so I think this approach may have promise.