### PR TITLE
Reduce log level of NV3 interface warning

### DIFF
--- a/bellows/zigbee/repairs.py
+++ b/bellows/zigbee/repairs.py
@@ -58,7 +58,7 @@ async def update_tx_power(ezsp: EZSP, tx_power: int) -> bool:
         rsp = await ezsp.getTokenData(token=t.NV3KeyId.NVM3KEY_STACK_NODE_DATA, index=0)
         assert t.sl_Status.from_ember_status(rsp.status) == t.sl_Status.OK
     except (InvalidCommandError, AttributeError, AssertionError):
-        LOGGER.warning("NV3 interface not available in this firmware, please upgrade!")
+        LOGGER.debug("NV3 interface not available in this firmware, please upgrade!")
         return False
 
     token, remaining = t.NV3StackNodeData.deserialize(rsp.value)

--- a/tests/test_zigbee_repairs.py
+++ b/tests/test_zigbee_repairs.py
@@ -190,7 +190,7 @@ async def test_update_tx_power(ezsp_f: EZSP, caplog) -> None:
 
     # Test 1: NV3 interface unavailable
     ezsp_f.getTokenData = AsyncMock(side_effect=InvalidCommandError())
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         assert await repairs.update_tx_power(ezsp_f, tx_power=10) is False
     assert "NV3 interface not available in this firmware" in caplog.text
 


### PR DESCRIPTION
When setting the TX power, adapters lacking the NV3 token interface will log a warning. This NV3 write technically isn't required, it just ensures the setting persists.

https://github.com/home-assistant/core/issues/157897