### PR TITLE
Send three resets when connecting, not just one

### DIFF
--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -715,4 +715,8 @@ class AshProtocol(asyncio.Protocol):
         )
 
     def send_reset(self) -> None:
+        # Some adapters seem to send a NAK immediately but still process the reset frame
+        # if one eventually makes it through
+        self._write_frame(RstFrame(), prefix=(Reserved.CANCEL,))
+        self._write_frame(RstFrame(), prefix=(Reserved.CANCEL,))
         self._write_frame(RstFrame(), prefix=(Reserved.CANCEL,))

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -438,7 +438,10 @@ async def test_ash_protocol_startup(caplog):
 
     assert ezsp.reset_received.mock_calls == [call(t.NcpResetCode.RESET_SOFTWARE)]
     assert protocol._write_frame.mock_calls == [
-        call(ash.RstFrame(), prefix=(ash.Reserved.CANCEL,))
+        # We send three
+        call(ash.RstFrame(), prefix=(ash.Reserved.CANCEL,)),
+        call(ash.RstFrame(), prefix=(ash.Reserved.CANCEL,)),
+        call(ash.RstFrame(), prefix=(ash.Reserved.CANCEL,)),
     ]
 
     protocol._write_frame.reset_mock()


### PR DESCRIPTION
Some devices, like the ZBT-2, send a single NAK if you connect to them immediately after the firmware starts. Sending more than one reset frame seems to flush enough buffers to "break through" and properly reset the device on the first try.