### PR TITLE
[RFC] Replace `ThreadsafeProxy` with `ThreadedGateway`

### DIFF
--- a/bellows/thread.py
+++ b/bellows/thread.py
@@ -1,10 +1,26 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-import contextlib
-import functools
 import logging
 
 LOGGER = logging.getLogger(__name__)
+
+# How long to let tasks finish on their own once the loop has been stopped, before
+# cancelling them. A transport closing its file descriptor in an executor is one of them.
+SHUTDOWN_TIMEOUT = 5
+
+
+async def _finish_tasks() -> None:
+    tasks = asyncio.all_tasks() - {asyncio.current_task()}
+    if not tasks:
+        return
+
+    _, pending = await asyncio.wait(tasks, timeout=SHUTDOWN_TIMEOUT)
+
+    for task in pending:
+        LOGGER.warning("Cancelling task that did not finish during shutdown: %r", task)
+        task.cancel()
+
+    await asyncio.gather(*pending, return_exceptions=True)
 
 
 class EventLoopThread:
@@ -15,109 +31,43 @@ class EventLoopThread:
         self.thread_complete = None
 
     def run_coroutine_threadsafe(self, coroutine):
-        current_loop = asyncio.get_event_loop()
+        current_loop = asyncio.get_running_loop()
         future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
         return asyncio.wrap_future(future, loop=current_loop)
 
-    def _thread_main(self, init_task):
+    def _thread_main(self, on_started):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
 
         try:
-            self.loop.run_until_complete(init_task)
+            # Signalled from inside `run_forever()`, so a `stop()` that arrives right after
+            # `start()` returns is seen by the same run of the loop
+            self.loop.call_soon(on_started)
             self.loop.run_forever()
+            self.loop.run_until_complete(_finish_tasks())
         finally:
-            # Publish `None` before closing: `self.loop` then never names a closed loop, and
-            # this thread no longer writes `self.loop` after a concurrent `start()` may have
-            # replaced it.
             loop, self.loop = self.loop, None
             loop.close()
 
     async def start(self):
-        current_loop = asyncio.get_event_loop()
-        if self.loop is not None and not self.loop.is_closed():
-            return
-
+        current_loop = asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=__name__)
 
         thread_started_future = current_loop.create_future()
 
-        async def init_task():
+        def on_started():
             current_loop.call_soon_threadsafe(thread_started_future.set_result, None)
 
         # Use current loop so current loop has a reference to the long-running thread
         # as one of its tasks
         thread_complete = current_loop.run_in_executor(
-            executor, self._thread_main, init_task()
+            executor, self._thread_main, on_started
         )
         self.thread_complete = thread_complete
         current_loop.call_soon(executor.shutdown, False)
         await thread_started_future
         return thread_complete
 
-    def force_stop(self):
-        loop = self.loop
-        if loop is None or loop.is_closed():
-            return
-
-        def cancel_tasks_and_stop_loop():
-            tasks = asyncio.all_tasks(loop=loop)
-
-            for task in tasks:
-                loop.call_soon_threadsafe(task.cancel)
-
-            gather = asyncio.gather(*tasks, return_exceptions=True)
-            gather.add_done_callback(lambda _: loop.call_soon_threadsafe(loop.stop))
-
-        # The worker thread may close the loop after our is_closed() check.
-        with contextlib.suppress(RuntimeError):
-            loop.call_soon_threadsafe(cancel_tasks_and_stop_loop)
-
-
-class ThreadsafeProxy:
-    """Proxy class which enforces threadsafe non-blocking calls
-    This class can be used to wrap an object to ensure any calls
-    using that object's methods are done on a particular event loop
-    """
-
-    def __init__(self, obj, obj_loop):
-        self._obj = obj
-        self._obj_loop = obj_loop
-
-    def __getattr__(self, name):
-        func = getattr(self._obj, name)
-        if not callable(func):
-            raise TypeError(
-                "Can only use ThreadsafeProxy with callable attributes: {}.{}".format(
-                    self._obj.__class__.__name__, name
-                )
-            )
-
-        def func_wrapper(*args, **kwargs):
-            loop = self._obj_loop
-            curr_loop = asyncio.get_running_loop()
-            call = functools.partial(func, *args, **kwargs)
-            if loop == curr_loop:
-                return call()
-            if loop.is_closed():
-                # Disconnected
-                LOGGER.warning("Attempted to use a closed event loop")
-                return
-            if asyncio.iscoroutinefunction(func):
-                future = asyncio.run_coroutine_threadsafe(call(), loop)
-                return asyncio.wrap_future(future, loop=curr_loop)
-            else:
-
-                def check_result_wrapper():
-                    result = call()
-                    if result is not None:
-                        raise TypeError(
-                            (
-                                "ThreadsafeProxy can only wrap functions with no return"
-                                "value \nUse an async method to return values: {}.{}"
-                            ).format(self._obj.__class__.__name__, name)
-                        )
-
-                loop.call_soon_threadsafe(check_result_wrapper)
-
-        return func_wrapper
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        return self.thread_complete

