### PR TITLE
Fix `xncp_set_manual_source_route` keyword arguments

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1042,8 +1042,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                                 ]
                             ):
                                 await self._ezsp.xncp_set_manual_source_route(
-                                    nwk=packet.dst.address,
-                                    relays=packet.source_route,
+                                    destination=packet.dst.address,
+                                    route=packet.source_route,
                                 )
                             else:
                                 await self._ezsp.set_source_route(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -899,7 +899,7 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
     app._ezsp._xncp_features |= FirmwareFeatures.MANUAL_SOURCE_ROUTE
 
     app._ezsp.xncp_set_manual_source_route = AsyncMock(
-        return_value=None, spec=app._ezsp._protocol.set_source_route
+        return_value=None, spec=app._ezsp.xncp_set_manual_source_route
     )
 
     packet.source_route = [0x0001, 0x0002]
@@ -913,8 +913,8 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
     )
 
     app._ezsp.xncp_set_manual_source_route.assert_called_once_with(
-        nwk=packet.dst.address,
-        relays=[0x0001, 0x0002],
+        destination=packet.dst.address,
+        route=[0x0001, 0x0002],
     )
 
 


### PR DESCRIPTION
## Proposed change

This makes **manual source routing*** work for the first time ever...? 😅 (by fixing the names of the provided kwargs).

(*: It's only supported on certain firmware builds and requires the `manual_source_routing` option to be turned on in the `bellows` section. This is not really related to the normal `source_routing` option.)

## Additional information

Firmware extensions (as well as the bug) were added with:
- https://github.com/zigpy/bellows/pull/611

### TODO

We should probably test the firmware side? Was that ever tested then?

## AI summary

The send-packet path called `xncp_set_manual_source_route` with `nwk=`/ `relays=` (the kwargs of the sibling `set_source_route`), but the XNCP wrapper takes `destination=`/`route=`. On firmware that advertises the `MANUAL_SOURCE_ROUTE` feature with manual source routing enabled, this raised `TypeError` instead of installing the route.

The existing test mocked the method against the wrong spec (`set_source_route`), so the bad kwargs validated and the bug went unnoticed. Re-spec the mock against `xncp_set_manual_source_route` so the assertion checks the real signature.