### PR TITLE
Fix gpepIncomingMessageHandler schema for EZSP v13+

### DIFF
--- a/bellows/ezsp/v13/commands.py
+++ b/bellows/ezsp/v13/commands.py
@@ -34,6 +34,29 @@ COMMANDS = {
             "number_of_entries": t.uint8_t,
         },
     ),
+    # Redefined: EmberZNet 7.x serializes EmberGpAddress as applicationId,
+    # an 8-byte id union, then endpoint, which the inherited schema predates.
+    "gpepIncomingMessageHandler": (
+        0x00C5,
+        {},
+        {
+            "status": t.uint8_t,
+            "gpdLink": t.uint8_t,
+            "sequenceNumber": t.uint8_t,
+            "applicationId": t.uint8_t,
+            "gpdIdUnion": t.FixedList[t.uint8_t, 8],
+            "endpoint": t.uint8_t,
+            "gpdfSecurityLevel": t.uint8_t,
+            "gpdfSecurityKeyType": t.uint8_t,
+            "autoCommissioning": t.Bool,
+            "bidirectionalInfo": t.uint8_t,
+            "gpdSecurityFrameCounter": t.uint32_t,
+            "gpdCommandId": t.uint8_t,
+            "mic": t.uint32_t,
+            "proxyTableIndex": t.uint8_t,
+            "gpdCommandPayload": t.LVBytes,
+        },
+    ),
     # The following commands are redefined because `SecurityManagerContext` changed
     "exportKey": (
         0x0114,

--- a/tests/test_ezsp_v13.py
+++ b/tests/test_ezsp_v13.py
@@ -227,3 +227,22 @@ async def test_factory_reset(ezsp_f) -> None:
     assert ezsp_f.tokenFactoryReset.mock_calls == [
         call(excludeOutgoingFC=False, excludeBootCounter=False)
     ]
+
+
+def test_gpep_incoming_message_handler_rx(ezsp_f):
+    """Test receiving a gpepIncomingMessageHandler frame from an EmberZNet 7.x NCP."""
+    ezsp_f(
+        b"\x03\x01\x80\xc5\x00"
+        + bytes.fromhex("7fdbc1009eea43009eea43000002010000c116000010153064adff00")
+    )
+    assert ezsp_f._handle_callback.call_count == 1
+    name, args = ezsp_f._handle_callback.call_args[0]
+    assert name == "gpepIncomingMessageHandler"
+    assert args[3] == 0x00  # applicationId: source ID addressing
+    assert bytes(args[4][:4]) == bytes.fromhex("9eea4300")  # sourceId 0x0043EA9E
+    assert args[6] == 0x02  # gpdfSecurityLevel: full frame counter + MIC
+    assert args[7] == 0x01  # gpdfSecurityKeyType
+    assert args[10] == 0x16C1  # gpdSecurityFrameCounter
+    assert args[11] == 0x10  # gpdCommandId
+    assert args[13] == 0xFF  # proxyTableIndex: not in proxy table
+    assert args[14] == b""  # gpdCommandPayload


### PR DESCRIPTION
## Fix gpepIncomingMessageHandler schema for EZSP v13+

### Problem

Every incoming Green Power frame on an EmberZNet 7.x NCP fails to parse and is dropped before it reaches the application:

```
WARNING bellows.ezsp.protocol: Failed to parse frame gpepIncomingMessageHandler: b'7fdbc1009eea43009eea43000002010000c116000010153064adff00'
WARNING bellows.ezsp: Failed to parse frame, ignoring
```

This is the long-standing symptom behind the Friends-of-Hue / PTM 215Z reports (e.g. zigpy/zha-device-handlers#2477) and blocks any Green Power work on top of bellows.

### Cause

`gpepIncomingMessageHandler` is only defined in the v4 schema (and redefined in v17). Everything from v5 through v16 inherits the v4 layout, which predates the EmberZNet 7.x wire format. In 7.x the `EmberGpAddress` member is serialized as `applicationId`, an 8-byte GPD id union, then `endpoint`; the v4 schema expects a different, longer layout and runs out of bytes.

### Fix

Redefine the handler for EZSP v13 (inherited by v14 and v16) with the 7.x layout:

`status, gpdLink, sequenceNumber, applicationId, gpdIdUnion[8], endpoint, gpdfSecurityLevel, gpdfSecurityKeyType, autoCommissioning, bidirectionalInfo, gpdSecurityFrameCounter, gpdCommandId, mic, proxyTableIndex, gpdCommandPayload`

This matches the field order the zigbee-herdsman ember adapter uses for the same callback.

### Verification

Captured live from a Home Assistant SkyConnect running EmberZNet 7.5.1 (EZSP v13) receiving an EnOcean PTM 215Z (Philips Hue Tap). With this change the frames parse correctly: source ID `0x0043EA9E`, security level 2 (full frame counter + MIC), a frame counter that increments per press, and distinct GPD command IDs per button (`0x10`–`0x12`, `0x22`). One captured operational frame is added to `tests/test_ezsp_v13.py` as a regression test. Full test suite passes.

### Notes

- The v17 redefinition uses the `EmberGpAddress` struct type, whose Python field order (`gpdIeeeAddress, sourceId, applicationId, endpoint`) does not match this wire layout either, so it likely needs the same treatment. Left out of this PR to keep the change minimal and limited to what was verified on hardware.
- Only the parse is fixed here. Routing the parsed frame to the application (`packet_received` as a GP Notification on endpoint 242 / cluster 0x0021) is a separate change that depends on zigpy's in-progress Green Power runtime (zigpy/zigpy#1848).