--- a/bellows/uart.py
+++ b/bellows/uart.py
@@ -6,23 +6,28 @@ import zigpy.config
 import zigpy.serial
 
 from bellows.ash import AshProtocol
-from bellows.thread import EventLoopThread, ThreadsafeProxy
+from bellows.thread import EventLoopThread
 import bellows.types as t
 
 LOGGER = logging.getLogger(__name__)
 RESET_TIMEOUT = 2.5
+DISCONNECT_TIMEOUT = 5
 
 
 class Gateway(zigpy.serial.SerialProtocol):
-    def __init__(self, api, connection_done_future=None):
+    def __init__(self, api):
         super().__init__()
         self._api = api
 
         self._reset_future = None
         self._startup_reset_future = None
-        self._connection_done_future = connection_done_future
+
+    def _ensure_connected(self) -> None:
+        if self._transport is None:
+            raise ConnectionResetError("Connection has been closed")
 
     async def send_data(self, data: bytes) -> None:
+        self._ensure_connected()
         await self._transport.send_data(data)
 
     def data_received(self, data):
@@ -52,6 +57,7 @@ class Gateway(zigpy.serial.SerialProtocol):
 
     async def wait_for_startup_reset(self) -> None:
         """Wait for the first reset frame on startup."""
+        self._ensure_connected()
         assert self._startup_reset_future is None
         self._startup_reset_future = asyncio.get_running_loop().create_future()
 
@@ -71,16 +77,8 @@ class Gateway(zigpy.serial.SerialProtocol):
         LOGGER.debug("Connection lost: %r", exc)
         reason = exc or ConnectionResetError("Remote server closed connection")
 
-        # XXX: The startup reset future must be resolved with an error *before* the
-        # "connection done" future is completed: the secondary thread has an attached
-        # callback to stop itself, which will cause the a future to propagate a
-        # `CancelledError` into the active event loop, breaking everything!
         if self._startup_reset_future:
             self._startup_reset_future.set_exception(reason)
-
-        if self._connection_done_future:
-            self._connection_done_future.set_result(exc)
-            self._connection_done_future = None
 
         if self._reset_future:
             self._reset_future.set_exception(reason)
@@ -97,20 +95,105 @@ class Gateway(zigpy.serial.SerialProtocol):
             )
             return await self._reset_future
 
+        self._ensure_connected()
         self._transport.send_reset()
-        self._reset_future = asyncio.get_event_loop().create_future()
+        self._reset_future = asyncio.get_running_loop().create_future()
         self._reset_future.add_done_callback(self._reset_cleanup)
 
         async with asyncio_timeout(RESET_TIMEOUT):
             return await self._reset_future
 
 
