### PR TITLE
Use `RESCHEDULE` source route discovery mode

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -603,7 +603,7 @@ class EZSP:
         if self._ezsp_version >= 8:
             await self.setSourceRouteDiscoveryMode(
                 mode=(
-                    t.SourceRouteDiscoveryMode.ON
+                    t.SourceRouteDiscoveryMode.RESCHEDULE
                     if enabled
                     else t.SourceRouteDiscoveryMode.OFF
                 )

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -431,7 +431,7 @@ async def test_set_enable_source_routing(ezsp_f):
     assert len(ezsp_f.setSourceRouteDiscoveryMode.mock_calls) == 1
     assert (
         ezsp_f.setSourceRouteDiscoveryMode.mock_calls[0].kwargs["mode"]
-        == t.SourceRouteDiscoveryMode.ON
+        == t.SourceRouteDiscoveryMode.RESCHEDULE
     )
 
 


### PR DESCRIPTION
DRAFT/TODO: Check if we want this at startup.

## AI summary

`SourceRouteDiscoveryMode.ON` only schedules the *periodic* MTORR; it does not trigger an immediate broadcast. Devices joining or rejoining during the first interval after startup therefore have no source-route table entry on the NCP and fall back to AODV/route discovery — the opposite of what enabling the concentrator is meant to achieve. With `MTOR_MAX_INTERVAL` currently at 3600s, that gap can be up to an hour.

Per the SDK enum docs (`sl_zigbee_types.h` /
`ember-types.h`):

 * SL_ZIGBEE_SOURCE_ROUTE_DISCOVERY_OFF no source route discovery is scheduled
 * SL_ZIGBEE_SOURCE_ROUTE_DISCOVERY_ON source routes discovery is scheduled, and it is triggered periodically
 * SL_ZIGBEE_SOURCE_ROUTE_DISCOVERY_RESCHEDULE  source routes discoveries are re-scheduled to be sent once immediately and then triggered periodically

zigbee-herdsman's ember adapter uses `RESCHEDULE` for this reason. Switch bellows to match.