### PR TITLE
Autoprobe with 460800 baud

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -80,6 +80,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     _watchdog_period = 10
     _probe_configs = [
         {zigpy.config.CONF_DEVICE_BAUDRATE: 115200},
+        {zigpy.config.CONF_DEVICE_BAUDRATE: 460800},
         {zigpy.config.CONF_DEVICE_BAUDRATE: 57600},
     ]
 


### PR DESCRIPTION
I'm going to be using 460800 baud for newer adapters.

57600 is used by I think one or two sticks, I wonder if it's time to drop it? Right now autoprobing is quite slow due to the sheer number of combinations.