+class ThreadedGateway:
+    """Runs a `Gateway` on an `EventLoopThread` and bridges calls in both directions.
+
+    The worker loop is stopped only from the application loop, either from `disconnect()`
+    or when the connection is lost, so `_closed` is read and written on one loop and every
+    call that passed the check was queued on the worker before the stop was.
+    """
+
+    def __init__(self, api, thread: EventLoopThread):
+        self._api = api
+        self._thread = thread
+        self._loop = asyncio.get_running_loop()
+        self._gateway = None
+        self._closed = False
+
+    async def connect(self, config) -> None:
+        try:
+            self._gateway = await self._thread.run_coroutine_threadsafe(
+                _connect(config, self)
+            )
+        except BaseException:
+            # Wait for the worker to exit so the port is released before the caller sees
+            # the failure and tries to reconnect
+            self._close()
+            await self._thread.thread_complete
+            raise
+
+    # Called by the `Gateway` on the worker loop
+    def frame_received(self, data: bytes) -> None:
+        self._loop.call_soon_threadsafe(self._api.frame_received, data)
+
+    def enter_failed_state(self, code: t.NcpResetCode) -> None:
+        self._loop.call_soon_threadsafe(self._api.enter_failed_state, code)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        self._loop.call_soon_threadsafe(self._connection_lost, exc)
+
+    # Called on the application loop
+    def _connection_lost(self, exc: Exception | None) -> None:
+        # The transport has already closed its file descriptor by the time it reports this
+        self._close()
+        self._api.connection_lost(exc)
+
+    def _close(self) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        self._thread.stop()
+
+    async def _run(self, coro):
+        if self._closed:
+            coro.close()
+            raise ConnectionResetError("Gateway has been disconnected")
+
+        try:
+            return await self._thread.run_coroutine_threadsafe(coro)
+        except asyncio.CancelledError:
+            # The worker cancelled the task while shutting down, not our caller
+            if self._closed and not asyncio.current_task().cancelling():
+                raise ConnectionResetError("Gateway has been disconnected") from None
+
+            raise
+
+    async def send_data(self, data: bytes) -> None:
+        await self._run(self._gateway.send_data(data))
+
+    async def reset(self):
+        return await self._run(self._gateway.reset())
+
+    async def wait_for_startup_reset(self) -> None:
+        await self._run(self._gateway.wait_for_startup_reset())
+
+    async def disconnect(self) -> None:
+        if not self._closed:
+            try:
+                async with asyncio_timeout(DISCONNECT_TIMEOUT):
+                    await self._run(self._gateway.disconnect())
+            except TimeoutError:
+                LOGGER.warning("Timed out waiting for the connection to close")
+            finally:
+                self._close()
+
+        await self._thread.thread_complete
+
+
 async def _connect(config, api):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
-    connection_done_future = loop.create_future()
-
-    gateway = Gateway(api, connection_done_future)
+    gateway = Gateway(api)
     protocol = AshProtocol(gateway)
 
     if config[zigpy.config.CONF_DEVICE_FLOW_CONTROL] is None:
@@ -118,7 +201,7 @@ async def _connect(config, api):
     else:
         xon_xoff, rtscts = False, True
 
