### PR TITLE
Move `ezspVersion` key to correct place for Z2M

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -409,9 +409,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     "flow_control": (
                         flow_control.name.lower() if flow_control is not None else None
                     ),
-                    # Z2M will not load EZSP backups without this internal key
-                    "ezspVersion": ezsp.ezsp_version,
                 },
+                # Z2M will not load EZSP backups without this internal key
+                "ezspVersion": ezsp.ezsp_version,
             },
         )
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2089,8 +2089,8 @@ def zigpy_backup() -> zigpy.backups.NetworkBackup:
                     "can_burn_userdata_custom_eui64": True,
                     "can_rewrite_custom_eui64": True,
                     "chip_info": None,
-                    "ezspVersion": 8,
-                }
+                },
+                "ezspVersion": 8,
             },
         ),
     )


### PR DESCRIPTION
This fixes an issue where the `eszpVersion` is not in the correct place for Z2M, leading to "Current backup file is not for EmberZNet" issues when starting Z2M with a zigpy `coordinator_backup.json`.

Currently, the `ezspVersion` lands in `metadata.internal.ezsp` when converted to the ~~open coordinator~~ Z2M backup format.
But it should directly be in `metadata.internal` instead. For us, that means we'll need to move it out from the `ezsp` key, directly into `metadata`, as that'll later become `metadata.internal` when converted to Z2M's backup format.

Follow-up to this PR/comment (though I missed this at the time):
- https://github.com/zigpy/bellows/pull/693#discussion_r2462179569