### PR TITLE
Reduce `RST` cancel prefix to 32 bytes

### DIFF
--- a/bellows/ash.py
+++ b/bellows/ash.py
@@ -719,4 +719,4 @@ class AshProtocol(asyncio.Protocol):
 
     def send_reset(self) -> None:
         # Some adapters seem to send a NAK immediately but still process the reset frame
-        self._write_frame(RstFrame(), prefix=40 * (Reserved.CANCEL,))
+        self._write_frame(RstFrame(), prefix=32 * (Reserved.CANCEL,))

--- a/tests/test_ash.py
+++ b/tests/test_ash.py
@@ -438,7 +438,7 @@ async def test_ash_protocol_startup(caplog):
 
     assert ezsp.reset_received.mock_calls == [call(t.NcpResetCode.RESET_SOFTWARE)]
     assert protocol._write_frame.mock_calls == [
-        call(ash.RstFrame(), prefix=40 * (ash.Reserved.CANCEL,))
+        call(ash.RstFrame(), prefix=32 * (ash.Reserved.CANCEL,))
     ]
 
     protocol._write_frame.reset_mock()


### PR DESCRIPTION
40 bytes for some reason is inconsistent upon more thorough testing, 32 does not have this problem.