-    transport, _ = await zigpy.serial.create_serial_connection(
+    await zigpy.serial.create_serial_connection(
         loop,
         lambda: protocol,
         url=config[zigpy.config.CONF_DEVICE_PATH],
@@ -129,23 +212,17 @@ async def _connect(config, api):
 
     await gateway.wait_until_connected()
 
-    thread_safe_protocol = ThreadsafeProxy(gateway, loop)
-    return thread_safe_protocol, connection_done_future
+    return gateway
 
 
 async def connect(config, api, use_thread=True):
-    if use_thread:
-        api = ThreadsafeProxy(api, asyncio.get_event_loop())
-        thread = EventLoopThread()
-        await thread.start()
-        try:
-            protocol, connection_done = await thread.run_coroutine_threadsafe(
-                _connect(config, api)
-            )
-        except Exception:
-            thread.force_stop()
-            raise
-        connection_done.add_done_callback(lambda _: thread.force_stop())
-    else:
-        protocol, _ = await _connect(config, api)
-    return protocol
+    if not use_thread:
+        return await _connect(config, api)
+
+    thread = EventLoopThread()
+    await thread.start()
+
+    gateway = ThreadedGateway(api, thread)
+    await gateway.connect(config)
+
+    return gateway

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -5,28 +5,40 @@ from unittest import mock
 
 import pytest
 
-from bellows.thread import EventLoopThread, ThreadsafeProxy
+import bellows.thread
+from bellows.thread import EventLoopThread
 
 
-async def test_thread_start(monkeypatch):
-    current_loop = asyncio.get_event_loop()
-    loopmock = mock.MagicMock()
+def bellows_threads():
+    return [t for t in threading.enumerate() if "bellows" in t.name]
 
-    monkeypatch.setattr(asyncio, "new_event_loop", lambda: loopmock)
-    monkeypatch.setattr(asyncio, "set_event_loop", lambda loop: None)
 
-    def mockrun(task):
-        future = asyncio.run_coroutine_threadsafe(task, loop=current_loop)
-        return future.result(1)
+@pytest.fixture
+async def thread():
+    thread = EventLoopThread()
+    await thread.start()
+    yield thread
+    if thread.loop is not None:
+        thread.stop()
+    async with asyncio_timeout(1):
+        await thread.thread_complete
+    [t.join(1) for t in bellows_threads()]
+    assert bellows_threads() == []
 
-    loopmock.run_until_complete.side_effect = mockrun
+
+async def test_thread_start_stop():
     thread = EventLoopThread()
     thread_complete = await thread.start()
-    await thread_complete
+    assert thread.loop is not None
+    assert len(bellows_threads()) == 1
 
-    assert loopmock.run_until_complete.call_count == 1
-    assert loopmock.run_forever.call_count == 1
-    assert loopmock.close.call_count == 1
+    assert thread.stop() is thread_complete
+    async with asyncio_timeout(1):
+        await thread_complete
+
+    assert thread.loop is None
+    [t.join(1) for t in bellows_threads()]
+    assert bellows_threads() == []
 
 
 async def test_thread_clears_loop_before_closing(monkeypatch):
@@ -50,48 +62,14 @@ async def test_thread_clears_loop_before_closing(monkeypatch):
     monkeypatch.setattr(asyncio, "new_event_loop", new_event_loop)
 
     thread_complete = await thread.start()
-    thread.force_stop()
+    thread.stop()
     async with asyncio_timeout(1):
         await thread_complete
 
     assert loop_at_close is None
     assert thread.loop is None
 
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-
-
-class ExceptionCollector:
-    def __init__(self):
-        self.exceptions = []
-
-    def __call__(self, thread_loop, context):
-        exc = context.get("exception") or Exception(context["message"])
-        self.exceptions.append(exc)
-
-
-@pytest.fixture
-async def thread():
-    thread = EventLoopThread()
-    await thread.start()
-    thread.loop.call_soon_threadsafe(
-        thread.loop.set_exception_handler, ExceptionCollector()
-    )
-    yield thread
-    thread.force_stop()
-    if thread.thread_complete is not None:
-        async with asyncio_timeout(1):
-            await thread.thread_complete
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
-
-
-async def yield_other_thread(thread):
-    await thread.run_coroutine_threadsafe(asyncio.sleep(0))
-
-    exception_collector = thread.loop.get_exception_handler()
-    if exception_collector.exceptions:
-        raise exception_collector.exceptions[0]
+    [t.join(1) for t in bellows_threads()]
 
 
 async def test_thread_loop(thread):
@@ -99,21 +77,8 @@ async def test_thread_loop(thread):
         return mock.sentinel.result
 
     future = asyncio.run_coroutine_threadsafe(test_coroutine(), loop=thread.loop)
-    result = await asyncio.wrap_future(future, loop=asyncio.get_event_loop())
+    result = await asyncio.wrap_future(future, loop=asyncio.get_running_loop())
     assert result is mock.sentinel.result
-
-
-async def test_thread_double_start(thread):
-    previous_loop = thread.loop
-    await thread.start()
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 1
-    assert thread.loop is previous_loop
-
-
-async def test_thread_already_stopped(thread):
-    thread.force_stop()
-    thread.force_stop()
 
 
 async def test_thread_run_coroutine_threadsafe(thread):
@@ -121,7 +86,7 @@ async def test_thread_run_coroutine_threadsafe(thread):
 
     async def test_coroutine():
         nonlocal inner_loop
-        inner_loop = asyncio.get_event_loop()
+        inner_loop = asyncio.get_running_loop()
         return mock.sentinel.result
 
     result = await thread.run_coroutine_threadsafe(test_coroutine())
@@ -129,85 +94,35 @@ async def test_thread_run_coroutine_threadsafe(thread):
     assert inner_loop is thread.loop
 
 
-async def test_proxy_callback(thread):
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, thread.loop)
-    obj.test.return_value = None
-    proxy.test()
-    await yield_other_thread(thread)
-    assert obj.test.call_count == 1
+async def test_thread_stop_lets_tasks_finish(thread):
+    """Tasks still running when the loop is stopped get to finish before it closes."""
 
-
-async def test_proxy_async(thread):
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, thread.loop)
-    call_count = 0
-
-    async def magic():
-        nonlocal thread, call_count
-        assert asyncio.get_event_loop() == thread.loop
-        call_count += 1
+    async def finishes_later():
+        await asyncio.sleep(0.1)
         return mock.sentinel.result
 
