### PR TITLE
Also enable AODV route discovery on source-routed unicasts

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -991,8 +991,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             aps_frame.groupId = t.uint16_t(0x0000)
 
         if self.config[zigpy.config.CONF_SOURCE_ROUTING]:
-            # Source routing uses address discovery to discover routes
-            aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+            # Concentrator/source-routing uses address discovery; also keep AODV
+            # route discovery as a fallback for destinations that aren't yet in
+            # the NCP's source-route table (e.g. immediately after startup,
+            # before the first MTORR has propagated). Mirrors what
+            # zigbee-herdsman's ember adapter does for the same reason.
+            aps_frame.options |= (
+                t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+                | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
+            )
         elif zigpy.types.TransmitOptions.FORCE_ROUTE_DISCOVERY in packet.tx_options:
             # Forcing route discovery requires retrying
             aps_frame.options |= t.EmberApsOption.APS_OPTION_FORCE_ROUTE_DISCOVERY

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -879,6 +879,7 @@ async def test_send_packet_unicast_source_route(make_app, packet):
         options=(
             t.EmberApsOption.APS_OPTION_RETRY
             | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+            | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
         ),
     )
 
@@ -909,6 +910,7 @@ async def test_send_packet_unicast_manual_source_route(make_app, packet):
         options=(
             t.EmberApsOption.APS_OPTION_RETRY
             | t.EmberApsOption.APS_OPTION_ENABLE_ADDRESS_DISCOVERY
+            | t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
         ),
     )
 


### PR DESCRIPTION
DRAFT/TODO: Check this and tidy up AI comment.

I've been somewhat accidentally using this for years by turning on source routing in the zigpy config once, then disabling it. This still caused the coordinator to set source routes, but apparently it never refreshed the network addresses this way.

But only with this was source routing actually worth using in my network: as zigpy thought source routing to be off, it still set `APS_OPTION_ENABLE_ROUTE_DISCOVERY` as well.

According to some sources referencing "BUGZID 12261", this is supposedly incorrect. This should be looked at with more detail.


## AI summary (check if accurate)

When `CONF_SOURCE_ROUTING` is enabled, bellows previously set only `APS_OPTION_ENABLE_ADDRESS_DISCOVERY` on outgoing NWK unicasts. The two flags are independent and address different stack subsystems:

- `ENABLE_ROUTE_DISCOVERY` (NWK frame flag) — initiates AODV route discovery *if and only if* the stack has no known route to the destination (per `sl_zigbee_types.h`: "causes a route discovery to be initiated **if no route to the destination is known**"). Contrast with `FORCE_ROUTE_DISCOVERY` which initiates discovery unconditionally.
- `ENABLE_ADDRESS_DISCOVERY` (APS frame flag) — sends a ZDO `NWK_addr_req` to resolve the destination NWK ID from its EUI64 if not already cached. It does not discover routes; it resolves addresses.

When source routing is on but a destination isn't yet in the NCP's source-route table (e.g. immediately after startup, before MTORR has propagated, or after a device rejoin), the previous configuration left the stack with neither a source route nor permission to fall back to AODV. The packet was dropped at the NWK layer instead of recovering via on-demand route discovery.

This change makes source-routed unicasts also set `ENABLE_ROUTE_DISCOVERY`, mirroring what zigbee-herdsman's ember adapter does (`emberAdapter.ts` `DEFAULT_APS_OPTIONS`):

```ts
DEFAULT_APS_OPTIONS = RETRY | ENABLE_ROUTE_DISCOVERY | ENABLE_ADDRESS_DISCOVERY;
// "Removing ENABLE_ROUTE_DISCOVERY leads to devices that won't reconnect/go
//  offline, and various other issues."
```

## Why this is correct (source routing is still preferred)

`ENABLE_ROUTE_DISCOVERY` does not run alongside source routing on every send. The SDK header text is explicit: discovery happens "if no route is known." The stack's outbound path for a concentrator is:

1. `sl_zigbee_af_override_append_source_route_cb` runs first. If a source route exists for the destination, it's prepended to the NWK header and each hop along the way uses that explicit route. AODV is not consulted.
2. If no source route exists, the NWK route table is checked. If a previously discovered AODV route is there, it's used.
3. Only if both tables come up empty does the `ENABLE_ROUTE_DISCOVERY` flag actually trigger an AODV route request.

Net effect: source routing remains the primary path; AODV is engaged strictly as a fallback for destinations the source-route table doesn't yet know about.