### PR TITLE
Fix fallback logic when starting up with an unsupported EZSP version

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -639,7 +639,8 @@ class EZSP:
         ezsp_config = {}
         ezsp_values = {}
 
-        for cfg in DEFAULT_CONFIG[self._ezsp_version]:
+        # If a protocol version is not explicitly supported, use config for the latest
+        for cfg in DEFAULT_CONFIG.get(self._ezsp_version, DEFAULT_CONFIG[EZSP_LATEST]):
             if isinstance(cfg, RuntimeConfig):
                 ezsp_config[cfg.config_id.name] = dataclasses.replace(
                     cfg, config_id=t.EzspConfigId[cfg.config_id.name]

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -951,6 +951,32 @@ async def test_cfg_initialize_skip():
         )
 
 
+@pytest.mark.parametrize("unsupported_version", [15, 18, 99])
+async def test_unsupported_ezsp_version_startup(unsupported_version: int, caplog):
+    """Test that startup works with an unsupported EZSP version."""
+    ezsp = make_ezsp(version=unsupported_version)
+
+    with patch("bellows.uart.connect"):
+        await ezsp.connect()
+
+    # The EZSP version should be stored as the unsupported version
+    assert ezsp._ezsp_version == unsupported_version
+
+    # But the protocol should fall back to the latest
+    assert ezsp._protocol.VERSION == EZSP_LATEST
+
+    assert f"Protocol version {unsupported_version} is not supported" in caplog.text
+
+    ezsp.getConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, 0))
+    ezsp.setConfigurationValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
+    ezsp.setValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS,))
+    ezsp.getValue = AsyncMock(return_value=(t.EzspStatus.SUCCESS, b"\xFF"))
+
+    # Startup should not fail
+    await ezsp.write_config({})
+    assert len(ezsp.setConfigurationValue.mock_calls) > 0
+
+
 async def test_reset_custom_eui64(ezsp_f):
     """Test resetting custom EUI64."""
     # No NV3 interface


### PR DESCRIPTION
I tested EZSPv18 a bit more thoroughly and while the frame format has indeed changed, it didn't actually change in any way that impacts bellows operation: it should have been supported by "falling back" to EZSPv17 parsing and logic.

ZHA startup fails because config writing tried to look up config for the exact version in our global config, which will fail. We should instead fall back to the latest version's config.

Should resolve https://github.com/home-assistant/core/issues/160051