-    obj.test = magic
-    result = await proxy.test()
+    future = thread.run_coroutine_threadsafe(finishes_later())
+    thread.stop()
 
-    assert call_count == 1
-    assert result == mock.sentinel.result
-
-
-async def test_proxy_bad_function(thread):
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, thread.loop)
-    obj.test.return_value = mock.sentinel.value
-
-    with pytest.raises(TypeError):
-        proxy.test()
-        await yield_other_thread(thread)
+    async with asyncio_timeout(1):
+        assert await future is mock.sentinel.result
+        await thread.thread_complete
 
 
-async def test_proxy_not_function():
-    loop = asyncio.get_event_loop()
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, loop)
-    obj.test = mock.sentinel.value
-    with pytest.raises(TypeError):
-        proxy.test
-
-
-async def test_proxy_no_thread():
-    loop = asyncio.get_event_loop()
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, loop)
-    proxy.test()
-    assert obj.test.call_count == 1
-
-
-async def test_proxy_loop_closed():
-    loop = asyncio.new_event_loop()
-    obj = mock.MagicMock()
-    proxy = ThreadsafeProxy(obj, loop)
-    loop.close()
-    proxy.test()
-    assert obj.test.call_count == 0
-
-
-async def test_thread_task_cancellation_after_stop(thread):
-    loop = asyncio.get_event_loop()
-    obj = mock.MagicMock()
+async def test_thread_stop_cancels_stuck_tasks(thread, monkeypatch, caplog):
+    monkeypatch.setattr(bellows.thread, "SHUTDOWN_TIMEOUT", 0.1)
 
     async def wait_forever():
-        return await thread.loop.create_future()
+        await asyncio.get_running_loop().create_future()
 
-    obj.wait_forever = wait_forever
+    future = thread.run_coroutine_threadsafe(wait_forever())
+    thread.stop()
 
-    # Stop the thread while we're waiting
-    loop.call_later(0.1, thread.force_stop)
-
-    proxy = ThreadsafeProxy(obj, thread.loop)
-
-    # The cancellation should propagate to the outer event loop
     with pytest.raises(asyncio.CancelledError):
-        # This will stall forever without the patch
         async with asyncio_timeout(1):
-            await proxy.wait_forever()
+            await future
+
+    async with asyncio_timeout(1):
+        await thread.thread_complete
+
+    assert "did not finish during shutdown" in caplog.text

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,13 +1,28 @@
 import asyncio
+from asyncio import timeout as asyncio_timeout
 import threading
-from unittest.mock import AsyncMock, MagicMock, call, patch, sentinel
+from unittest.mock import AsyncMock, MagicMock, call, sentinel
 
 import pytest
 import zigpy.config as conf
 import zigpy.serial
 
 from bellows import uart
+import bellows.thread
 import bellows.types as t
+
+DEVICE_CONFIG = conf.SCHEMA_DEVICE(
+    {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
+)
+
+
+def bellows_threads():
+    return [t for t in threading.enumerate() if "bellows" in t.name]
+
+
+def assert_no_threads():
+    [t.join(1) for t in bellows_threads()]
+    assert bellows_threads() == []
 
 
 @pytest.mark.parametrize("flow_control", ["software", "hardware"])
@@ -33,109 +48,223 @@ async def test_connect(flow_control, monkeypatch):
         use_thread=False,
     )
 
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
+    assert bellows_threads() == []
     gw.close()
 
 
