### PR TITLE
Fix "Event loop is closed" race in EventLoopThread.force_stop

### DIFF
--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import functools
 import logging
 
@@ -65,11 +66,9 @@ class EventLoopThread:
             gather = asyncio.gather(*tasks, return_exceptions=True)
             gather.add_done_callback(lambda _: loop.call_soon_threadsafe(loop.stop))
 
-        try:
+        # The worker thread may close the loop after our is_closed() check.
+        with contextlib.suppress(RuntimeError):
             loop.call_soon_threadsafe(cancel_tasks_and_stop_loop)
-        except RuntimeError:  # pragma: no cover
-            # loop closed by the worker thread after our is_closed() check
-            pass
 
 
 class ThreadsafeProxy:

--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -52,21 +52,24 @@ class EventLoopThread:
         return thread_complete
 
     def force_stop(self):
-        if self.loop is None:
+        loop = self.loop
+        if loop is None or loop.is_closed():
             return
 
         def cancel_tasks_and_stop_loop():
-            tasks = asyncio.all_tasks(loop=self.loop)
+            tasks = asyncio.all_tasks(loop=loop)
 
             for task in tasks:
-                self.loop.call_soon_threadsafe(task.cancel)
+                loop.call_soon_threadsafe(task.cancel)
 
             gather = asyncio.gather(*tasks, return_exceptions=True)
-            gather.add_done_callback(
-                lambda _: self.loop.call_soon_threadsafe(self.loop.stop)
-            )
+            gather.add_done_callback(lambda _: loop.call_soon_threadsafe(loop.stop))
 
-        self.loop.call_soon_threadsafe(cancel_tasks_and_stop_loop)
+        try:
+            loop.call_soon_threadsafe(cancel_tasks_and_stop_loop)
+        except RuntimeError:  # pragma: no cover
+            # loop closed by the worker thread after our is_closed() check
+            pass
 
 
 class ThreadsafeProxy:


### PR DESCRIPTION
Independent of any feature work and pre-exists on `dev`; surfaced while stabilizing CI.

`tests/test_thread.py::test_thread_already_stopped` intermittently errors at teardown with
`RuntimeError: Event loop is closed` (observed on the 3.11/3.13 CI legs; passes on 3.12/3.14 and locally).

Root cause: the worker thread's `_thread_main` `finally` runs `self.loop.close()` and then `self.loop = None`
as two separate statements. `force_stop`'s `if self.loop is None` guard can therefore pass while the loop is
already closed, and the following `call_soon_threadsafe` raises.

Fix: snapshot `self.loop` into a local, also guard on `loop.is_closed()`, and swallow the `RuntimeError`
if the worker closes the loop after the check. The `is_closed()` guard is exercised by the existing
`test_thread_already_stopped`; the race-only `except` is marked `# pragma: no cover`.
