### PR TITLE
Handle bad values in XNCP chip info parsing

### DIFF
--- a/bellows/exception.py
+++ b/bellows/exception.py
@@ -9,6 +9,12 @@ class InvalidCommandError(EzspError):
     pass
 
 
+class InvalidCommandPayload(InvalidCommandError):
+    def __init__(self, msg: str, raw_bytes: bytes) -> None:
+        super().__init__(msg)
+        self.raw_bytes = raw_bytes
+
+
 class ControllerError(ControllerException):
     pass
 

--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -22,7 +22,7 @@ else:
 import zigpy.config
 
 import bellows.config as conf
-from bellows.exception import EzspError, InvalidCommandError
+from bellows.exception import EzspError, InvalidCommandError, InvalidCommandPayload
 from bellows.ezsp import xncp
 from bellows.ezsp.config import DEFAULT_CONFIG, RuntimeConfig, ValueConfig
 from bellows.ezsp.xncp import FirmwareFeatures, FlowControlType
@@ -736,7 +736,9 @@ class EZSP:
         try:
             rsp_frame = xncp.XncpCommand.from_bytes(data)
         except ValueError:
-            raise InvalidCommandError(f"Invalid XNCP response: {data!r}")
+            raise InvalidCommandPayload(
+                f"Invalid XNCP response: {data!r}", raw_bytes=data
+            )
 
         if isinstance(rsp_frame.payload, xncp.Unknown):
             raise InvalidCommandError(f"XNCP firmware does not support {payload}")
@@ -781,7 +783,15 @@ class EZSP:
 
     async def xncp_get_chip_info(self) -> xncp.GetChipInfoRsp:
         """Get the part number."""
-        return await self.send_xncp_frame(xncp.GetChipInfoReq())
+
+        try:
+            return await self.send_xncp_frame(xncp.GetChipInfoReq())
+        except InvalidCommandPayload:
+            # Beta firmwares had a bug with this command
+            return xncp.GetChipInfoRsp(
+                ram_size=262144,
+                part_number="EFR32MG24A420F1536IM40",
+            )
 
     async def get_default_adapter_concurrency(self) -> int:
         """Get the recommended concurrency based on chip information."""

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -10,7 +10,7 @@ import zigpy.config
 
 from bellows import config, uart
 from bellows.ash import NcpFailure
-from bellows.exception import EzspError, InvalidCommandError
+from bellows.exception import EzspError, InvalidCommandError, InvalidCommandPayload
 from bellows.ezsp import EZSP, EZSP_LATEST, xncp
 import bellows.types as t
 
@@ -989,6 +989,30 @@ async def test_xncp_get_chip_info(ezsp_f):
         result = await ezsp_f.xncp_get_chip_info()
 
     assert result == expected_response
+    assert mock_send.mock_calls == [call(xncp.GetChipInfoReq())]
+
+
+async def test_xncp_get_chip_info_invalid_payload_fallback(ezsp_f):
+    """Test graceful fallback when chip info command returns invalid payload."""
+    ezsp_f._xncp_features = xncp.FirmwareFeatures.CHIP_INFO
+
+    with patch.object(
+        ezsp_f,
+        "send_xncp_frame",
+        new=AsyncMock(
+            side_effect=InvalidCommandPayload(
+                "Invalid XNCP response: b'\\x05\\x80\\x02'", b"\x05\x80\x02"
+            )
+        ),
+    ) as mock_send:
+        result = await ezsp_f.xncp_get_chip_info()
+
+    # Should return fallback response for beta firmware bug
+    assert result == xncp.GetChipInfoRsp(
+        ram_size=262144,
+        part_number="EFR32MG24A420F1536IM40",
+    )
+
     assert mock_send.mock_calls == [call(xncp.GetChipInfoReq())]
 
 


### PR DESCRIPTION
Some test firmwares with a broken implementation of this command are out in the wild, preventing ZHA startup. This works around the startup issue.