-async def test_connect_threaded(monkeypatch):
-    appmock = MagicMock()
-    transport = MagicMock()
+class MockSerial:
+    """Stands in for `zigpy.serial.create_serial_connection` and remembers the worker side."""
 
-    async def mockconnect(loop, protocol_factory, **kwargs):
-        protocol = protocol_factory()
-        loop.call_soon(protocol.connection_made, transport)
-        return None, protocol
+    def __init__(self):
+        self.transport = MagicMock()
+        self.transport.close.side_effect = self.on_transport_close
+        self.protocol = None
+        self.loop = None
 
-    monkeypatch.setattr(zigpy.serial, "create_serial_connection", mockconnect)
+    async def __call__(self, loop, protocol_factory, **kwargs):
+        self.loop = asyncio.get_running_loop()
+        self.protocol = protocol_factory()
+        loop.call_soon(self.protocol.connection_made, self.transport)
+        return self.transport, self.protocol
 
-    def on_transport_close():
-        gw.connection_lost(None)
+    def on_transport_close(self):
+        self.protocol.connection_lost(None)
 
-    transport.close.side_effect = on_transport_close
-    gw = await uart.connect(
-        conf.SCHEMA_DEVICE(
-            {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
-        ),
-        appmock,
-    )
+    def lose_connection(self, exc):
+        self.loop.call_soon_threadsafe(self.protocol.connection_lost, exc)
 
-    # Need to close to release thread
-    gw.close()
 
-    # Ensure all threads are cleaned up
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
+@pytest.fixture
+def serial(monkeypatch):
+    serial = MockSerial()
+    monkeypatch.setattr(zigpy.serial, "create_serial_connection", serial)
+    return serial
+
+
+@pytest.fixture
+def app():
+    return MagicMock()
+
+
+@pytest.fixture
+async def threaded_gw(serial, app):
+    gw = await uart.connect(DEVICE_CONFIG, app, use_thread=True)
+    assert isinstance(gw, uart.ThreadedGateway)
+    assert len(bellows_threads()) == 1
+
+    yield gw
+
+    async with asyncio_timeout(1):
+        await gw.disconnect()
+    assert_no_threads()
+
+
+async def test_connect_threaded(threaded_gw, serial, app):
+    async with asyncio_timeout(1):
+        await threaded_gw.disconnect()
+
+    assert serial.transport.close.call_count == 1
+    assert app.connection_lost.mock_calls == [call(None)]
+    assert_no_threads()
+
+    # A second disconnect is a no-op
+    async with asyncio_timeout(1):
+        await threaded_gw.disconnect()
 
 
 async def test_connect_threaded_failure(monkeypatch):
     appmock = MagicMock()
-    transport = MagicMock()
+    mockconnect = AsyncMock(side_effect=OSError)
+    monkeypatch.setattr(zigpy.serial, "create_serial_connection", mockconnect)
 
-    mockconnect = AsyncMock()
-    mockconnect.side_effect = OSError
+    with pytest.raises(OSError):
+        await uart.connect(DEVICE_CONFIG, appmock, use_thread=True)
+
+    assert_no_threads()
+
+
+async def test_connect_threaded_cancelled(monkeypatch):
+    appmock = MagicMock()
+
+    async def mockconnect(loop, protocol_factory, **kwargs):
+        await asyncio.get_running_loop().create_future()
 
     monkeypatch.setattr(zigpy.serial, "create_serial_connection", mockconnect)
 
-    def on_transport_close():
-        gw.connection_lost(None)
+    task = asyncio.create_task(uart.connect(DEVICE_CONFIG, appmock, use_thread=True))
+    await asyncio.sleep(0.1)
+    task.cancel()
 
-    transport.close.side_effect = on_transport_close
-    with pytest.raises(OSError):
-        gw = await uart.connect(
-            conf.SCHEMA_DEVICE(
-                {
-                    conf.CONF_DEVICE_PATH: "/dev/serial",
-                    conf.CONF_DEVICE_BAUDRATE: 115200,
-                }
-            ),
-            appmock,
-        )
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
-    # Ensure all threads are cleaned up
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
+    assert_no_threads()
 
 
-async def test_connect_threaded_failure_cancellation_propagation(monkeypatch):
-    appmock = MagicMock()
+async def test_threaded_calls_run_on_worker(threaded_gw, serial, app):
+    gateway = threaded_gw._gateway
+    worker_loop = None
 
-    async def mock_connect(loop, protocol_factory, *args, **kwargs):
-        protocol = protocol_factory()
-        transport = AsyncMock()
+    async def send_data(data):
+        nonlocal worker_loop
+        worker_loop = asyncio.get_running_loop()
 
-        protocol.connection_made(transport)
+    # `serial.protocol` is the `AshProtocol`, the gateway's transport
+    serial.protocol.send_data = send_data
 
-        return transport, protocol
+    await threaded_gw.send_data(b"data")
+    assert worker_loop is serial.loop
 
-    with patch("bellows.uart.zigpy.serial.create_serial_connection", mock_connect):
-        gw = await uart.connect(
-            conf.SCHEMA_DEVICE(
-                {
-                    conf.CONF_DEVICE_PATH: "/dev/serial",
-                    conf.CONF_DEVICE_BAUDRATE: 115200,
-                }
-            ),
-            appmock,
-            use_thread=True,
-        )
+    serial.loop.call_soon_threadsafe(gateway.data_received, b"frame")
+    serial.loop.call_soon_threadsafe(
+        gateway.error_received, t.NcpResetCode.RESET_SOFTWARE
+    )
+    await threaded_gw.send_data(b"data")
+    await asyncio.sleep(0)
 
-    # Begin waiting for the startup reset
-    wait_for_reset = gw.wait_for_startup_reset()
+    assert app.frame_received.mock_calls == [call(b"frame")]
+    assert app.enter_failed_state.mock_calls == [call(t.NcpResetCode.RESET_SOFTWARE)]
 
-    # But lose connection halfway through
-    asyncio.get_running_loop().call_later(0.1, gw.connection_lost, RuntimeError())
 
-    # Cancellation should propagate to the outer loop
+async def test_threaded_reset(threaded_gw, serial):
+    gateway = threaded_gw._gateway
+
+    def send_reset():
+        serial.loop.call_soon(gateway.reset_received, t.NcpResetCode.RESET_SOFTWARE)
+
+    serial.protocol.send_reset = send_reset
+
+    async with asyncio_timeout(1):
+        assert await threaded_gw.reset() is True
+
+
+async def test_threaded_connection_lost(threaded_gw, serial, app):
+    exc = RuntimeError()
+
+    wait_for_reset = asyncio.ensure_future(threaded_gw.wait_for_startup_reset())
+    await asyncio.sleep(0.1)
+    serial.lose_connection(exc)
+
+    # The failure propagates to the outer loop
     with pytest.raises(RuntimeError):
-        await wait_for_reset
+        async with asyncio_timeout(1):
+            await wait_for_reset
 
-    # Ensure all threads are cleaned up
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
+    async with asyncio_timeout(1):
+        await threaded_gw.disconnect()
+
+    assert app.connection_lost.mock_calls == [call(exc)]
+    assert_no_threads()
+
+    with pytest.raises(ConnectionResetError):
+        await threaded_gw.send_data(b"data")
+
+
+async def test_threaded_call_after_disconnect(threaded_gw):
+    async with asyncio_timeout(1):
+        await threaded_gw.disconnect()
+
+    with pytest.raises(ConnectionResetError):
+        await threaded_gw.reset()
+
+
+async def test_threaded_call_after_connection_lost_on_worker(threaded_gw, serial, app):
+    """A call queued before the loss is delivered here fails instead of hanging."""
+    lost = asyncio.get_running_loop().create_future()
+    app.connection_lost.side_effect = lambda exc: lost.set_result(exc)
+
+    # Lose the connection on the worker and queue a call behind it, before the application
+    # loop has been told
+    serial.lose_connection(None)
+    send = asyncio.ensure_future(threaded_gw.send_data(b"data"))
+
+    with pytest.raises(ConnectionResetError):
+        async with asyncio_timeout(1):
+            await send
+
+    async with asyncio_timeout(1):
+        await lost
+
+
+async def test_threaded_stuck_task_on_shutdown(threaded_gw, serial, monkeypatch):
+    monkeypatch.setattr(bellows.thread, "SHUTDOWN_TIMEOUT", 0.1)
+
+    async def wait_forever(data):
+        await asyncio.get_running_loop().create_future()
+
+    serial.protocol.send_data = wait_forever
+
+    send = asyncio.ensure_future(threaded_gw.send_data(b"data"))
+    await asyncio.sleep(0.1)
+    serial.lose_connection(None)
+
+    # Cancelled by the worker during shutdown, so the caller sees a connection error
+    with pytest.raises(ConnectionResetError):
+        async with asyncio_timeout(1):
+            await send
+
+
+async def test_threaded_caller_cancellation(threaded_gw, serial):
+    async def wait_forever(data):
+        await asyncio.get_running_loop().create_future()
+
+    serial.protocol.send_data = wait_forever
+
+    with pytest.raises(TimeoutError):
+        async with asyncio_timeout(0.1):
+            await threaded_gw.send_data(b"data")
+
+
+async def test_threaded_disconnect_timeout(threaded_gw, serial, monkeypatch, caplog):
+    monkeypatch.setattr(uart, "DISCONNECT_TIMEOUT", 0.1)
+    monkeypatch.setattr(bellows.thread, "SHUTDOWN_TIMEOUT", 0.1)
+    serial.transport.close.side_effect = None
+
+    async with asyncio_timeout(1):
+        await threaded_gw.disconnect()
+
+    assert "Timed out waiting for the connection to close" in caplog.text
+    assert_no_threads()
 
 
 @pytest.fixture
@@ -157,12 +286,25 @@ async def test_reset_timeout(gw, monkeypatch):
 
 
 async def test_reset_old(gw):
-    future = asyncio.get_event_loop().create_future()
+    future = asyncio.get_running_loop().create_future()
     future.set_result(sentinel.result)
     gw._reset_future = future
     ret = await gw.reset()
     assert ret == sentinel.result
-    gw._transport.write.assert_not_called()
+    assert len(gw._transport.write.mock_calls) == 0
+
+
+async def test_disconnected(gw):
+    gw._transport = None
+
+    with pytest.raises(ConnectionResetError):
+        await gw.send_data(b"data")
+
+    with pytest.raises(ConnectionResetError):
+        await gw.reset()
+
+    with pytest.raises(ConnectionResetError):
+        await gw.wait_for_startup_reset()
 
 
 def test_connection_lost_exc(gw):
@@ -189,26 +331,15 @@ async def test_connection_lost_reset_error_propagation(monkeypatch):
         gw.connection_lost(None)
 
     transport.close.side_effect = on_transport_close
-    gw = await uart.connect(
-        conf.SCHEMA_DEVICE(
-            {conf.CONF_DEVICE_PATH: "/dev/serial", conf.CONF_DEVICE_BAUDRATE: 115200}
-        ),
-        app,
-        use_thread=False,  # required until #484 is merged
-    )
+    gw = await uart.connect(DEVICE_CONFIG, app, use_thread=False)
 
     asyncio.get_running_loop().call_later(0.1, gw.connection_lost, ValueError())
 
     with pytest.raises(ValueError):
         await gw.reset()
 
-    # Need to close to release thread
     gw.close()
-
-    # Ensure all threads are cleaned up
-    [t.join(1) for t in threading.enumerate() if "bellows" in t.name]
-    threads = [t for t in threading.enumerate() if "bellows" in t.name]
-    assert len(threads) == 0
+    assert_no_threads()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`ThreadsafeProxy` is a generic abstraction for controlling an object running on a separate event loop. While elegant, this generic abstraction doesn't contain enough state tracking to deal with the bellows gateway lifecycle.

This PR moves things up a layer and creates a `ThreadedGateway` that fully describes the API and abides by the gateway lifecycle explicitly. This should fix the spurious `CancelledError`s and such.