### PR TITLE
Support `APS_Encryption` transmit option

### DIFF
--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1000,6 +1000,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         else:
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
 
+        if zigpy.types.TransmitOptions.APS_Encryption in packet.tx_options:
+            # APS encryption uses the link key shared with the destination node
+            aps_frame.options |= t.EmberApsOption.APS_OPTION_ENCRYPTION
+
         extended_timeout = packet.extended_timeout
 
         # EmberZNet requires retrying to enable APS ACKs

--- a/bellows/zigbee/application.py
+++ b/bellows/zigbee/application.py
@@ -1001,7 +1001,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
 
         if zigpy.types.TransmitOptions.APS_Encryption in packet.tx_options:
-            # APS encryption uses the link key shared with the destination node
             aps_frame.options |= t.EmberApsOption.APS_OPTION_ENCRYPTION
 
         extended_timeout = packet.extended_timeout

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -990,6 +990,23 @@ async def test_send_packet_unicast_force_route_discovery(app, packet):
     )
 
 
+async def test_send_packet_unicast_aps_encryption(app, packet):
+    await _test_send_packet_unicast(
+        app,
+        packet.replace(
+            tx_options=(
+                zigpy.types.TransmitOptions.ACK
+                | zigpy.types.TransmitOptions.APS_Encryption
+            )
+        ),
+        options=(
+            t.EmberApsOption.APS_OPTION_ENABLE_ROUTE_DISCOVERY
+            | t.EmberApsOption.APS_OPTION_ENCRYPTION
+            | t.EmberApsOption.APS_OPTION_RETRY
+        ),
+    )
+
+
 async def test_send_packet_unicast_unexpected_failure(app, packet):
     with pytest.raises(zigpy.exceptions.DeliveryError):
         await _test_send_packet_unicast(app, packet, status=t.EmberStatus.ERR_FATAL)


### PR DESCRIPTION
Maps `zigpy.types.TransmitOptions.APS_Encryption` onto EmberZNet's `APS_OPTION_ENCRYPTION` APS frame option, so packets that require APS encryption (e.g. the Zigbee Direct Configuration cluster) are actually sent encrypted with the link key shared with the destination.

Related zigpy PR that requires this (but bellows doesn't require a new zigpy version):
- https://github.com/zigpy/zigpy/pull/1867