### PR TITLE
Log time until next MTORR broadcast for source routing

### DIFF
--- a/bellows/ezsp/__init__.py
+++ b/bellows/ezsp/__init__.py
@@ -601,12 +601,16 @@ class EZSP:
             LOGGER.warning("Couldn't set concentrator type %s: %s", True, res)
 
         if self._ezsp_version >= 8:
-            await self.setSourceRouteDiscoveryMode(
+            (remaining_ms,) = await self.setSourceRouteDiscoveryMode(
                 mode=(
                     t.SourceRouteDiscoveryMode.ON
                     if enabled
                     else t.SourceRouteDiscoveryMode.OFF
                 )
+            )
+            LOGGER.debug(
+                "Source route discovery: %d ms until next MTORR broadcast",
+                remaining_ms,
             )
 
     def start_ezsp(self):

--- a/tests/test_ezsp.py
+++ b/tests/test_ezsp.py
@@ -425,7 +425,7 @@ async def test_board_info(
 async def test_set_enable_source_routing(ezsp_f):
     """Test enabling source routing."""
     ezsp_f.setConcentrator = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
-    ezsp_f.setSourceRouteDiscoveryMode = AsyncMock()
+    ezsp_f.setSourceRouteDiscoveryMode = AsyncMock(return_value=(12345,))
 
     await ezsp_f.set_source_routing(enabled=True)
     assert len(ezsp_f.setSourceRouteDiscoveryMode.mock_calls) == 1
@@ -438,7 +438,7 @@ async def test_set_enable_source_routing(ezsp_f):
 async def test_set_disable_source_routing(ezsp_f):
     """Test disabling source routing."""
     ezsp_f.setConcentrator = AsyncMock(return_value=(t.EmberStatus.SUCCESS,))
-    ezsp_f.setSourceRouteDiscoveryMode = AsyncMock()
+    ezsp_f.setSourceRouteDiscoveryMode = AsyncMock(return_value=(0,))
 
     await ezsp_f.set_source_routing(enabled=False)
     assert len(ezsp_f.setSourceRouteDiscoveryMode.mock_calls) == 1


### PR DESCRIPTION
## AI summary

`setSourceRouteDiscoveryMode` returns a `uint32_t remainingTime` — the milliseconds until the next MTORR broadcast — but bellows was discarding it. Capture and log it at debug level. With the `RESCHEDULE` mode this is approximately the configured min-interval; the value makes startup behavior visible in logs and matches what zigbee-herdsman's ember adapter reports
("Started source route discovery. Xms until next broadcast.").